### PR TITLE
Implement Phase 0 `runtime.status` JSON-RPC support

### DIFF
--- a/crates/brownie-protocol/Cargo.toml
+++ b/crates/brownie-protocol/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 serde.workspace = true
+serde_json.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -1,6 +1,32 @@
 //! JSON-RPC protocol types for Brownie VSIX/runtime communication.
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,
+    pub id: Value,
+    pub method: String,
+    #[serde(default)]
+    pub params: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsonRpcResponse<T> {
+    pub jsonrpc: String,
+    pub id: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<T>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JsonRpcError {
+    pub code: i64,
+    pub message: String,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeStatus {

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,11 +1,74 @@
 //! Brownie runtime entry points.
 
-use brownie_protocol::{RuntimeState, RuntimeStatus};
+use brownie_protocol::{
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, RuntimeState, RuntimeStatus,
+};
+use serde_json::Value;
+
+const JSONRPC_VERSION: &str = "2.0";
+const METHOD_RUNTIME_STATUS: &str = "runtime.status";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
         name: "brownie-runtime".to_string(),
         version: env!("CARGO_PKG_VERSION").to_string(),
         status: RuntimeState::Ready,
+    }
+}
+
+pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<RuntimeStatus> {
+    if request.jsonrpc != JSONRPC_VERSION {
+        return error_response(request.id, -32600, "invalid JSON-RPC version");
+    }
+
+    match request.method.as_str() {
+        METHOD_RUNTIME_STATUS => JsonRpcResponse {
+            jsonrpc: JSONRPC_VERSION.to_string(),
+            id: request.id,
+            result: Some(runtime_status()),
+            error: None,
+        },
+        _ => error_response(request.id, -32601, "method not found"),
+    }
+}
+
+fn error_response(id: Value, code: i64, message: &str) -> JsonRpcResponse<RuntimeStatus> {
+    JsonRpcResponse {
+        jsonrpc: JSONRPC_VERSION.to_string(),
+        id,
+        result: None,
+        error: Some(JsonRpcError {
+            code,
+            message: message.to_string(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn runtime_status_reports_ready() {
+        let status = runtime_status();
+        assert_eq!(status.name, "brownie-runtime");
+        assert_eq!(status.status, RuntimeState::Ready);
+    }
+
+    #[test]
+    fn handles_runtime_status_jsonrpc_request() {
+        let response = handle_jsonrpc_request(JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Value::from(1),
+            method: "runtime.status".to_string(),
+            params: None,
+        });
+
+        assert!(response.error.is_none());
+        assert_eq!(response.id, Value::from(1));
+        assert_eq!(
+            response.result.expect("status result").status,
+            RuntimeState::Ready
+        );
     }
 }

--- a/crates/brownie-runtime/src/main.rs
+++ b/crates/brownie-runtime/src/main.rs
@@ -1,5 +1,30 @@
+use std::io::{self, IsTerminal, Read};
+
+use brownie_protocol::{JsonRpcRequest, JsonRpcResponse, RuntimeStatus};
+
 fn main() -> anyhow::Result<()> {
-    let status = brownie_runtime::runtime_status();
-    println!("{}", serde_json::to_string(&status)?);
+    let mut input = String::new();
+
+    if io::stdin().is_terminal() {
+        let status = brownie_runtime::runtime_status();
+        println!("{}", serde_json::to_string(&status)?);
+        return Ok(());
+    }
+
+    io::stdin().read_to_string(&mut input)?;
+    let response = match serde_json::from_str::<JsonRpcRequest>(&input) {
+        Ok(request) => brownie_runtime::handle_jsonrpc_request(request),
+        Err(error) => JsonRpcResponse::<RuntimeStatus> {
+            jsonrpc: "2.0".to_string(),
+            id: serde_json::Value::Null,
+            result: None,
+            error: Some(brownie_protocol::JsonRpcError {
+                code: -32700,
+                message: format!("parse error: {error}"),
+            }),
+        },
+    };
+
+    println!("{}", serde_json::to_string(&response)?);
     Ok(())
 }

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -14,17 +14,33 @@ Brownie Runtime
 
 ## Phase 0 request
 
-The first supported request is runtime status.
+The first supported request is `runtime.status` over JSON-RPC 2.0.
+
+Request shape:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "runtime.status"
+}
+```
 
 Expected response shape:
 
 ```json
 {
-  "name": "brownie-runtime",
-  "version": "0.1.0",
-  "status": "Ready"
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "name": "brownie-runtime",
+    "version": "0.1.0",
+    "status": "Ready"
+  }
 }
 ```
+
+For direct smoke testing without a JSON-RPC request, the runtime binary may still emit the bare status object when stdin is attached to a terminal.
 
 ## Future categories
 


### PR DESCRIPTION
### Motivation

- Provide a concrete JSON-RPC 2.0 protocol boundary for Phase 0 so the VSIX and Rust runtime can communicate over stdio.
- Expose the Phase 0 runtime health check as a `runtime.status` JSON-RPC method for reliable machine-to-machine integration.
- Preserve the existing terminal smoke-test behavior so the runtime can still emit a bare status object when invoked interactively.

### Description

- Add JSON-RPC types (`JsonRpcRequest`, `JsonRpcResponse`, `JsonRpcError`) to `crates/brownie-protocol/src/lib.rs` and add `serde_json` to the protocol crate dependencies in `crates/brownie-protocol/Cargo.toml`.
- Implement `handle_jsonrpc_request` with JSON-RPC version validation and method dispatch (supports `runtime.status`) in `crates/brownie-runtime/src/lib.rs` and return proper JSON-RPC error responses for invalid version or unknown methods.
- Update the runtime binary in `crates/brownie-runtime/src/main.rs` to read stdin, parse a JSON-RPC request, and print a JSON-RPC response while still emitting the bare status object when `stdin` is a terminal.
- Add unit tests covering `runtime_status` and handling of a `runtime.status` JSON-RPC request, and update `docs/specifications/runtime-protocol-spec-v0.md` to document the request/response shapes and the terminal smoke-test behavior.

### Testing

- Ran `cargo check --workspace` which completed successfully.
- Ran `cargo test --workspace` which completed successfully and the runtime tests passed (`tests::runtime_status_reports_ready` and `tests::handles_runtime_status_jsonrpc_request`).
- Sent a live request with `printf '{"jsonrpc":"2.0","id":1,"method":"runtime.status"}' | cargo run -q -p brownie-runtime` and received the expected JSON-RPC response containing the `result` status object.
- Attempted `pnpm install` but it failed due to the environment proxy blocking Corepack's download of `pnpm@9.0.0` (HTTP tunneling 403), so VSIX `pnpm` setup was not validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec534b98c83289a1ddcd4c5de1a6e)