### PR TITLE
Implement Phase 1.3 built-in mode policy baseline (mode resolution, mode.list/get, ModeResolved)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,9 @@ dependencies = [
 [[package]]
 name = "brownie-agentmodes"
 version = "0.1.0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "brownie-common"
@@ -37,6 +40,7 @@ dependencies = [
  "brownie-protocol",
  "brownie-store",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -80,6 +84,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "brownie-agent-loop",
+ "brownie-agentmodes",
  "brownie-context",
  "brownie-protocol",
  "brownie-store",

--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -114,6 +114,7 @@ mod tests {
             run_id: "run_1".into(),
             goal: "test".into(),
             mode_id: None,
+            mode_policy_summary: Some("Mode Policy:\n<unresolved>".into()),
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 

--- a/crates/brownie-agentmodes/Cargo.toml
+++ b/crates/brownie-agentmodes/Cargo.toml
@@ -8,3 +8,6 @@ rust-version.workspace = true
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true

--- a/crates/brownie-agentmodes/src/lib.rs
+++ b/crates/brownie-agentmodes/src/lib.rs
@@ -1,3 +1,128 @@
 //! AgentModes compatibility crate.
 
+use serde::{Deserialize, Serialize};
+
 pub const COMPATIBILITY_TARGET: &str = "AgentModes";
+pub const DEFAULT_MODE_ID: &str = "orchestrator";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CompiledModePolicy {
+    pub mode_id: String,
+    pub display_name: String,
+    pub role_definition: String,
+    pub permissions: ModePermissions,
+    pub completion_rules: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePermissions {
+    pub read_only: bool,
+    pub workspace_write: bool,
+    pub process_exec: bool,
+    pub network_access: bool,
+    pub service_control: bool,
+    pub destructive: bool,
+    pub can_spawn_subtasks: bool,
+}
+
+pub struct BuiltinModeRegistry;
+
+impl BuiltinModeRegistry {
+    pub fn list() -> Vec<CompiledModePolicy> {
+        vec![orchestrator(), implementer(), verifier()]
+    }
+
+    pub fn get(mode_id: &str) -> Option<CompiledModePolicy> {
+        Self::list()
+            .into_iter()
+            .find(|policy| policy.mode_id == mode_id)
+    }
+
+    pub fn default_policy() -> CompiledModePolicy {
+        orchestrator()
+    }
+}
+
+fn permissions(
+    workspace_write: bool,
+    process_exec: bool,
+    can_spawn_subtasks: bool,
+) -> ModePermissions {
+    ModePermissions {
+        read_only: !workspace_write,
+        workspace_write,
+        process_exec,
+        network_access: false,
+        service_control: false,
+        destructive: false,
+        can_spawn_subtasks,
+    }
+}
+
+fn orchestrator() -> CompiledModePolicy {
+    CompiledModePolicy {
+        mode_id: DEFAULT_MODE_ID.to_string(),
+        display_name: "Orchestrator".to_string(),
+        role_definition:
+            "Coordinate task planning without direct workspace writes or process execution."
+                .to_string(),
+        permissions: permissions(false, false, true),
+        completion_rules: vec![
+            "Stop after producing a coordination result for the current task phase.".to_string(),
+        ],
+    }
+}
+
+fn implementer() -> CompiledModePolicy {
+    CompiledModePolicy {
+        mode_id: "implementer".to_string(),
+        display_name: "Implementer".to_string(),
+        role_definition: "Implement bounded workspace changes for an assigned task.".to_string(),
+        permissions: permissions(true, true, false),
+        completion_rules: vec![
+            "Stop after the requested implementation work is complete or blocked.".to_string(),
+        ],
+    }
+}
+
+fn verifier() -> CompiledModePolicy {
+    CompiledModePolicy {
+        mode_id: "verifier".to_string(),
+        display_name: "Verifier".to_string(),
+        role_definition:
+            "Run checks and report verification results without modifying workspace files."
+                .to_string(),
+        permissions: permissions(false, true, false),
+        completion_rules: vec![
+            "Stop after reporting verification status and relevant failures.".to_string(),
+        ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registry_lists_required_modes() {
+        let ids: Vec<_> = BuiltinModeRegistry::list()
+            .into_iter()
+            .map(|policy| policy.mode_id)
+            .collect();
+        assert_eq!(ids, vec!["orchestrator", "implementer", "verifier"]);
+    }
+
+    #[test]
+    fn builtin_registry_resolves_default_orchestrator() {
+        let policy = BuiltinModeRegistry::default_policy();
+        assert_eq!(policy.mode_id, "orchestrator");
+        assert!(!policy.permissions.workspace_write);
+        assert!(!policy.permissions.process_exec);
+        assert!(policy.permissions.can_spawn_subtasks);
+    }
+
+    #[test]
+    fn builtin_registry_unknown_returns_none() {
+        assert_eq!(BuiltinModeRegistry::get("unknown-mode"), None);
+    }
+}

--- a/crates/brownie-context/Cargo.toml
+++ b/crates/brownie-context/Cargo.toml
@@ -10,6 +10,7 @@ rust-version.workspace = true
 brownie-protocol = { path = "../brownie-protocol" }
 brownie-store = { path = "../brownie-store" }
 serde.workspace = true
+serde_json.workspace = true
 
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-context/src/lib.rs
+++ b/crates/brownie-context/src/lib.rs
@@ -1,7 +1,7 @@
 //! Context materialization and sliding window truncation crate.
 
 use brownie_protocol::TaskRecord;
-use brownie_store::LedgerEvent;
+use brownie_store::{LedgerEvent, LedgerEventKind};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -36,6 +36,7 @@ pub struct PromptBuildInput {
     pub run_id: String,
     pub goal: String,
     pub mode_id: Option<String>,
+    pub mode_policy_summary: Option<String>,
     pub ledger_summary: Vec<String>,
 }
 
@@ -49,6 +50,19 @@ pub struct ContextMaterializer;
 
 impl ContextMaterializer {
     pub fn materialize(input: ContextMaterializerInput) -> PromptBuildInput {
+        let mode_policy_summary = input
+            .ledger_events
+            .iter()
+            .rev()
+            .find(|event| event.kind == LedgerEventKind::ModeResolved)
+            .and_then(|event| event.payload.as_ref())
+            .map(format_mode_policy_summary)
+            .unwrap_or_else(|| {
+                "Mode Policy:
+<unresolved>"
+                    .to_string()
+            });
+
         let ledger_summary = input
             .ledger_events
             .iter()
@@ -60,9 +74,36 @@ impl ContextMaterializer {
             run_id: input.task.run_id,
             goal: input.task.goal,
             mode_id: input.task.mode_id,
+            mode_policy_summary: Some(mode_policy_summary),
             ledger_summary,
         }
     }
+}
+
+fn format_mode_policy_summary(payload: &serde_json::Value) -> String {
+    let mode_id = payload
+        .get("mode_id")
+        .and_then(|value| value.as_str())
+        .unwrap_or("<unknown>");
+    let permissions = payload.get("permissions");
+    let permission_bool = |name: &str| {
+        permissions
+            .and_then(|value| value.get(name))
+            .and_then(|value| value.as_bool())
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "<unknown>".to_string())
+    };
+
+    format!(
+        "Mode Policy:
+mode_id: {mode_id}
+workspace_write: {}
+process_exec: {}
+can_spawn_subtasks: {}",
+        permission_bool("workspace_write"),
+        permission_bool("process_exec"),
+        permission_bool("can_spawn_subtasks")
+    )
 }
 
 pub struct PromptBuilder;
@@ -70,6 +111,9 @@ pub struct PromptBuilder;
 impl PromptBuilder {
     pub fn build(input: PromptBuildInput) -> PromptView {
         let mode_id = input.mode_id.as_deref().unwrap_or("<none>");
+        let mode_policy_summary = input
+            .mode_policy_summary
+            .unwrap_or_else(|| "Mode Policy:\n<unresolved>".to_string());
         let ledger = if input.ledger_summary.is_empty() {
             "- <empty>".to_string()
         } else {
@@ -90,8 +134,8 @@ impl PromptBuilder {
                 PromptMessage {
                     role: PromptRole::User,
                     content: format!(
-                        "Task ID: {}\nRun ID: {}\nMode ID: {}\nGoal:\n{}\n\nLedger:\n{}",
-                        input.task_id, input.run_id, mode_id, input.goal, ledger
+                        "Task ID: {}\nRun ID: {}\nMode ID: {}\n{}\n\nGoal:\n{}\n\nLedger:\n{}",
+                        input.task_id, input.run_id, mode_id, mode_policy_summary, input.goal, ledger
                     ),
                 },
             ],
@@ -155,6 +199,7 @@ mod tests {
             run_id: "run_1".into(),
             goal: "Test goal".into(),
             mode_id: Some("orchestrator".into()),
+            mode_policy_summary: Some("Mode Policy:\nmode_id: orchestrator".into()),
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 
@@ -187,6 +232,39 @@ mod tests {
         let materialized = ContextMaterializer::materialize(input);
         assert_eq!(materialized.goal, "Ship Phase 1.2");
         assert_eq!(materialized.ledger_summary, vec!["TaskStarted"]);
+        assert_eq!(
+            materialized.mode_policy_summary,
+            Some("Mode Policy:\n<unresolved>".into())
+        );
+    }
+
+    #[test]
+    fn context_materializer_includes_mode_policy_summary_from_ledger() {
+        let input = ContextMaterializerInput {
+            task: task_record(),
+            ledger_events: vec![LedgerEvent {
+                event_id: "event_1".into(),
+                task_id: "task_1".into(),
+                run_id: "run_1".into(),
+                kind: LedgerEventKind::ModeResolved,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                payload: Some(serde_json::json!({
+                    "mode_id": "orchestrator",
+                    "display_name": "Orchestrator",
+                    "permissions": {
+                        "workspace_write": false,
+                        "process_exec": false,
+                        "can_spawn_subtasks": true
+                    }
+                })),
+            }],
+        };
+
+        let materialized = ContextMaterializer::materialize(input);
+        let summary = materialized.mode_policy_summary.expect("mode summary");
+        assert!(summary.contains("mode_id: orchestrator"));
+        assert!(summary.contains("workspace_write: false"));
+        assert!(summary.contains("can_spawn_subtasks: true"));
     }
 
     #[test]

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -44,6 +44,35 @@ pub enum RuntimeState {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModeSummary {
+    pub mode_id: String,
+    pub display_name: String,
+    pub role_definition: String,
+    pub permissions: ModePermissionsSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePermissionsSummary {
+    pub read_only: bool,
+    pub workspace_write: bool,
+    pub process_exec: bool,
+    pub network_access: bool,
+    pub service_control: bool,
+    pub destructive: bool,
+    pub can_spawn_subtasks: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModeListResult {
+    pub modes: Vec<ModeSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModeGetParams {
+    pub mode_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskStartParams {
     pub goal: String,
     pub mode_id: Option<String>,

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+brownie-agentmodes = { path = "../brownie-agentmodes" }
 brownie-agent-loop = { path = "../brownie-agent-loop" }
 brownie-context = { path = "../brownie-context" }
 brownie-protocol = { path = "../brownie-protocol" }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,9 +1,11 @@
 //! Brownie runtime entry points.
 
 use brownie_agent_loop::{AgentLoop, AgentLoopState};
+use brownie_agentmodes::{BuiltinModeRegistry, CompiledModePolicy};
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_protocol::{
-    JsonRpcError, JsonRpcRequest, JsonRpcResponse, RuntimeState, RuntimeStatus, TaskGetParams,
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, ModeGetParams, ModeListResult,
+    ModePermissionsSummary, ModeSummary, RuntimeState, RuntimeStatus, TaskGetParams,
     TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
 };
 use brownie_store::{BrownieStore, LedgerEventKind};
@@ -15,6 +17,8 @@ const METHOD_TASK_START: &str = "task.start";
 const METHOD_TASK_GET: &str = "task.get";
 const METHOD_TASK_RUN: &str = "task.run";
 const METHOD_TASK_LIST: &str = "task.list";
+const METHOD_MODE_LIST: &str = "mode.list";
+const METHOD_MODE_GET: &str = "mode.get";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -49,6 +53,8 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TASK_GET => handle_task_get(request.id, request.params),
         METHOD_TASK_RUN => handle_task_run(request.id, request.params),
         METHOD_TASK_LIST => handle_task_list(request.id),
+        METHOD_MODE_LIST => handle_mode_list(request.id),
+        METHOD_MODE_GET => handle_mode_get(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -63,20 +69,38 @@ fn handle_task_start(id: Value, params: Option<Value>) -> JsonRpcResponse<Value>
         return error_response(id, -32602, "invalid params: goal must not be empty");
     }
 
+    let policy = match resolve_task_start_policy(params.mode_id.as_deref()) {
+        Ok(policy) => policy,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    let params = TaskStartParams {
+        goal: params.goal,
+        mode_id: Some(policy.mode_id.clone()),
+    };
+
     let store = match BrownieStore::from_env_or_cwd() {
         Ok(store) => store,
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
 
     match store.tasks().start_task(params) {
-        Ok(record) => result_response(
-            id,
-            json!(TaskStartResult {
-                task_id: record.task_id,
-                run_id: record.run_id,
-                status: record.status,
-            }),
-        ),
+        Ok(record) => {
+            if let Err(error) = store.tasks().append_task_event_with_payload(
+                &record,
+                LedgerEventKind::ModeResolved,
+                Some(mode_resolved_payload(&policy)),
+            ) {
+                return error_response(id, -32603, &format!("internal error: {error}"));
+            }
+            result_response(
+                id,
+                json!(TaskStartResult {
+                    task_id: record.task_id,
+                    run_id: record.run_id,
+                    status: record.status,
+                }),
+            )
+        }
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
     }
 }
@@ -208,6 +232,63 @@ fn handle_task_list(id: Value) -> JsonRpcResponse<Value> {
         Ok(tasks) => result_response(id, json!(TaskListResult { tasks })),
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
     }
+}
+
+fn handle_mode_list(id: Value) -> JsonRpcResponse<Value> {
+    let modes = BuiltinModeRegistry::list()
+        .into_iter()
+        .map(mode_summary)
+        .collect();
+    result_response(id, json!(ModeListResult { modes }))
+}
+
+fn handle_mode_get(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ModeGetParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+
+    match BuiltinModeRegistry::get(&params.mode_id) {
+        Some(policy) => result_response(id, json!(mode_summary(policy))),
+        None => error_response(id, -32602, "invalid params: unknown mode_id"),
+    }
+}
+
+fn resolve_task_start_policy(mode_id: Option<&str>) -> Result<CompiledModePolicy, String> {
+    match mode_id {
+        Some(mode_id) if !mode_id.trim().is_empty() => BuiltinModeRegistry::get(mode_id)
+            .ok_or_else(|| "invalid params: unknown mode_id".to_string()),
+        _ => Ok(BuiltinModeRegistry::default_policy()),
+    }
+}
+
+fn mode_summary(policy: CompiledModePolicy) -> ModeSummary {
+    ModeSummary {
+        mode_id: policy.mode_id,
+        display_name: policy.display_name,
+        role_definition: policy.role_definition,
+        permissions: ModePermissionsSummary {
+            read_only: policy.permissions.read_only,
+            workspace_write: policy.permissions.workspace_write,
+            process_exec: policy.permissions.process_exec,
+            network_access: policy.permissions.network_access,
+            service_control: policy.permissions.service_control,
+            destructive: policy.permissions.destructive,
+            can_spawn_subtasks: policy.permissions.can_spawn_subtasks,
+        },
+    }
+}
+
+fn mode_resolved_payload(policy: &CompiledModePolicy) -> Value {
+    json!({
+        "mode_id": policy.mode_id,
+        "display_name": policy.display_name,
+        "permissions": {
+            "workspace_write": policy.permissions.workspace_write,
+            "process_exec": policy.permissions.process_exec,
+            "can_spawn_subtasks": policy.permissions.can_spawn_subtasks,
+        }
+    })
 }
 
 fn preview_prompt(prompt: &brownie_context::PromptView) -> String {
@@ -410,6 +491,7 @@ mod tests {
             events,
             vec![
                 LedgerEventKind::TaskStarted,
+                LedgerEventKind::ModeResolved,
                 LedgerEventKind::TaskRunning,
                 LedgerEventKind::PromptBuilt,
                 LedgerEventKind::LlmRequestCreated,
@@ -467,6 +549,76 @@ mod tests {
     fn task_start_with_empty_goal_returns_invalid_params() {
         let response = parse_line(
             r#"{"jsonrpc":"2.0","id":4,"method":"task.start","params":{"goal":"   ","mode_id":null}}"#,
+        );
+        assert!(response.result.is_none());
+        assert_eq!(response.error.expect("error").code, -32602);
+    }
+
+    #[test]
+    fn task_start_with_null_mode_stores_default_and_mode_resolved() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Default mode","mode_id":null}}"#,
+        );
+        let run_id = start.result.expect("start result")["run_id"]
+            .as_str()
+            .expect("run id")
+            .to_string();
+        let state: TaskRecord = serde_json::from_str(
+            &std::fs::read_to_string(
+                temp.path()
+                    .join(".brownie/runs")
+                    .join(&run_id)
+                    .join("state.json"),
+            )
+            .expect("state"),
+        )
+        .expect("state record");
+        assert_eq!(state.mode_id, Some("orchestrator".into()));
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/runs")
+                .join(&run_id)
+                .join("ledger.jsonl"),
+        )
+        .expect("ledger");
+        assert!(ledger.contains("ModeResolved"));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_start_with_unknown_mode_returns_invalid_params() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Bad mode","mode_id":"unknown-mode"}}"#,
+        );
+        assert!(response.result.is_none());
+        assert_eq!(response.error.expect("error").code, -32602);
+    }
+
+    #[test]
+    fn mode_list_and_get_return_builtin_modes() {
+        let list = parse_line(r#"{"jsonrpc":"2.0","id":1,"method":"mode.list"}"#);
+        let modes = list.result.expect("list result")["modes"]
+            .as_array()
+            .expect("modes")
+            .clone();
+        assert_eq!(modes.len(), 3);
+        assert!(modes.iter().any(|mode| mode["mode_id"] == "orchestrator"));
+
+        let get = parse_line(
+            r#"{"jsonrpc":"2.0","id":2,"method":"mode.get","params":{"mode_id":"orchestrator"}}"#,
+        );
+        assert_eq!(get.result.expect("get result")["mode_id"], "orchestrator");
+    }
+
+    #[test]
+    fn mode_get_unknown_returns_invalid_params() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"mode.get","params":{"mode_id":"unknown-mode"}}"#,
         );
         assert!(response.result.is_none());
         assert_eq!(response.error.expect("error").code, -32602);

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -241,6 +241,7 @@ pub struct LedgerEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LedgerEventKind {
     TaskStarted,
+    ModeResolved,
     TaskRunning,
     PromptBuilt,
     LlmRequestCreated,

--- a/docs/specifications/agentmodes-compatibility-spec-v0.md
+++ b/docs/specifications/agentmodes-compatibility-spec-v0.md
@@ -66,3 +66,11 @@ The tests should verify that the same input mode definitions compile to stable r
 - Rewriting AgentModes format.
 - Embedding AgentModes repo into Brownie.
 - Runtime mutation of active mode definitions inside a running task.
+
+## Phase 1.3 built-in mode policy baseline
+
+Phase 1.3 does not implement AgentModes YAML parsing, Mode Pack fetching, validation, or activation. Instead, the runtime uses a static built-in stub mode registry as the compatibility bridge before the full parser exists.
+
+The built-in registry resolves `mode_id` values into `CompiledModePolicy` records. The required Phase 1.3 modes are `orchestrator`, `implementer`, and `verifier`. Unknown mode IDs are rejected by runtime entry points that require an executable policy.
+
+Runtime permissions are modeled as policy data so later phases can enforce them outside of LLM instructions. Permission policy remains authoritative over prompt text.

--- a/docs/specifications/mode-policy-spec-v0.md
+++ b/docs/specifications/mode-policy-spec-v0.md
@@ -1,0 +1,25 @@
+# Mode Policy Spec v0
+
+## Phase 1.3 scope
+
+Phase 1.3 introduces the runtime-side foundation for mode policies without implementing the full AgentModes parser or Mode Pack lifecycle.
+
+In scope:
+
+- `CompiledModePolicy` in `brownie-agentmodes`.
+- A static built-in stub registry containing `orchestrator`, `implementer`, and `verifier`.
+- Resolution of `mode_id` to a compiled policy during `task.start`.
+- Ledger recording of compact `ModeResolved` summaries.
+- Prompt materialization of the resolved mode policy summary.
+- JSON-RPC `mode.list` and `mode.get` methods.
+
+Out of scope:
+
+- AgentModes YAML parsing.
+- Mode Pack fetch, validation, activation, or hot updates.
+- Tool execution and runtime permission enforcement.
+- Real LLM API calls.
+
+## Policy precedence
+
+Runtime permission policy is authoritative and is designed to override any LLM instruction. Phase 1.3 only resolves, stores, and exposes policy summaries; later phases will enforce permissions at runtime boundaries.

--- a/docs/specifications/prompt-builder-spec-v0.md
+++ b/docs/specifications/prompt-builder-spec-v0.md
@@ -37,3 +37,11 @@ Phase 1.2 records prompt lifecycle metadata in the run ledger, but it does not p
 - Tool execution.
 - Mode Pack fetch or activation.
 - Qdrant, llama-server, or indexer integration.
+
+## Phase 1.3 mode policy prompt summary
+
+`PromptBuildInput` includes an optional mode policy summary materialized from the run ledger. `ContextMaterializer` reads the latest `ModeResolved` event and formats the resolved mode and key permissions for prompt construction.
+
+`PromptBuilder` includes the mode policy summary in the prompt view. This is informational for Phase 1.3 only; permission enforcement is reserved for later runtime phases and remains authoritative over any LLM instruction.
+
+If no `ModeResolved` event is available, the materialized prompt input uses `Mode Policy:\n<unresolved>` as a fallback summary.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -163,3 +163,11 @@ TaskCompleted
 The response still reports `Completed` on success. The additional ledger events contain metadata only, such as message counts, fake model name, and short previews. Full prompt text is not persisted by default.
 
 The fake LLM adapter is deterministic and local-only. Phase 1.2 performs no real LLM network calls and does not introduce tool execution, AgentModes parsing, Mode Pack fetch or activation, Qdrant, llama-server, or indexing behavior.
+
+## Phase 1.3 mode protocol methods
+
+Phase 1.3 adds `mode.list` and `mode.get` JSON-RPC methods backed by the built-in stub mode registry. These methods do not fetch or parse external AgentModes repositories.
+
+`mode.list` returns `{ "modes": ModeSummary[] }`, where each summary includes `mode_id`, `display_name`, `role_definition`, and permission booleans. `mode.get` accepts `{ "mode_id": string }` and returns one `ModeSummary`.
+
+Unknown mode IDs passed to `mode.get` return JSON-RPC `-32602 invalid params`. `task.start` applies the same unknown-mode rejection, while omitted or `null` `mode_id` defaults to `orchestrator`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -98,3 +98,11 @@ TaskCancelled
 `LedgerEvent` may include an optional `payload` object. Prompt and fake-LLM events store metadata such as `message_count`, `model`, `prompt_preview`, and `content_preview`. Full prompt text is not persisted by default.
 
 Phase 1.2 still does not call a real LLM API, implement an OpenAI-compatible HTTP client, execute tools, parse AgentModes, fetch or activate Mode Packs, use Qdrant, use llama-server, or run an indexer.
+
+## Phase 1.3 mode resolution during task.start
+
+`task.start` resolves the requested `mode_id` before creating a task record. If `mode_id` is omitted or `null`, the runtime uses the default built-in `orchestrator` policy and stores `mode_id: "orchestrator"` in `state.json`.
+
+If a caller supplies an unknown `mode_id`, `task.start` returns JSON-RPC `-32602 invalid params` and does not create a task. This prevents tasks from running without a resolved runtime policy.
+
+After task creation, the run ledger records `TaskStarted` followed by `ModeResolved`. The `ModeResolved` payload stores a compact policy summary rather than the full policy.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -22,6 +22,10 @@
         "title": "Brownie: Runtime Status"
       },
       {
+        "command": "brownie.modeList",
+        "title": "Brownie: List Modes"
+      },
+      {
         "command": "brownie.taskStart",
         "title": "Brownie: Start Task"
       },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -19,6 +19,18 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const modeListCommand = vscode.commands.registerCommand('brownie.modeList', async () => {
+    try {
+      const modes = await runtimeClient.listModes();
+      output.appendLine(`mode.list: ${JSON.stringify(modes, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(`Brownie modes: ${modes.length}`);
+    } catch (error) {
+      output.appendLine(`mode.list failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie mode list failed: ${formatError(error)}`);
+    }
+  });
+
   const taskStartCommand = vscode.commands.registerCommand('brownie.taskStart', async () => {
     const goal = await vscode.window.showInputBox({
       prompt: 'Task goal',
@@ -88,7 +100,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, taskStartCommand, taskListCommand, taskRunCommand);
+  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, taskRunCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -25,6 +25,24 @@ export interface RuntimeStatusResult {
 
 export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
+
+export interface ModePermissionsSummary {
+  read_only: boolean;
+  workspace_write: boolean;
+  process_exec: boolean;
+  network_access: boolean;
+  service_control: boolean;
+  destructive: boolean;
+  can_spawn_subtasks: boolean;
+}
+
+export interface ModeSummary {
+  mode_id: string;
+  display_name: string;
+  role_definition: string;
+  permissions: ModePermissionsSummary;
+}
+
 export interface TaskStartParams {
   goal: string;
   modeId?: string;
@@ -83,6 +101,20 @@ export function isRuntimeStatusResult(value: unknown): value is RuntimeStatusRes
   );
 }
 
+export function isModeSummary(value: unknown): value is ModeSummary {
+  return (
+    isRecord(value) &&
+    typeof value.mode_id === 'string' &&
+    typeof value.display_name === 'string' &&
+    typeof value.role_definition === 'string' &&
+    isModePermissionsSummary(value.permissions)
+  );
+}
+
+export function isModeListResult(value: unknown): value is { modes: ModeSummary[] } {
+  return isRecord(value) && Array.isArray(value.modes) && value.modes.every(isModeSummary);
+}
+
 export function isTaskStartResult(value: unknown): value is TaskStartResult {
   return (
     isRecord(value) &&
@@ -111,6 +143,19 @@ export function isTaskRecord(value: unknown): value is TaskRecord {
     isTaskStatus(value.status) &&
     typeof value.created_at === 'string' &&
     typeof value.updated_at === 'string'
+  );
+}
+
+function isModePermissionsSummary(value: unknown): value is ModePermissionsSummary {
+  return (
+    isRecord(value) &&
+    typeof value.read_only === 'boolean' &&
+    typeof value.workspace_write === 'boolean' &&
+    typeof value.process_exec === 'boolean' &&
+    typeof value.network_access === 'boolean' &&
+    typeof value.service_control === 'boolean' &&
+    typeof value.destructive === 'boolean' &&
+    typeof value.can_spawn_subtasks === 'boolean'
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, RuntimeStatusResult, TaskRecord, TaskRunResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, ModeSummary, RuntimeStatusResult, TaskRecord, TaskRunResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isModeListResult, isModeSummary, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -18,6 +18,26 @@ export class RuntimeClient {
 
     if (!isRuntimeStatusResult(result)) {
       throw new RuntimeProtocolError('runtime.status returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async listModes(): Promise<ModeSummary[]> {
+    const result = await this.call<{ modes: unknown }>('mode.list');
+
+    if (!isModeListResult(result)) {
+      throw new RuntimeProtocolError('mode.list returned an invalid result');
+    }
+
+    return result.modes;
+  }
+
+  async getMode(modeId: string): Promise<ModeSummary> {
+    const result = await this.call<ModeSummary>('mode.get', { mode_id: modeId });
+
+    if (!isModeSummary(result)) {
+      throw new RuntimeProtocolError('mode.get returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isRuntimeStatusResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isModeSummary, isRuntimeStatusResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -14,6 +14,22 @@ class FakeTransport implements RuntimeTransport {
     return this.response as JsonRpcResponse<T>;
   }
 }
+
+
+const modeSummary = {
+  mode_id: 'orchestrator',
+  display_name: 'Orchestrator',
+  role_definition: 'Coordinate tasks.',
+  permissions: {
+    read_only: true,
+    workspace_write: false,
+    process_exec: false,
+    network_access: false,
+    service_control: false,
+    destructive: false,
+    can_spawn_subtasks: true,
+  },
+};
 
 const taskRecord = {
   task_id: 'task_1',
@@ -37,6 +53,11 @@ describe('protocol validation', () => {
     expect(isJsonRpcResponse({ jsonrpc: '2.0', id: 1, error: { code: '1', message: 'bad' } })).toBe(false);
   });
 
+  it('accepts mode summaries and rejects invalid permission shapes', () => {
+    expect(isModeSummary(modeSummary)).toBe(true);
+    expect(isModeSummary({ ...modeSummary, permissions: { ...modeSummary.permissions, workspace_write: 'false' } })).toBe(false);
+  });
+
   it('accepts runtime.status results with string fields', () => {
     expect(isRuntimeStatusResult({ name: 'brownie-runtime', version: '0.1.0', status: 'Ready' })).toBe(true);
   });
@@ -57,6 +78,22 @@ describe('RuntimeClient', () => {
       status: 'Ready',
     });
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'runtime.status' }]);
+  });
+
+  it('creates a mode.list request', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { modes: [modeSummary] } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.listModes()).resolves.toEqual([modeSummary]);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'mode.list' }]);
+  });
+
+  it('creates a mode.get request', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: modeSummary });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.getMode('orchestrator')).resolves.toEqual(modeSummary);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'mode.get', params: { mode_id: 'orchestrator' } }]);
   });
 
   it('creates a task.start request', async () => {


### PR DESCRIPTION
### Motivation

- Provide a minimal runtime foundation for AgentModes by resolving `mode_id` to a compiled policy and exposing mode metadata before implementing a full AgentModes parser. 
- Ensure tasks cannot be created or run without a resolved runtime policy by rejecting unknown `mode_id` values and defaulting omitted/null `mode_id` to `orchestrator`.
- Surface resolved policy information to prompt materialization so prompts include an authoritative mode policy summary for later enforcement. 

### Description

- Added `CompiledModePolicy` and `ModePermissions` types and a static `BuiltinModeRegistry` providing `orchestrator`, `implementer`, and `verifier` modes with a default `orchestrator` policy (`crates/brownie-agentmodes`).
- Added protocol types `ModeSummary`, `ModePermissionsSummary`, `ModeListResult`, and `ModeGetParams` (`crates/brownie-protocol`) and extended `LedgerEventKind` with `ModeResolved` (`crates/brownie-store`).
- Resolved `mode_id` during `task.start`, rejected unknown mode IDs with JSON-RPC `-32602`, defaulted omitted/null to `orchestrator`, stored the resolved `mode_id` in `state.json`, and appended a compact `ModeResolved` ledger payload (`crates/brownie-runtime`).
- Materialized a `mode_policy_summary` in `PromptBuildInput` by reading the latest `ModeResolved` ledger event and included the summary in the built prompt; added helper to format the summary (`crates/brownie-context`).
- Added JSON-RPC handlers `mode.list` and `mode.get` backed by the built-in registry (`crates/brownie-runtime`) and added VSIX runtime protocol/types and `RuntimeClient` helpers `listModes()` / `getMode()` plus the `Brownie: List Modes` command in the extension (`extensions/brownie-vsix`).
- Added unit tests covering the built-in registry, mode resolution behavior in `task.start`, `ModeResolved` ledger consumption in the materializer and prompt builder, runtime `mode.list`/`mode.get`, and VSIX protocol/client validations, and updated Phase 1.3 documentation (`docs/specifications/*`).

### Testing

- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all Rust checks and unit tests passed (Rust test suites all green).
- Ran VSIX validation and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and TypeScript checks and Vitest tests passed and the extension build succeeded.
- Performed the scripted runtime smoke commands and verified `mode.list` contains the three built-in modes, `task.start` with `mode_id: "orchestrator"` created a task with `mode_id` stored as `orchestrator` and appended `ModeResolved` to the ledger, and `task.start` with an unknown mode returned `-32602` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f36d826c483288c60715638e65f56)