### PR TITLE
Implement Phase 1.2 fake LLM prompt path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,6 +17,10 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 [[package]]
 name = "brownie-agent-loop"
 version = "0.1.0"
+dependencies = [
+ "brownie-context",
+ "brownie-llm",
+]
 
 [[package]]
 name = "brownie-agentmodes"
@@ -29,6 +33,11 @@ version = "0.1.0"
 [[package]]
 name = "brownie-context"
 version = "0.1.0"
+dependencies = [
+ "brownie-protocol",
+ "brownie-store",
+ "serde",
+]
 
 [[package]]
 name = "brownie-events"
@@ -45,6 +54,9 @@ version = "0.1.0"
 [[package]]
 name = "brownie-llm"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "brownie-modepack"
@@ -68,6 +80,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brownie-agent-loop",
+ "brownie-context",
  "brownie-protocol",
  "brownie-store",
  "serde",

--- a/crates/brownie-agent-loop/Cargo.toml
+++ b/crates/brownie-agent-loop/Cargo.toml
@@ -6,5 +6,9 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+brownie-context = { path = "../brownie-context" }
+brownie-llm = { path = "../brownie-llm" }
+
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -1,5 +1,10 @@
 //! Agent loop state-machine crate.
 
+use brownie_context::{PromptBuildInput, PromptBuilder, PromptRole, PromptView};
+use brownie_llm::{FakeLlm, LlmMessage, LlmRequest, LlmResponse};
+
+pub const FAKE_LLM_MODEL: &str = "brownie-fake-llm";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentLoopState {
     Created,
@@ -31,6 +36,15 @@ pub struct AgentLoopResult {
     pub completion_summary: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentLoopRunOutput {
+    pub final_state: AgentLoopState,
+    pub prompt: PromptView,
+    pub llm_request: LlmRequest,
+    pub llm_response: LlmResponse,
+    pub completion_summary: String,
+}
+
 pub struct AgentLoop;
 
 impl AgentLoop {
@@ -39,6 +53,40 @@ impl AgentLoop {
             final_state: AgentLoopState::Completed,
             completion_summary: format!("No-op agent loop completed for {}", input.task_id),
         }
+    }
+
+    pub fn run_with_fake_llm(prompt_input: PromptBuildInput) -> AgentLoopRunOutput {
+        let task_id = prompt_input.task_id.clone();
+        let prompt = PromptBuilder::build(prompt_input);
+        let llm_request = LlmRequest {
+            model: FAKE_LLM_MODEL.to_string(),
+            messages: prompt
+                .messages
+                .iter()
+                .map(|message| LlmMessage {
+                    role: prompt_role_to_llm_role(&message.role).to_string(),
+                    content: message.content.clone(),
+                })
+                .collect(),
+        };
+        let llm_response = FakeLlm::complete(&llm_request);
+
+        AgentLoopRunOutput {
+            final_state: AgentLoopState::Completed,
+            prompt,
+            llm_request,
+            completion_summary: format!("Fake LLM agent loop completed for {task_id}"),
+            llm_response,
+        }
+    }
+}
+
+fn prompt_role_to_llm_role(role: &PromptRole) -> &'static str {
+    match role {
+        PromptRole::System => "system",
+        PromptRole::User => "user",
+        PromptRole::Assistant => "assistant",
+        PromptRole::Tool => "tool",
     }
 }
 
@@ -57,5 +105,24 @@ mod tests {
 
         assert_eq!(result.final_state, AgentLoopState::Completed);
         assert!(result.completion_summary.contains("task_1"));
+    }
+
+    #[test]
+    fn run_with_fake_llm_returns_completed_and_response() {
+        let result = AgentLoop::run_with_fake_llm(PromptBuildInput {
+            task_id: "task_1".into(),
+            run_id: "run_1".into(),
+            goal: "test".into(),
+            mode_id: None,
+            ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
+        });
+
+        assert_eq!(result.final_state, AgentLoopState::Completed);
+        assert_eq!(result.prompt.messages.len(), 2);
+        assert_eq!(result.llm_request.model, FAKE_LLM_MODEL);
+        assert_eq!(
+            result.llm_response.content,
+            "Fake LLM completed request with 2 messages."
+        );
     }
 }

--- a/crates/brownie-context/Cargo.toml
+++ b/crates/brownie-context/Cargo.toml
@@ -6,5 +6,10 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+brownie-protocol = { path = "../brownie-protocol" }
+brownie-store = { path = "../brownie-store" }
+serde.workspace = true
+
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-context/src/lib.rs
+++ b/crates/brownie-context/src/lib.rs
@@ -1,8 +1,221 @@
 //! Context materialization and sliding window truncation crate.
 
+use brownie_protocol::TaskRecord;
+use brownie_store::LedgerEvent;
+use serde::{Deserialize, Serialize};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ContextRegion {
     Protected,
     Recent,
     Truncatable,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PromptRole {
+    System,
+    User,
+    Assistant,
+    Tool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptMessage {
+    pub role: PromptRole,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptView {
+    pub messages: Vec<PromptMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptBuildInput {
+    pub task_id: String,
+    pub run_id: String,
+    pub goal: String,
+    pub mode_id: Option<String>,
+    pub ledger_summary: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContextMaterializerInput {
+    pub task: TaskRecord,
+    pub ledger_events: Vec<LedgerEvent>,
+}
+
+pub struct ContextMaterializer;
+
+impl ContextMaterializer {
+    pub fn materialize(input: ContextMaterializerInput) -> PromptBuildInput {
+        let ledger_summary = input
+            .ledger_events
+            .iter()
+            .map(|event| format!("{:?}", event.kind))
+            .collect();
+
+        PromptBuildInput {
+            task_id: input.task.task_id,
+            run_id: input.task.run_id,
+            goal: input.task.goal,
+            mode_id: input.task.mode_id,
+            ledger_summary,
+        }
+    }
+}
+
+pub struct PromptBuilder;
+
+impl PromptBuilder {
+    pub fn build(input: PromptBuildInput) -> PromptView {
+        let mode_id = input.mode_id.as_deref().unwrap_or("<none>");
+        let ledger = if input.ledger_summary.is_empty() {
+            "- <empty>".to_string()
+        } else {
+            input
+                .ledger_summary
+                .iter()
+                .map(|entry| format!("- {entry}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        PromptView {
+            messages: vec![
+                PromptMessage {
+                    role: PromptRole::System,
+                    content: "You are Brownie Runtime. Execute the task according to the current runtime phase. Real LLM/tool execution is disabled in this phase.".to_string(),
+                },
+                PromptMessage {
+                    role: PromptRole::User,
+                    content: format!(
+                        "Task ID: {}\nRun ID: {}\nMode ID: {}\nGoal:\n{}\n\nLedger:\n{}",
+                        input.task_id, input.run_id, mode_id, input.goal, ledger
+                    ),
+                },
+            ],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenBudget {
+    pub max_prompt_chars: usize,
+}
+
+pub struct SlidingWindowTruncator;
+
+impl SlidingWindowTruncator {
+    pub fn truncate(prompt: PromptView, budget: TokenBudget) -> PromptView {
+        let total_chars: usize = prompt
+            .messages
+            .iter()
+            .map(|message| message.content.len())
+            .sum();
+        if total_chars <= budget.max_prompt_chars {
+            return prompt;
+        }
+
+        let mut messages = Vec::new();
+        for message in prompt.messages {
+            let protected = matches!(message.role, PromptRole::System)
+                || (matches!(message.role, PromptRole::User)
+                    && message.content.contains("Goal:\n"));
+            if protected {
+                messages.push(message);
+            }
+        }
+
+        PromptView { messages }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use brownie_store::LedgerEventKind;
+
+    fn task_record() -> TaskRecord {
+        TaskRecord {
+            task_id: "task_1".into(),
+            run_id: "run_1".into(),
+            goal: "Ship Phase 1.2".into(),
+            mode_id: Some("orchestrator".into()),
+            status: brownie_protocol::TaskStatus::Running,
+            created_at: "2026-01-01T00:00:00Z".into(),
+            updated_at: "2026-01-01T00:00:01Z".into(),
+        }
+    }
+
+    #[test]
+    fn prompt_builder_builds_deterministic_messages() {
+        let prompt = PromptBuilder::build(PromptBuildInput {
+            task_id: "task_1".into(),
+            run_id: "run_1".into(),
+            goal: "Test goal".into(),
+            mode_id: Some("orchestrator".into()),
+            ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
+        });
+
+        assert_eq!(prompt.messages.len(), 2);
+        assert_eq!(prompt.messages[0].role, PromptRole::System);
+        assert!(prompt.messages[0]
+            .content
+            .contains("Real LLM/tool execution is disabled"));
+        assert_eq!(prompt.messages[1].role, PromptRole::User);
+        assert!(prompt.messages[1].content.contains("Task ID: task_1"));
+        assert!(prompt.messages[1]
+            .content
+            .contains("- TaskStarted\n- TaskRunning"));
+    }
+
+    #[test]
+    fn context_materializer_includes_task_goal_and_ledger_summary() {
+        let input = ContextMaterializerInput {
+            task: task_record(),
+            ledger_events: vec![LedgerEvent {
+                event_id: "event_1".into(),
+                task_id: "task_1".into(),
+                run_id: "run_1".into(),
+                kind: LedgerEventKind::TaskStarted,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                payload: None,
+            }],
+        };
+
+        let materialized = ContextMaterializer::materialize(input);
+        assert_eq!(materialized.goal, "Ship Phase 1.2");
+        assert_eq!(materialized.ledger_summary, vec!["TaskStarted"]);
+    }
+
+    #[test]
+    fn truncator_preserves_system_message_and_task_goal() {
+        let prompt = PromptView {
+            messages: vec![
+                PromptMessage {
+                    role: PromptRole::System,
+                    content: "system".into(),
+                },
+                PromptMessage {
+                    role: PromptRole::Assistant,
+                    content: "x".repeat(1000),
+                },
+                PromptMessage {
+                    role: PromptRole::User,
+                    content: "Goal:\nkeep me".into(),
+                },
+            ],
+        };
+
+        let truncated = SlidingWindowTruncator::truncate(
+            prompt,
+            TokenBudget {
+                max_prompt_chars: 10,
+            },
+        );
+        assert_eq!(truncated.messages.len(), 2);
+        assert_eq!(truncated.messages[0].content, "system");
+        assert!(truncated.messages[1].content.contains("keep me"));
+    }
 }

--- a/crates/brownie-llm/Cargo.toml
+++ b/crates/brownie-llm/Cargo.toml
@@ -6,5 +6,8 @@ license.workspace = true
 repository.workspace = true
 rust-version.workspace = true
 
+[dependencies]
+serde.workspace = true
+
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -1,3 +1,62 @@
-//! OpenAI-compatible LLM client abstraction crate.
+//! LLM client abstraction crate.
+
+use serde::{Deserialize, Serialize};
 
 pub const OPENAI_COMPATIBLE_API_VERSION: &str = "v1";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmRequest {
+    pub model: String,
+    pub messages: Vec<LlmMessage>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmResponse {
+    pub content: String,
+}
+
+pub struct FakeLlm;
+
+impl FakeLlm {
+    pub fn complete(request: &LlmRequest) -> LlmResponse {
+        LlmResponse {
+            content: format!(
+                "Fake LLM completed request with {} messages.",
+                request.messages.len()
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fake_llm_returns_deterministic_response() {
+        let request = LlmRequest {
+            model: "brownie-fake-llm".into(),
+            messages: vec![
+                LlmMessage {
+                    role: "system".into(),
+                    content: "system".into(),
+                },
+                LlmMessage {
+                    role: "user".into(),
+                    content: "user".into(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            FakeLlm::complete(&request).content,
+            "Fake LLM completed request with 2 messages."
+        );
+    }
+}

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -9,6 +9,7 @@ rust-version.workspace = true
 [dependencies]
 anyhow.workspace = true
 brownie-agent-loop = { path = "../brownie-agent-loop" }
+brownie-context = { path = "../brownie-context" }
 brownie-protocol = { path = "../brownie-protocol" }
 brownie-store = { path = "../brownie-store" }
 serde.workspace = true

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,6 +1,7 @@
 //! Brownie runtime entry points.
 
-use brownie_agent_loop::{AgentLoop, AgentLoopInput, AgentLoopState};
+use brownie_agent_loop::{AgentLoop, AgentLoopState};
+use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_protocol::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, RuntimeState, RuntimeStatus, TaskGetParams,
     TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
@@ -128,12 +129,45 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
 
-    let result = AgentLoop::run_noop(AgentLoopInput {
-        task_id: running.task_id.clone(),
-        run_id: running.run_id.clone(),
-        goal: running.goal.clone(),
-        mode_id: running.mode_id.clone(),
+    let ledger_events = match store.tasks().read_ledger_events(&running.run_id) {
+        Ok(events) => events,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    let prompt_input = ContextMaterializer::materialize(ContextMaterializerInput {
+        task: running.clone(),
+        ledger_events,
     });
+    let result = AgentLoop::run_with_fake_llm(prompt_input);
+
+    if let Err(error) = store.tasks().append_task_event_with_payload(
+        &running,
+        LedgerEventKind::PromptBuilt,
+        Some(json!({
+            "message_count": result.prompt.messages.len(),
+            "prompt_preview": preview_prompt(&result.prompt),
+        })),
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
+    if let Err(error) = store.tasks().append_task_event_with_payload(
+        &running,
+        LedgerEventKind::LlmRequestCreated,
+        Some(json!({
+            "model": result.llm_request.model.clone(),
+            "message_count": result.llm_request.messages.len(),
+        })),
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
+    if let Err(error) = store.tasks().append_task_event_with_payload(
+        &running,
+        LedgerEventKind::LlmResponseReceived,
+        Some(json!({
+            "content_preview": preview(&result.llm_response.content),
+        })),
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
 
     let final_status = match result.final_state {
         AgentLoopState::Completed => TaskStatus::Completed,
@@ -174,6 +208,21 @@ fn handle_task_list(id: Value) -> JsonRpcResponse<Value> {
         Ok(tasks) => result_response(id, json!(TaskListResult { tasks })),
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
     }
+}
+
+fn preview_prompt(prompt: &brownie_context::PromptView) -> String {
+    let joined = prompt
+        .messages
+        .iter()
+        .map(|message| message.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n---\n");
+    preview(&joined)
+}
+
+fn preview(content: &str) -> String {
+    const MAX_PREVIEW_CHARS: usize = 200;
+    content.chars().take(MAX_PREVIEW_CHARS).collect()
 }
 
 fn parse_params<T: serde::de::DeserializeOwned>(params: Option<Value>) -> Result<T, String> {
@@ -345,7 +394,29 @@ mod tests {
         .expect("ledger");
         assert!(ledger.contains("TaskStarted"));
         assert!(ledger.contains("TaskRunning"));
+        assert!(ledger.contains("PromptBuilt"));
+        assert!(ledger.contains("LlmRequestCreated"));
+        assert!(ledger.contains("LlmResponseReceived"));
         assert!(ledger.contains("TaskCompleted"));
+        let events: Vec<LedgerEventKind> = ledger
+            .lines()
+            .map(|line| {
+                serde_json::from_str::<brownie_store::LedgerEvent>(line)
+                    .expect("event")
+                    .kind
+            })
+            .collect();
+        assert_eq!(
+            events,
+            vec![
+                LedgerEventKind::TaskStarted,
+                LedgerEventKind::TaskRunning,
+                LedgerEventKind::PromptBuilt,
+                LedgerEventKind::LlmRequestCreated,
+                LedgerEventKind::LlmResponseReceived,
+                LedgerEventKind::TaskCompleted,
+            ]
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -1,7 +1,7 @@
 //! Brownie persistence crate.
 
 use std::fs::{self, OpenOptions};
-use std::io::Write;
+use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 use anyhow::{bail, Context, Result};
@@ -149,14 +149,28 @@ impl TaskStore {
         fs::write(run_dir.join("state.json"), state).context("failed to write task state")
     }
 
-    fn append_task_event(&self, record: &TaskRecord, kind: LedgerEventKind) -> Result<()> {
+    pub fn append_task_event(&self, record: &TaskRecord, kind: LedgerEventKind) -> Result<()> {
+        self.append_task_event_with_payload(record, kind, None)
+    }
+
+    pub fn append_task_event_with_payload(
+        &self,
+        record: &TaskRecord,
+        kind: LedgerEventKind,
+        payload: Option<serde_json::Value>,
+    ) -> Result<()> {
         RunLedger::new(self.run_dir(&record.run_id)).append(&LedgerEvent {
             event_id: format!("event_{}", Uuid::new_v4()),
             task_id: record.task_id.clone(),
             run_id: record.run_id.clone(),
             kind,
             timestamp: timestamp()?,
+            payload,
         })
+    }
+
+    pub fn read_ledger_events(&self, run_id: &str) -> Result<Vec<LedgerEvent>> {
+        RunLedger::new(self.run_dir(run_id)).read_events()
     }
 
     fn runs_dir(&self) -> PathBuf {
@@ -188,6 +202,29 @@ impl RunLedger {
         writeln!(file).context("failed to write ledger newline")?;
         Ok(())
     }
+
+    pub fn read_events(&self) -> Result<Vec<LedgerEvent>> {
+        let ledger_path = self.run_dir.join("ledger.jsonl");
+        if !ledger_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = fs::File::open(&ledger_path)
+            .with_context(|| format!("failed to open {}", ledger_path.display()))?;
+        let reader = BufReader::new(file);
+        let mut events = Vec::new();
+        for line in reader.lines() {
+            let line = line.context("failed to read ledger line")?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            events.push(
+                serde_json::from_str(&line)
+                    .with_context(|| format!("failed to parse {}", ledger_path.display()))?,
+            );
+        }
+        Ok(events)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -197,12 +234,17 @@ pub struct LedgerEvent {
     pub run_id: String,
     pub kind: LedgerEventKind,
     pub timestamp: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LedgerEventKind {
     TaskStarted,
     TaskRunning,
+    PromptBuilt,
+    LlmRequestCreated,
+    LlmResponseReceived,
     TaskCompleted,
     TaskFailed,
     TaskCancelled,
@@ -276,6 +318,32 @@ mod tests {
             .lines()
             .map(|line| serde_json::from_str(line).expect("event"))
             .collect();
+        assert_eq!(events[0].kind, LedgerEventKind::TaskStarted);
+        assert_eq!(events[1].kind, LedgerEventKind::TaskRunning);
+    }
+
+    #[test]
+    fn ledger_read_events_returns_appended_events_in_order() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = TaskStore::new(temp.path());
+        let record = store
+            .start_task(TaskStartParams {
+                goal: "read ledger".into(),
+                mode_id: None,
+            })
+            .expect("start task");
+        store
+            .update_task_status(
+                &record.task_id,
+                TaskStatus::Running,
+                LedgerEventKind::TaskRunning,
+            )
+            .expect("update task");
+
+        let events = store
+            .read_ledger_events(&record.run_id)
+            .expect("read ledger events");
+        assert_eq!(events.len(), 2);
         assert_eq!(events[0].kind, LedgerEventKind::TaskStarted);
         assert_eq!(events[1].kind, LedgerEventKind::TaskRunning);
     }

--- a/docs/specifications/agent-loop-spec-v0.md
+++ b/docs/specifications/agent-loop-spec-v0.md
@@ -96,3 +96,11 @@ A parent receives a compact result:
 - Parallel subtask scheduling.
 - Distributed task execution.
 - Full UI timeline implementation.
+
+## Phase 1.2 fake LLM path
+
+Phase 1.2 adds `AgentLoop::run_with_fake_llm` as the minimal executable prompt path. The loop accepts a materialized `PromptBuildInput`, builds a deterministic `PromptView`, converts that view to an in-process fake LLM request, and returns `Completed` with the deterministic fake response.
+
+This path is local-only. It does not call a real LLM API, open an OpenAI-compatible HTTP client, parse AgentModes, execute tools, fetch or activate Mode Packs, use Qdrant, use llama-server, or run an indexer.
+
+The runtime records prompt and fake-LLM lifecycle metadata in the run ledger around this path. Full prompt text is not persisted by default; the ledger stores counts and short previews only.

--- a/docs/specifications/context-window-spec-v0.md
+++ b/docs/specifications/context-window-spec-v0.md
@@ -53,3 +53,16 @@ A compact tool result should preserve tool name, status, relevant summary, affec
 - Semantic memory compression.
 - Learned summarization.
 - Exact tokenizer parity for every model.
+
+## Phase 1.2 prompt materialization
+
+Phase 1.2 introduces the first minimal `ContextMaterializer` and `PromptBuilder` implementation in `brownie-context`.
+
+The materializer reads the persisted `TaskRecord` and the append-only ledger events for the run, then produces a `PromptBuildInput` containing the task goal, task/run identifiers, optional mode id, and a simple deterministic ledger summary. This is intentionally not semantic summarization.
+
+The prompt builder emits a fixed two-message prompt:
+
+- a protected system message identifying Brownie Runtime and stating that real LLM/tool execution is disabled in this phase
+- a user message containing task metadata, the current goal, and ledger summary lines
+
+Sliding window truncation remains a placeholder. Phase 1.2 may use a character-budget stub, but truncation applies only to the prompt view and must preserve protected content such as the system message and current task goal. It must not delete or rewrite the persisted ledger.

--- a/docs/specifications/prompt-builder-spec-v0.md
+++ b/docs/specifications/prompt-builder-spec-v0.md
@@ -1,0 +1,39 @@
+# Prompt Builder Specification v0
+
+## Purpose
+
+The Phase 1.2 prompt builder defines the first deterministic prompt view used by Brownie Runtime. It exists to make prompt construction testable before real LLM integration.
+
+## Inputs
+
+`ContextMaterializer` produces `PromptBuildInput` from persisted runtime data:
+
+```text
+task_id
+run_id
+goal
+mode_id
+ledger_summary
+```
+
+The task goal comes from `TaskRecord`. The ledger summary comes from the persisted run ledger. Prompt materialization must not truncate or delete ledger records.
+
+## Prompt shape
+
+`PromptBuilder` emits a fixed prompt view with two messages:
+
+1. `System`: identifies Brownie Runtime and states that real LLM/tool execution is disabled in the current phase.
+2. `User`: includes task id, run id, mode id, current goal, and deterministic ledger summary lines.
+
+## Persistence rule
+
+Phase 1.2 records prompt lifecycle metadata in the run ledger, but it does not persist the full prompt by default. Ledger payloads may include message counts and short previews.
+
+## Non-goals
+
+- Real LLM calls.
+- OpenAI-compatible HTTP client implementation.
+- AgentModes parser implementation.
+- Tool execution.
+- Mode Pack fetch or activation.
+- Qdrant, llama-server, or indexer integration.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -144,3 +144,22 @@ The runtime returns JSON-RPC errors for protocol failures that it can report:
 ## Rule
 
 The VSIX is a presentation and workspace bridge. Runtime policy and task execution remain in Rust.
+
+## Phase 1.2 `task.run` behavior
+
+In Phase 1.2, the `task.run` JSON-RPC request and response shape are unchanged, but the runtime now connects the task to prompt materialization and a deterministic local fake LLM adapter.
+
+For a `Created` task, the runtime performs this ordered lifecycle:
+
+```text
+TaskStarted
+TaskRunning
+PromptBuilt
+LlmRequestCreated
+LlmResponseReceived
+TaskCompleted
+```
+
+The response still reports `Completed` on success. The additional ledger events contain metadata only, such as message counts, fake model name, and short previews. Full prompt text is not persisted by default.
+
+The fake LLM adapter is deterministic and local-only. Phase 1.2 performs no real LLM network calls and does not introduce tool execution, AgentModes parsing, Mode Pack fetch or activation, Qdrant, llama-server, or indexing behavior.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -69,3 +69,32 @@ The persisted ledger is separate from any future prompt window truncation behavi
 - No Qdrant wrapper.
 - No llama-server wrapper.
 - No codebase indexer.
+
+## Phase 1.2 prompt and fake LLM execution
+
+Phase 1.2 changes `task.run` from the no-op loop to a minimal prompt/fake-LLM path while keeping the runtime as the task lifecycle authority.
+
+The implemented transition remains:
+
+```text
+Created -> Running -> Completed
+```
+
+After writing `TaskRunning`, the runtime reads the run ledger, materializes prompt input from the current task and ledger events, builds a prompt through the agent loop, creates a local fake LLM request, receives a deterministic fake response, writes `Completed` to `state.json`, and appends `TaskCompleted`.
+
+Phase 1.2 ledger event kinds are:
+
+```text
+TaskStarted
+TaskRunning
+PromptBuilt
+LlmRequestCreated
+LlmResponseReceived
+TaskCompleted
+TaskFailed
+TaskCancelled
+```
+
+`LedgerEvent` may include an optional `payload` object. Prompt and fake-LLM events store metadata such as `message_count`, `model`, `prompt_preview`, and `content_preview`. Full prompt text is not persisted by default.
+
+Phase 1.2 still does not call a real LLM API, implement an OpenAI-compatible HTTP client, execute tools, parse AgentModes, fetch or activate Mode Packs, use Qdrant, use llama-server, or run an indexer.


### PR DESCRIPTION
### Motivation
- Provide a minimal Phase 1.2 execution path where the runtime materializes a prompt from persisted run ledger, invokes a deterministic local fake LLM, and records prompt/LLM lifecycle metadata without calling any real LLMs.
- Make prompt construction, truncation stub, fake LLM behavior, and the agent-loop path testable before integrating real LLM, ModePack, tool execution, Qdrant, or indexer components.

### Description
- Added prompt model types, `ContextMaterializer`, `PromptBuilder`, and a character-budget `SlidingWindowTruncator` stub to `crates/brownie-context` to produce a deterministic `PromptView` from a `PromptBuildInput` built from the `TaskRecord` and run ledger.
- Implemented `LlmRequest`/`LlmMessage`/`LlmResponse` and a deterministic `FakeLlm` adapter in `crates/brownie-llm` that returns a stable response like `"Fake LLM completed request with N messages."`.
- Extended `crates/brownie-agent-loop` with `AgentLoop::run_with_fake_llm` which builds a prompt, converts it into an in-process `LlmRequest`, invokes `FakeLlm::complete`, and returns a completed run output containing prompt, request, and response.
- Added ledger read support and payload-capable events in `crates/brownie-store` (`RunLedger::read_events`, `append_task_event_with_payload`, optional `payload` on `LedgerEvent`), and extended `LedgerEventKind` with `PromptBuilt`, `LlmRequestCreated`, and `LlmResponseReceived` while preserving privacy by storing only counts/previews/model metadata.
- Wired `task.run` in `crates/brownie-runtime` to: read ledger events, materialize `PromptBuildInput`, call `AgentLoop::run_with_fake_llm`, append `PromptBuilt`/`LlmRequestCreated`/`LlmResponseReceived` events (with previews/counts), and then update state to `Completed` and append `TaskCompleted`.
- Added unit tests covering `PromptBuilder`, `ContextMaterializer`, `SlidingWindowTruncator` behavior, `FakeLlm` determinism, `AgentLoop::run_with_fake_llm` behavior, and ledger read ordering; and updated documentation specs to describe Phase 1.2 non-goals and prompt/fake-LLM behavior.

### Testing
- Ran formatting and Rust workspace checks with `cargo fmt --check` and `cargo check --workspace`, which completed successfully.
- Executed the Rust test suite with `cargo test --workspace`, and all tests passed (including new tests for context/prompt/fake-LLM/ledger flow).
- Ran VSIX checks and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, which all succeeded after `pnpm install`.
- Performed the manual smoke test: started a task and ran `task.run` against a temporary `BROWNIE_WORKSPACE_ROOT`, then verified `ledger.jsonl` and `state.json` include the ordered events `TaskStarted`, `TaskRunning`, `PromptBuilt`, `LlmRequestCreated`, `LlmResponseReceived`, and `TaskCompleted`, and observed no real LLM network calls during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed9c755bc832895b453a400b682fb)