### PR TITLE
Add Phase 1.1 `task.run` and no-op AgentLoop skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,7 @@ name = "brownie-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "brownie-agent-loop",
  "brownie-protocol",
  "brownie-store",
  "serde",

--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -16,3 +16,46 @@ pub enum AgentLoopState {
     Failed,
     Cancelled,
 }
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLoopInput {
+    pub task_id: String,
+    pub run_id: String,
+    pub goal: String,
+    pub mode_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLoopResult {
+    pub final_state: AgentLoopState,
+    pub completion_summary: String,
+}
+
+pub struct AgentLoop;
+
+impl AgentLoop {
+    pub fn run_noop(input: AgentLoopInput) -> AgentLoopResult {
+        AgentLoopResult {
+            final_state: AgentLoopState::Completed,
+            completion_summary: format!("No-op agent loop completed for {}", input.task_id),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_noop_completes() {
+        let result = AgentLoop::run_noop(AgentLoopInput {
+            task_id: "task_1".into(),
+            run_id: "run_1".into(),
+            goal: "test".into(),
+            mode_id: None,
+        });
+
+        assert_eq!(result.final_state, AgentLoopState::Completed);
+        assert!(result.completion_summary.contains("task_1"));
+    }
+}

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -62,6 +62,18 @@ pub struct TaskGetParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskRunParams {
+    pub task_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskRunResult {
+    pub task_id: String,
+    pub run_id: String,
+    pub status: TaskStatus,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskListResult {
     pub tasks: Vec<TaskRecord>,
 }
@@ -80,5 +92,8 @@ pub struct TaskRecord {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum TaskStatus {
     Created,
+    Running,
+    Completed,
     Failed,
+    Cancelled,
 }

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+brownie-agent-loop = { path = "../brownie-agent-loop" }
 brownie-protocol = { path = "../brownie-protocol" }
 brownie-store = { path = "../brownie-store" }
 serde.workspace = true

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,16 +1,18 @@
 //! Brownie runtime entry points.
 
+use brownie_agent_loop::{AgentLoop, AgentLoopInput, AgentLoopState};
 use brownie_protocol::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, RuntimeState, RuntimeStatus, TaskGetParams,
-    TaskListResult, TaskStartParams, TaskStartResult,
+    TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
 };
-use brownie_store::BrownieStore;
+use brownie_store::{BrownieStore, LedgerEventKind};
 use serde_json::{json, Value};
 
 const JSONRPC_VERSION: &str = "2.0";
 const METHOD_RUNTIME_STATUS: &str = "runtime.status";
 const METHOD_TASK_START: &str = "task.start";
 const METHOD_TASK_GET: &str = "task.get";
+const METHOD_TASK_RUN: &str = "task.run";
 const METHOD_TASK_LIST: &str = "task.list";
 
 pub fn runtime_status() -> RuntimeStatus {
@@ -44,6 +46,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_RUNTIME_STATUS => result_response(request.id, json!(runtime_status())),
         METHOD_TASK_START => handle_task_start(request.id, request.params),
         METHOD_TASK_GET => handle_task_get(request.id, request.params),
+        METHOD_TASK_RUN => handle_task_run(request.id, request.params),
         METHOD_TASK_LIST => handle_task_list(request.id),
         _ => error_response(request.id, -32601, "method not found"),
     }
@@ -91,6 +94,72 @@ fn handle_task_get(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     match store.tasks().get_task(&params.task_id) {
         Ok(Some(record)) => result_response(id, json!(record)),
         Ok(None) => error_response(id, -32602, "invalid params: task not found"),
+        Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
+    }
+}
+
+fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: TaskRunParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+
+    let record = match store.tasks().get_task(&params.task_id) {
+        Ok(Some(record)) => record,
+        Ok(None) => return error_response(id, -32602, "invalid params: task not found"),
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+
+    if record.status != TaskStatus::Created {
+        return error_response(id, -32602, "invalid params: task must be Created");
+    }
+
+    let running = match store.tasks().update_task_status(
+        &record.task_id,
+        TaskStatus::Running,
+        LedgerEventKind::TaskRunning,
+    ) {
+        Ok(record) => record,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+
+    let result = AgentLoop::run_noop(AgentLoopInput {
+        task_id: running.task_id.clone(),
+        run_id: running.run_id.clone(),
+        goal: running.goal.clone(),
+        mode_id: running.mode_id.clone(),
+    });
+
+    let final_status = match result.final_state {
+        AgentLoopState::Completed => TaskStatus::Completed,
+        AgentLoopState::Cancelled => TaskStatus::Cancelled,
+        AgentLoopState::Failed => TaskStatus::Failed,
+        _ => TaskStatus::Failed,
+    };
+    let event_kind = match final_status {
+        TaskStatus::Completed => LedgerEventKind::TaskCompleted,
+        TaskStatus::Cancelled => LedgerEventKind::TaskCancelled,
+        TaskStatus::Failed => LedgerEventKind::TaskFailed,
+        TaskStatus::Created | TaskStatus::Running => LedgerEventKind::TaskFailed,
+    };
+
+    match store
+        .tasks()
+        .update_task_status(&running.task_id, final_status, event_kind)
+    {
+        Ok(record) => result_response(
+            id,
+            json!(TaskRunResult {
+                task_id: record.task_id,
+                run_id: record.run_id,
+                status: record.status,
+            }),
+        ),
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
     }
 }
@@ -219,6 +288,106 @@ mod tests {
                 .len(),
             1
         );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_changes_created_to_completed_through_jsonrpc() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Run no-op","mode_id":"orchestrator"}}"#,
+        );
+        let start_result = start.result.expect("start result");
+        let task_id = start_result["task_id"]
+            .as_str()
+            .expect("task id")
+            .to_string();
+        let run_id = start_result["run_id"].as_str().expect("run id").to_string();
+
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert!(run.error.is_none());
+        let result = run.result.expect("run result");
+        assert_eq!(result["task_id"], task_id);
+        assert_eq!(result["run_id"], run_id);
+        assert_eq!(result["status"], "Completed");
+
+        let get = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.get","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        let record: TaskRecord =
+            serde_json::from_value(get.result.expect("get result")).expect("task record");
+        assert_eq!(record.status, TaskStatus::Completed);
+
+        let state: TaskRecord = serde_json::from_str(
+            &std::fs::read_to_string(
+                temp.path()
+                    .join(".brownie/runs")
+                    .join(&run_id)
+                    .join("state.json"),
+            )
+            .expect("state"),
+        )
+        .expect("state record");
+        assert_eq!(state.status, TaskStatus::Completed);
+
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/runs")
+                .join(&run_id)
+                .join("ledger.jsonl"),
+        )
+        .expect("ledger");
+        assert!(ledger.contains("TaskStarted"));
+        assert!(ledger.contains("TaskRunning"));
+        assert!(ledger.contains("TaskCompleted"));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_unknown_task_returns_invalid_params() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.run","params":{"task_id":"task_missing"}}"#,
+        );
+        assert!(response.result.is_none());
+        assert_eq!(response.error.expect("error").code, -32602);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_completed_task_returns_invalid_params() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Run once","mode_id":null}}"#,
+        );
+        let task_id = start.result.expect("start result")["task_id"]
+            .as_str()
+            .expect("task id")
+            .to_string();
+        let first = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert!(first.error.is_none());
+
+        let second = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert!(second.result.is_none());
+        assert_eq!(second.error.expect("error").code, -32602);
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -4,7 +4,7 @@ use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use brownie_protocol::{TaskRecord, TaskStartParams, TaskStatus};
 use serde::{Deserialize, Serialize};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -67,18 +67,26 @@ impl TaskStore {
         let run_dir = self.run_dir(&run_id);
         fs::create_dir_all(&run_dir)
             .with_context(|| format!("failed to create {}", run_dir.display()))?;
-        let state =
-            serde_json::to_string_pretty(&record).context("failed to serialize task state")?;
-        fs::write(run_dir.join("state.json"), state).context("failed to write task state")?;
+        self.write_task_state(&record)?;
+        self.append_task_event(&record, LedgerEventKind::TaskStarted)?;
 
-        RunLedger::new(run_dir).append(&LedgerEvent {
-            event_id: format!("event_{}", Uuid::new_v4()),
-            task_id,
-            run_id,
-            kind: LedgerEventKind::TaskStarted,
-            timestamp: timestamp()?,
-        })?;
+        Ok(record)
+    }
 
+    pub fn update_task_status(
+        &self,
+        task_id: &str,
+        status: TaskStatus,
+        event_kind: LedgerEventKind,
+    ) -> Result<TaskRecord> {
+        let Some(mut record) = self.get_task(task_id)? else {
+            bail!("task not found: {task_id}");
+        };
+
+        record.status = status;
+        record.updated_at = timestamp()?;
+        self.write_task_state(&record)?;
+        self.append_task_event(&record, event_kind)?;
         Ok(record)
     }
 
@@ -132,6 +140,25 @@ impl TaskStore {
         self.runs_dir().join(run_id)
     }
 
+    fn write_task_state(&self, record: &TaskRecord) -> Result<()> {
+        let run_dir = self.run_dir(&record.run_id);
+        fs::create_dir_all(&run_dir)
+            .with_context(|| format!("failed to create {}", run_dir.display()))?;
+        let state =
+            serde_json::to_string_pretty(record).context("failed to serialize task state")?;
+        fs::write(run_dir.join("state.json"), state).context("failed to write task state")
+    }
+
+    fn append_task_event(&self, record: &TaskRecord, kind: LedgerEventKind) -> Result<()> {
+        RunLedger::new(self.run_dir(&record.run_id)).append(&LedgerEvent {
+            event_id: format!("event_{}", Uuid::new_v4()),
+            task_id: record.task_id.clone(),
+            run_id: record.run_id.clone(),
+            kind,
+            timestamp: timestamp()?,
+        })
+    }
+
     fn runs_dir(&self) -> PathBuf {
         self.workspace_root.join(WORKSPACE_STATE_DIR).join(RUNS_DIR)
     }
@@ -175,6 +202,10 @@ pub struct LedgerEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LedgerEventKind {
     TaskStarted,
+    TaskRunning,
+    TaskCompleted,
+    TaskFailed,
+    TaskCancelled,
 }
 
 fn timestamp() -> Result<String> {
@@ -211,6 +242,42 @@ mod tests {
             serde_json::from_str(ledger.lines().next().expect("event")).expect("ledger event");
         assert_eq!(event.kind, LedgerEventKind::TaskStarted);
         assert_eq!(event.task_id, record.task_id);
+    }
+
+    #[test]
+    fn update_task_status_updates_state_and_appends_ledger() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = TaskStore::new(temp.path());
+        let record = store
+            .start_task(TaskStartParams {
+                goal: "run me".into(),
+                mode_id: None,
+            })
+            .expect("start task");
+
+        let updated = store
+            .update_task_status(
+                &record.task_id,
+                TaskStatus::Running,
+                LedgerEventKind::TaskRunning,
+            )
+            .expect("update task");
+
+        assert_eq!(updated.status, TaskStatus::Running);
+        assert_ne!(updated.updated_at, "");
+        let state: TaskRecord = serde_json::from_str(
+            &fs::read_to_string(store.run_dir(&record.run_id).join("state.json")).expect("state"),
+        )
+        .expect("record");
+        assert_eq!(state.status, TaskStatus::Running);
+        let ledger =
+            fs::read_to_string(store.run_dir(&record.run_id).join("ledger.jsonl")).expect("ledger");
+        let events: Vec<LedgerEvent> = ledger
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("event"))
+            .collect();
+        assert_eq!(events[0].kind, LedgerEventKind::TaskStarted);
+        assert_eq!(events[1].kind, LedgerEventKind::TaskRunning);
     }
 
     #[test]

--- a/docs/specifications/agent-loop-spec-v0.md
+++ b/docs/specifications/agent-loop-spec-v0.md
@@ -31,7 +31,7 @@ Failed
 Cancelled
 ```
 
-The Rust crate `brownie-agent-loop` owns this state model.
+The Rust crate `brownie-agent-loop` owns this state model. Phase 1.1 includes only a no-op skeleton entry point that accepts task metadata and returns `Completed` with a completion summary; it does not build prompts, call an LLM, execute tools, parse AgentModes, index code, use Qdrant, or use llama-server.
 
 ## Runtime authority
 
@@ -85,6 +85,10 @@ A parent receives a compact result:
 - verification evidence
 - unresolved issues
 ```
+
+## Phase 1.1 skeleton
+
+`AgentLoop::run_noop` is the only executable loop path in Phase 1.1. It exists so the Rust runtime calls the AgentLoop crate while advancing task state from `Created` to `Running` to `Completed`.
 
 ## Non-goals for v0
 

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -89,13 +89,31 @@ Expected response result shape:
   "run_id": "run_<uuid>",
   "goal": "Implement something",
   "mode_id": "orchestrator",
-  "status": "Created",
+  "status": "Created | Running | Completed | Failed | Cancelled",
   "created_at": "2026-06-26T00:00:00Z",
   "updated_at": "2026-06-26T00:00:00Z"
 }
 ```
 
 Missing tasks return `-32602` in Phase 1.0.
+
+## `task.run`
+
+Runs a `Created` task through the Phase 1.1 no-op AgentLoop skeleton. The runtime is authoritative for transitions and persists `Running` and `Completed` state changes before returning.
+
+Request line:
+
+```json
+{"jsonrpc":"2.0","id":2,"method":"task.run","params":{"task_id":"task_<uuid>"}}
+```
+
+Expected response line:
+
+```json
+{"jsonrpc":"2.0","id":2,"result":{"task_id":"task_<uuid>","run_id":"run_<uuid>","status":"Completed"}}
+```
+
+Unknown tasks and tasks whose status is not `Created` return `-32602`. Phase 1.1 does not call an LLM, execute tools, parse AgentModes, use Qdrant, use llama-server, or run an indexer.
 
 ## `task.list`
 

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -2,7 +2,7 @@
 
 ## Purpose
 
-Phase 1.0 adds the minimal task lifecycle authority to the Rust runtime. It does not implement the agent loop, LLM calls, tool execution, AgentModes parsing, indexing, Qdrant, or llama-server integration.
+Phase 1.1 extends the minimal task lifecycle authority in the Rust runtime with no-op task execution. It does not implement LLM calls, tool execution, AgentModes parsing, indexing, Qdrant, or llama-server integration.
 
 ## TaskRecord
 
@@ -20,12 +20,15 @@ updated_at: RFC3339 timestamp
 
 ## TaskStatus
 
-Phase 1.0 defines these status values:
+Phase 1.1 defines these status values:
 
 - `Created`: the runtime accepted and persisted the task.
-- `Failed`: reserved for minimal failure reporting.
+- `Running`: `task.run` has started the no-op AgentLoop skeleton.
+- `Completed`: the no-op AgentLoop skeleton completed successfully.
+- `Failed`: reserved for runtime or future AgentLoop failure reporting.
+- `Cancelled`: reserved for future cancellation handling.
 
-No `Running` or `Completed` transitions are performed in Phase 1.0 because the full agent loop is a non-goal.
+In Phase 1.1, only `Created -> Running -> Completed` is implemented.
 
 ## Run storage
 
@@ -41,19 +44,23 @@ The runtime treats the workspace root as `BROWNIE_WORKSPACE_ROOT` when set, othe
 
 ## RunLedger
 
-`ledger.jsonl` is append-only JSON Lines. Phase 1.0 emits one event when a task is created:
+`ledger.jsonl` is append-only JSON Lines. Phase 1.1 emits task lifecycle events:
 
 ```text
 event_id: string
 task_id: string
 run_id: string
-kind: TaskStarted
+kind: TaskStarted | TaskRunning | TaskCompleted | TaskFailed | TaskCancelled
 timestamp: RFC3339 timestamp
 ```
 
 The persisted ledger is separate from any future prompt window truncation behavior.
 
-## Phase 1.0 non-goals
+## `task.run`
+
+`task.run` advances a `Created` task to `Running`, calls the no-op AgentLoop skeleton, then persists `Completed`. The runtime updates `state.json` and appends `TaskRunning` and `TaskCompleted` events to `ledger.jsonl`. Running an unknown task or a task that is not `Created` returns invalid params.
+
+## Phase 1.1 non-goals
 
 - No LLM calls.
 - No full agent loop.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -28,6 +28,10 @@
       {
         "command": "brownie.taskList",
         "title": "Brownie: List Tasks"
+      },
+      {
+        "command": "brownie.taskRun",
+        "title": "Brownie: Run Task"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -63,7 +63,32 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, taskStartCommand, taskListCommand);
+
+  const taskRunCommand = vscode.commands.registerCommand('brownie.taskRun', async () => {
+    const taskId = await vscode.window.showInputBox({
+      prompt: 'Task ID',
+      placeHolder: 'task_...',
+      ignoreFocusOut: true,
+    });
+
+    if (taskId === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.runTask(taskId.trim());
+      output.appendLine(`task.run: ${JSON.stringify(result)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie task run: ${result.task_id} (${result.status})`,
+      );
+    } catch (error) {
+      output.appendLine(`task.run failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie task run failed: ${formatError(error)}`);
+    }
+  });
+
+  context.subscriptions.push(output, statusCommand, taskStartCommand, taskListCommand, taskRunCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -23,7 +23,7 @@ export interface RuntimeStatusResult {
   status: string;
 }
 
-export type TaskStatus = 'Created' | 'Failed';
+export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
 export interface TaskStartParams {
   goal: string;
@@ -31,6 +31,12 @@ export interface TaskStartParams {
 }
 
 export interface TaskStartResult {
+  task_id: string;
+  run_id: string;
+  status: TaskStatus;
+}
+
+export interface TaskRunResult {
   task_id: string;
   run_id: string;
   status: TaskStatus;
@@ -86,6 +92,15 @@ export function isTaskStartResult(value: unknown): value is TaskStartResult {
   );
 }
 
+export function isTaskRunResult(value: unknown): value is TaskRunResult {
+  return (
+    isRecord(value) &&
+    typeof value.task_id === 'string' &&
+    typeof value.run_id === 'string' &&
+    isTaskStatus(value.status)
+  );
+}
+
 export function isTaskRecord(value: unknown): value is TaskRecord {
   return (
     isRecord(value) &&
@@ -100,7 +115,7 @@ export function isTaskRecord(value: unknown): value is TaskRecord {
 }
 
 function isTaskStatus(value: unknown): value is TaskStatus {
-  return value === 'Created' || value === 'Failed';
+  return value === 'Created' || value === 'Running' || value === 'Completed' || value === 'Failed' || value === 'Cancelled';
 }
 
 function isJsonRpcError(value: unknown): value is JsonRpcError {

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, RuntimeStatusResult, TaskRecord, TaskStartParams, TaskStartResult } from './protocol';
-import { isRuntimeStatusResult, isTaskRecord, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, RuntimeStatusResult, TaskRecord, TaskRunResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -31,6 +31,16 @@ export class RuntimeClient {
 
     if (!isTaskStartResult(result)) {
       throw new RuntimeProtocolError('task.start returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async runTask(taskId: string): Promise<TaskRunResult> {
+    const result = await this.call<TaskRunResult>('task.run', { task_id: taskId });
+
+    if (!isTaskRunResult(result)) {
+      throw new RuntimeProtocolError('task.run returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -67,6 +67,32 @@ describe('RuntimeClient', () => {
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'task.start', params: { goal: 'test goal', mode_id: 'orchestrator' } }]);
   });
 
+  it('creates a task.run request', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { task_id: 'task_1', run_id: 'run_1', status: 'Completed' } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.runTask('task_1')).resolves.toEqual({ task_id: 'task_1', run_id: 'run_1', status: 'Completed' });
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'task.run', params: { task_id: 'task_1' } }]);
+  });
+
+  it('rejects invalid task.run results', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { task_id: 'task_1', run_id: 'run_1', status: 'Unknown' } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.runTask('task_1')).rejects.toThrow('task.run returned an invalid result');
+  });
+
+  it('converts task.run JSON-RPC errors into exceptions', async () => {
+    const transport = new FakeTransport({
+      jsonrpc: '2.0',
+      id: 1,
+      error: { code: -32602, message: 'invalid params: task not found' },
+    });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.runTask('task_missing')).rejects.toBeInstanceOf(RuntimeJsonRpcError);
+  });
+
   it('creates a task.get request', async () => {
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: taskRecord });
     const client = new RuntimeClient(transport);


### PR DESCRIPTION
### Motivation
- Advance Phase 1.x lifecycle support so the runtime can move a `Created` task to `Running` and then to `Completed` without implementing LLMs, AgentModes parsing, tools, Qdrant, llama-server, or indexing.
- Provide a minimal `AgentLoop` entrypoint so the runtime can call into the agent-loop crate and observe a deterministic completion path.

### Description
- Extended protocol types in `crates/brownie-protocol` to add `TaskRunParams`, `TaskRunResult`, and expanded `TaskStatus` to `Created | Running | Completed | Failed | Cancelled`.
- Added `AgentLoop` no-op skeleton in `crates/brownie-agent-loop` with `AgentLoopInput`, `AgentLoopResult`, and `run_noop` that returns `Completed` and a summary string.
- Implemented `task.run` JSON-RPC handling in `crates/brownie-runtime` that validates a `Created` task, updates it to `Running`, calls `AgentLoop::run_noop`, then updates to a final status and returns a `TaskRunResult`.
- Added `TaskStore::update_task_status`, plus helpers to write `state.json` and append ledger events, and extended `LedgerEventKind` with lifecycle events (`TaskRunning`, `TaskCompleted`, etc.) in `crates/brownie-store`.
- Added VSIX changes to the protocol (`TaskRunResult`), `RuntimeClient.runTask`, and a `Brownie: Run Task` command in the extension to call `task.run` and display results.
- Updated documentation (`docs/specifications/*`) for Phase 1.1 behavior and non-goals.

### Testing
- Ran Rust formatting and checks with `cargo fmt --check` and `cargo check --workspace`, which passed. 
- Ran unit and integration tests with `cargo test --workspace`, and all added and existing Rust tests passed. 
- Ran VSIX checks and tests with `pnpm install` and `pnpm --filter brownie-vsix check` and `pnpm --filter brownie-vsix test`, and the TypeScript validation and Vitest tests passed, followed by `pnpm --filter brownie-vsix build` which also succeeded. 
- Performed a manual smoke test using the runtime over NDJSON JSON-RPC (`task.start` -> `task.run` -> `task.list`) which showed the run completing with `Completed` status and `ledger.jsonl` containing `TaskStarted`, `TaskRunning`, and `TaskCompleted` events.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed3ceaf5c8328b78ede5c4c61bf55)