### PR TITLE
Implement Phase 1.4: RuntimePermissionGate and `permission.check`

### DIFF
--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -115,6 +115,7 @@ mod tests {
             goal: "test".into(),
             mode_id: None,
             mode_policy_summary: Some("Mode Policy:\n<unresolved>".into()),
+            permission_summary: vec![],
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 

--- a/crates/brownie-agentmodes/src/lib.rs
+++ b/crates/brownie-agentmodes/src/lib.rs
@@ -25,6 +25,63 @@ pub struct ModePermissions {
     pub can_spawn_subtasks: bool,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeAction {
+    ReadWorkspace,
+    WriteWorkspace,
+    ExecuteProcess,
+    AccessNetwork,
+    ControlService,
+    DestructiveOperation,
+    SpawnSubtask,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionDecision {
+    pub action: RuntimeAction,
+    pub allowed: bool,
+    pub reason: String,
+}
+
+pub struct RuntimePermissionGate;
+
+impl RuntimePermissionGate {
+    pub fn check(policy: &CompiledModePolicy, action: RuntimeAction) -> PermissionDecision {
+        let allowed = match action {
+            RuntimeAction::ReadWorkspace => true,
+            RuntimeAction::WriteWorkspace => policy.permissions.workspace_write,
+            RuntimeAction::ExecuteProcess => policy.permissions.process_exec,
+            RuntimeAction::AccessNetwork => policy.permissions.network_access,
+            RuntimeAction::ControlService => policy.permissions.service_control,
+            RuntimeAction::DestructiveOperation => policy.permissions.destructive,
+            RuntimeAction::SpawnSubtask => policy.permissions.can_spawn_subtasks,
+        };
+        let reason = permission_reason(policy, &action, allowed);
+        PermissionDecision {
+            action,
+            allowed,
+            reason,
+        }
+    }
+}
+
+fn permission_reason(policy: &CompiledModePolicy, action: &RuntimeAction, allowed: bool) -> String {
+    let capability = match action {
+        RuntimeAction::ReadWorkspace => "workspace reads",
+        RuntimeAction::WriteWorkspace => "workspace writes",
+        RuntimeAction::ExecuteProcess => "process execution",
+        RuntimeAction::AccessNetwork => "network access",
+        RuntimeAction::ControlService => "service control",
+        RuntimeAction::DestructiveOperation => "destructive operations",
+        RuntimeAction::SpawnSubtask => "subtask spawning",
+    };
+    if allowed {
+        format!("Mode {} allows {capability}.", policy.mode_id)
+    } else {
+        format!("Mode {} does not allow {capability}.", policy.mode_id)
+    }
+}
+
 pub struct BuiltinModeRegistry;
 
 impl BuiltinModeRegistry {
@@ -124,5 +181,33 @@ mod tests {
     #[test]
     fn builtin_registry_unknown_returns_none() {
         assert_eq!(BuiltinModeRegistry::get("unknown-mode"), None);
+    }
+
+    #[test]
+    fn permission_gate_allows_read_workspace_for_all_modes() {
+        for policy in BuiltinModeRegistry::list() {
+            let decision = RuntimePermissionGate::check(&policy, RuntimeAction::ReadWorkspace);
+            assert!(decision.allowed, "{} should read workspace", policy.mode_id);
+        }
+    }
+
+    #[test]
+    fn permission_gate_matches_builtin_capabilities() {
+        let orchestrator = BuiltinModeRegistry::get("orchestrator").expect("orchestrator");
+        assert!(
+            !RuntimePermissionGate::check(&orchestrator, RuntimeAction::WriteWorkspace).allowed
+        );
+        assert!(
+            !RuntimePermissionGate::check(&orchestrator, RuntimeAction::ExecuteProcess).allowed
+        );
+        assert!(RuntimePermissionGate::check(&orchestrator, RuntimeAction::SpawnSubtask).allowed);
+
+        let implementer = BuiltinModeRegistry::get("implementer").expect("implementer");
+        assert!(RuntimePermissionGate::check(&implementer, RuntimeAction::WriteWorkspace).allowed);
+        assert!(RuntimePermissionGate::check(&implementer, RuntimeAction::ExecuteProcess).allowed);
+
+        let verifier = BuiltinModeRegistry::get("verifier").expect("verifier");
+        assert!(!RuntimePermissionGate::check(&verifier, RuntimeAction::WriteWorkspace).allowed);
+        assert!(RuntimePermissionGate::check(&verifier, RuntimeAction::ExecuteProcess).allowed);
     }
 }

--- a/crates/brownie-context/src/lib.rs
+++ b/crates/brownie-context/src/lib.rs
@@ -37,6 +37,7 @@ pub struct PromptBuildInput {
     pub goal: String,
     pub mode_id: Option<String>,
     pub mode_policy_summary: Option<String>,
+    pub permission_summary: Vec<String>,
     pub ledger_summary: Vec<String>,
 }
 
@@ -63,6 +64,8 @@ impl ContextMaterializer {
                     .to_string()
             });
 
+        let permission_summary = format_permission_summary(&input.ledger_events);
+
         let ledger_summary = input
             .ledger_events
             .iter()
@@ -75,6 +78,7 @@ impl ContextMaterializer {
             goal: input.task.goal,
             mode_id: input.task.mode_id,
             mode_policy_summary: Some(mode_policy_summary),
+            permission_summary,
             ledger_summary,
         }
     }
@@ -99,11 +103,33 @@ fn format_mode_policy_summary(payload: &serde_json::Value) -> String {
 mode_id: {mode_id}
 workspace_write: {}
 process_exec: {}
-can_spawn_subtasks: {}",
+can_spawn_subtasks: {}
+network_access: {}
+service_control: {}
+destructive: {}
+read_only: {}",
         permission_bool("workspace_write"),
         permission_bool("process_exec"),
-        permission_bool("can_spawn_subtasks")
+        permission_bool("can_spawn_subtasks"),
+        permission_bool("network_access"),
+        permission_bool("service_control"),
+        permission_bool("destructive"),
+        permission_bool("read_only")
     )
+}
+
+fn format_permission_summary(events: &[LedgerEvent]) -> Vec<String> {
+    events
+        .iter()
+        .filter(|event| event.kind == LedgerEventKind::PermissionChecked)
+        .filter_map(|event| {
+            let payload = event.payload.as_ref()?;
+            let action = payload.get("action")?.as_str()?;
+            let allowed = payload.get("allowed")?.as_bool()?;
+            let status = if allowed { "allowed" } else { "denied" };
+            Some(format!("{action}: {status}"))
+        })
+        .collect()
 }
 
 pub struct PromptBuilder;
@@ -114,6 +140,17 @@ impl PromptBuilder {
         let mode_policy_summary = input
             .mode_policy_summary
             .unwrap_or_else(|| "Mode Policy:\n<unresolved>".to_string());
+        let permission_checks = if input.permission_summary.is_empty() {
+            "- <none>".to_string()
+        } else {
+            input
+                .permission_summary
+                .iter()
+                .map(|entry| format!("- {entry}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
         let ledger = if input.ledger_summary.is_empty() {
             "- <empty>".to_string()
         } else {
@@ -134,8 +171,8 @@ impl PromptBuilder {
                 PromptMessage {
                     role: PromptRole::User,
                     content: format!(
-                        "Task ID: {}\nRun ID: {}\nMode ID: {}\n{}\n\nGoal:\n{}\n\nLedger:\n{}",
-                        input.task_id, input.run_id, mode_id, mode_policy_summary, input.goal, ledger
+                        "Task ID: {}\nRun ID: {}\nMode ID: {}\n{}\n\nPermission Checks:\n{}\n\nGoal:\n{}\n\nLedger:\n{}",
+                        input.task_id, input.run_id, mode_id, mode_policy_summary, permission_checks, input.goal, ledger
                     ),
                 },
             ],
@@ -200,6 +237,7 @@ mod tests {
             goal: "Test goal".into(),
             mode_id: Some("orchestrator".into()),
             mode_policy_summary: Some("Mode Policy:\nmode_id: orchestrator".into()),
+            permission_summary: vec![],
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 
@@ -252,8 +290,12 @@ mod tests {
                     "mode_id": "orchestrator",
                     "display_name": "Orchestrator",
                     "permissions": {
+                        "read_only": true,
                         "workspace_write": false,
                         "process_exec": false,
+                        "network_access": false,
+                        "service_control": false,
+                        "destructive": false,
                         "can_spawn_subtasks": true
                     }
                 })),
@@ -265,6 +307,37 @@ mod tests {
         assert!(summary.contains("mode_id: orchestrator"));
         assert!(summary.contains("workspace_write: false"));
         assert!(summary.contains("can_spawn_subtasks: true"));
+    }
+
+    #[test]
+    fn context_materializer_includes_permission_summary() {
+        let input = ContextMaterializerInput {
+            task: task_record(),
+            ledger_events: vec![LedgerEvent {
+                event_id: "event_1".into(),
+                task_id: "task_1".into(),
+                run_id: "run_1".into(),
+                kind: LedgerEventKind::PermissionChecked,
+                timestamp: "2026-01-01T00:00:00Z".into(),
+                payload: Some(serde_json::json!({
+                    "mode_id": "orchestrator",
+                    "action": "WriteWorkspace",
+                    "allowed": false,
+                    "reason": "Mode orchestrator does not allow workspace writes."
+                })),
+            }],
+        };
+
+        let materialized = ContextMaterializer::materialize(input);
+        assert_eq!(
+            materialized.permission_summary,
+            vec!["WriteWorkspace: denied"]
+        );
+        let prompt = PromptBuilder::build(materialized);
+        assert!(prompt.messages[1].content.contains("Permission Checks:"));
+        assert!(prompt.messages[1]
+            .content
+            .contains("- WriteWorkspace: denied"));
     }
 
     #[test]

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -73,6 +73,31 @@ pub struct ModeGetParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionCheckParams {
+    pub mode_id: String,
+    pub action: RuntimeActionName,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PermissionCheckResult {
+    pub mode_id: String,
+    pub action: RuntimeActionName,
+    pub allowed: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RuntimeActionName {
+    ReadWorkspace,
+    WriteWorkspace,
+    ExecuteProcess,
+    AccessNetwork,
+    ControlService,
+    DestructiveOperation,
+    SpawnSubtask,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskStartParams {
     pub goal: String,
     pub mode_id: Option<String>,

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,12 +1,15 @@
 //! Brownie runtime entry points.
 
 use brownie_agent_loop::{AgentLoop, AgentLoopState};
-use brownie_agentmodes::{BuiltinModeRegistry, CompiledModePolicy};
+use brownie_agentmodes::{
+    BuiltinModeRegistry, CompiledModePolicy, RuntimeAction, RuntimePermissionGate,
+};
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_protocol::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, ModeGetParams, ModeListResult,
-    ModePermissionsSummary, ModeSummary, RuntimeState, RuntimeStatus, TaskGetParams,
-    TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
+    ModePermissionsSummary, ModeSummary, PermissionCheckParams, PermissionCheckResult,
+    RuntimeActionName, RuntimeState, RuntimeStatus, TaskGetParams, TaskListResult, TaskRunParams,
+    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
 };
 use brownie_store::{BrownieStore, LedgerEventKind};
 use serde_json::{json, Value};
@@ -19,6 +22,7 @@ const METHOD_TASK_RUN: &str = "task.run";
 const METHOD_TASK_LIST: &str = "task.list";
 const METHOD_MODE_LIST: &str = "mode.list";
 const METHOD_MODE_GET: &str = "mode.get";
+const METHOD_PERMISSION_CHECK: &str = "permission.check";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -55,6 +59,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TASK_LIST => handle_task_list(request.id),
         METHOD_MODE_LIST => handle_mode_list(request.id),
         METHOD_MODE_GET => handle_mode_get(request.id, request.params),
+        METHOD_PERMISSION_CHECK => handle_permission_check(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -153,6 +158,15 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
 
+    let policy = match resolve_policy_for_task_run(&running, &store) {
+        Ok(policy) => policy,
+        Err(message) => return error_response(id, -32603, &format!("internal error: {message}")),
+    };
+
+    if let Err(error) = append_permission_checks(&store, &running, &policy) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
+
     let ledger_events = match store.tasks().read_ledger_events(&running.run_id) {
         Ok(events) => events,
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
@@ -242,6 +256,30 @@ fn handle_mode_list(id: Value) -> JsonRpcResponse<Value> {
     result_response(id, json!(ModeListResult { modes }))
 }
 
+fn handle_permission_check(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: PermissionCheckParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+
+    let policy = match BuiltinModeRegistry::get(&params.mode_id) {
+        Some(policy) => policy,
+        None => return error_response(id, -32602, "invalid params: unknown mode_id"),
+    };
+    let action = runtime_action_from_name(&params.action);
+    let decision = RuntimePermissionGate::check(&policy, action);
+
+    result_response(
+        id,
+        json!(PermissionCheckResult {
+            mode_id: policy.mode_id,
+            action: params.action,
+            allowed: decision.allowed,
+            reason: decision.reason,
+        }),
+    )
+}
+
 fn handle_mode_get(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     let params: ModeGetParams = match parse_params(params) {
         Ok(params) => params,
@@ -284,11 +322,111 @@ fn mode_resolved_payload(policy: &CompiledModePolicy) -> Value {
         "mode_id": policy.mode_id,
         "display_name": policy.display_name,
         "permissions": {
+            "read_only": policy.permissions.read_only,
             "workspace_write": policy.permissions.workspace_write,
             "process_exec": policy.permissions.process_exec,
+            "network_access": policy.permissions.network_access,
+            "service_control": policy.permissions.service_control,
+            "destructive": policy.permissions.destructive,
             "can_spawn_subtasks": policy.permissions.can_spawn_subtasks,
         }
     })
+}
+
+fn resolve_policy_for_task_run(
+    record: &brownie_protocol::TaskRecord,
+    store: &BrownieStore,
+) -> Result<CompiledModePolicy, String> {
+    if let Some(mode_id) = record.mode_id.as_deref() {
+        return BuiltinModeRegistry::get(mode_id)
+            .ok_or_else(|| format!("stored task has unknown mode_id: {mode_id}"));
+    }
+
+    let events = store
+        .tasks()
+        .read_ledger_events(&record.run_id)
+        .map_err(|error| error.to_string())?;
+    let mode_id = events
+        .iter()
+        .rev()
+        .find(|event| event.kind == LedgerEventKind::ModeResolved)
+        .and_then(|event| event.payload.as_ref())
+        .and_then(|payload| payload.get("mode_id"))
+        .and_then(|value| value.as_str())
+        .unwrap_or(DEFAULT_MODE_ID_FOR_RUN);
+    BuiltinModeRegistry::get(mode_id)
+        .ok_or_else(|| format!("ledger has unknown mode_id: {mode_id}"))
+}
+
+const DEFAULT_MODE_ID_FOR_RUN: &str = "orchestrator";
+
+fn append_permission_checks(
+    store: &BrownieStore,
+    record: &brownie_protocol::TaskRecord,
+    policy: &CompiledModePolicy,
+) -> anyhow::Result<()> {
+    for action in [
+        RuntimeAction::ReadWorkspace,
+        RuntimeAction::SpawnSubtask,
+        RuntimeAction::WriteWorkspace,
+        RuntimeAction::ExecuteProcess,
+    ] {
+        let decision = RuntimePermissionGate::check(policy, action);
+        debug_assert!(
+            decision.allowed || decision.action != RuntimeAction::ReadWorkspace,
+            "ReadWorkspace is a required runtime permission and must always be allowed"
+        );
+        let payload = permission_payload(policy, &decision);
+        store.tasks().append_task_event_with_payload(
+            record,
+            LedgerEventKind::PermissionChecked,
+            Some(payload.clone()),
+        )?;
+        if !decision.allowed {
+            store.tasks().append_task_event_with_payload(
+                record,
+                LedgerEventKind::PermissionDenied,
+                Some(payload),
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn permission_payload(
+    policy: &CompiledModePolicy,
+    decision: &brownie_agentmodes::PermissionDecision,
+) -> Value {
+    json!({
+        "mode_id": policy.mode_id,
+        "action": runtime_action_name(&decision.action),
+        "allowed": decision.allowed,
+        "reason": decision.reason,
+    })
+}
+
+fn runtime_action_from_name(action: &RuntimeActionName) -> RuntimeAction {
+    match action {
+        RuntimeActionName::ReadWorkspace => RuntimeAction::ReadWorkspace,
+        RuntimeActionName::WriteWorkspace => RuntimeAction::WriteWorkspace,
+        RuntimeActionName::ExecuteProcess => RuntimeAction::ExecuteProcess,
+        RuntimeActionName::AccessNetwork => RuntimeAction::AccessNetwork,
+        RuntimeActionName::ControlService => RuntimeAction::ControlService,
+        RuntimeActionName::DestructiveOperation => RuntimeAction::DestructiveOperation,
+        RuntimeActionName::SpawnSubtask => RuntimeAction::SpawnSubtask,
+    }
+}
+
+fn runtime_action_name(action: &RuntimeAction) -> RuntimeActionName {
+    match action {
+        RuntimeAction::ReadWorkspace => RuntimeActionName::ReadWorkspace,
+        RuntimeAction::WriteWorkspace => RuntimeActionName::WriteWorkspace,
+        RuntimeAction::ExecuteProcess => RuntimeActionName::ExecuteProcess,
+        RuntimeAction::AccessNetwork => RuntimeActionName::AccessNetwork,
+        RuntimeAction::ControlService => RuntimeActionName::ControlService,
+        RuntimeAction::DestructiveOperation => RuntimeActionName::DestructiveOperation,
+        RuntimeAction::SpawnSubtask => RuntimeActionName::SpawnSubtask,
+    }
 }
 
 fn preview_prompt(prompt: &brownie_context::PromptView) -> String {
@@ -493,6 +631,12 @@ mod tests {
                 LedgerEventKind::TaskStarted,
                 LedgerEventKind::ModeResolved,
                 LedgerEventKind::TaskRunning,
+                LedgerEventKind::PermissionChecked,
+                LedgerEventKind::PermissionChecked,
+                LedgerEventKind::PermissionChecked,
+                LedgerEventKind::PermissionDenied,
+                LedgerEventKind::PermissionChecked,
+                LedgerEventKind::PermissionDenied,
                 LedgerEventKind::PromptBuilt,
                 LedgerEventKind::LlmRequestCreated,
                 LedgerEventKind::LlmResponseReceived,
@@ -613,6 +757,88 @@ mod tests {
             r#"{"jsonrpc":"2.0","id":2,"method":"mode.get","params":{"mode_id":"orchestrator"}}"#,
         );
         assert_eq!(get.result.expect("get result")["mode_id"], "orchestrator");
+    }
+
+    #[test]
+    fn permission_check_returns_allowed_and_denied_decisions() {
+        let denied = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"permission.check","params":{"mode_id":"orchestrator","action":"WriteWorkspace"}}"#,
+        );
+        assert!(denied.error.is_none());
+        let result = denied.result.expect("denied result");
+        assert_eq!(result["mode_id"], "orchestrator");
+        assert_eq!(result["action"], "WriteWorkspace");
+        assert_eq!(result["allowed"], false);
+        assert!(result["reason"]
+            .as_str()
+            .expect("reason")
+            .contains("workspace writes"));
+
+        let allowed = parse_line(
+            r#"{"jsonrpc":"2.0","id":2,"method":"permission.check","params":{"mode_id":"implementer","action":"WriteWorkspace"}}"#,
+        );
+        assert_eq!(allowed.result.expect("allowed result")["allowed"], true);
+    }
+
+    #[test]
+    fn permission_check_unknown_mode_returns_invalid_params() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"permission.check","params":{"mode_id":"unknown-mode","action":"WriteWorkspace"}}"#,
+        );
+        assert!(response.result.is_none());
+        assert_eq!(response.error.expect("error").code, -32602);
+    }
+
+    #[test]
+    fn task_run_appends_permission_events() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Permission checks","mode_id":"orchestrator"}}"#,
+        );
+        let start_result = start.result.expect("start result");
+        let task_id = start_result["task_id"]
+            .as_str()
+            .expect("task id")
+            .to_string();
+        let run_id = start_result["run_id"].as_str().expect("run id").to_string();
+
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert_eq!(run.result.expect("run result")["status"], "Completed");
+
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/runs")
+                .join(&run_id)
+                .join("ledger.jsonl"),
+        )
+        .expect("ledger");
+        let events: Vec<brownie_store::LedgerEvent> = ledger
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("event"))
+            .collect();
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::PermissionChecked)
+                .count(),
+            4
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::PermissionDenied)
+                .count(),
+            2
+        );
+        assert!(ledger.contains("WriteWorkspace"));
+        assert!(ledger.contains("ExecuteProcess"));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }
 
     #[test]

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -242,6 +242,8 @@ pub struct LedgerEvent {
 pub enum LedgerEventKind {
     TaskStarted,
     ModeResolved,
+    PermissionChecked,
+    PermissionDenied,
     TaskRunning,
     PromptBuilt,
     LlmRequestCreated,

--- a/docs/specifications/agentmodes-compatibility-spec-v0.md
+++ b/docs/specifications/agentmodes-compatibility-spec-v0.md
@@ -74,3 +74,11 @@ Phase 1.3 does not implement AgentModes YAML parsing, Mode Pack fetching, valida
 The built-in registry resolves `mode_id` values into `CompiledModePolicy` records. The required Phase 1.3 modes are `orchestrator`, `implementer`, and `verifier`. Unknown mode IDs are rejected by runtime entry points that require an executable policy.
 
 Runtime permissions are modeled as policy data so later phases can enforce them outside of LLM instructions. Permission policy remains authoritative over prompt text.
+
+## Phase 1.4 permission gate update
+
+Phase 1.4 adds the `RuntimePermissionGate` foundation. Runtime permission checks are based on compiled mode policy capabilities and override LLM instructions.
+
+Runtime actions are `ReadWorkspace`, `WriteWorkspace`, `ExecuteProcess`, `AccessNetwork`, `ControlService`, `DestructiveOperation`, and `SpawnSubtask`. Phase 1.4 records permission decisions only; it does not execute real tools, write files, apply patches, execute processes, call real LLM APIs, parse AgentModes YAML, fetch Mode Packs, or implement Qdrant/llama-server/indexer behavior.
+
+The runtime protocol includes `permission.check`. Task runs append `PermissionChecked` ledger events for minimum checks and append `PermissionDenied` when a checked action is denied. `ModeResolved` stores a full permission snapshot so prompt materialization can summarize active mode capabilities.

--- a/docs/specifications/mode-policy-spec-v0.md
+++ b/docs/specifications/mode-policy-spec-v0.md
@@ -23,3 +23,11 @@ Out of scope:
 ## Policy precedence
 
 Runtime permission policy is authoritative and is designed to override any LLM instruction. Phase 1.3 only resolves, stores, and exposes policy summaries; later phases will enforce permissions at runtime boundaries.
+
+## Phase 1.4 permission gate update
+
+Phase 1.4 adds the `RuntimePermissionGate` foundation. Runtime permission checks are based on compiled mode policy capabilities and override LLM instructions.
+
+Runtime actions are `ReadWorkspace`, `WriteWorkspace`, `ExecuteProcess`, `AccessNetwork`, `ControlService`, `DestructiveOperation`, and `SpawnSubtask`. Phase 1.4 records permission decisions only; it does not execute real tools, write files, apply patches, execute processes, call real LLM APIs, parse AgentModes YAML, fetch Mode Packs, or implement Qdrant/llama-server/indexer behavior.
+
+The runtime protocol includes `permission.check`. Task runs append `PermissionChecked` ledger events for minimum checks and append `PermissionDenied` when a checked action is denied. `ModeResolved` stores a full permission snapshot so prompt materialization can summarize active mode capabilities.

--- a/docs/specifications/permission-gate-spec-v0.md
+++ b/docs/specifications/permission-gate-spec-v0.md
@@ -1,0 +1,27 @@
+# Permission Gate Spec v0
+
+Phase 1.4 introduces the runtime permission gate foundation. The gate is a runtime-enforced policy boundary and takes precedence over any LLM instruction or generated plan.
+
+## Runtime actions
+
+`RuntimePermissionGate` evaluates these actions against a `CompiledModePolicy` permission snapshot:
+
+- `ReadWorkspace` — always allowed.
+- `WriteWorkspace` — controlled by `workspace_write`.
+- `ExecuteProcess` — controlled by `process_exec`.
+- `AccessNetwork` — controlled by `network_access`.
+- `ControlService` — controlled by `service_control`.
+- `DestructiveOperation` — controlled by `destructive`.
+- `SpawnSubtask` — controlled by `can_spawn_subtasks`.
+
+The `read_only` field is informational for summaries. Individual capabilities are authoritative for gate decisions.
+
+## JSON-RPC
+
+`permission.check` accepts a built-in `mode_id` and action name, resolves the mode through the built-in registry, and returns an allowed/denied decision with a human-readable reason. Unknown modes return JSON-RPC `-32602`.
+
+## Ledger events
+
+`task.run` records `PermissionChecked` events for minimum Phase 1.4 checks: `ReadWorkspace`, `SpawnSubtask`, `WriteWorkspace`, and `ExecuteProcess`. Denied checks also append a `PermissionDenied` event with the same payload.
+
+Phase 1.4 does not execute real tools, apply file edits, execute processes, call real LLM APIs, fetch Mode Packs, parse AgentModes YAML, or implement Qdrant/llama-server/indexer wrappers.

--- a/docs/specifications/prompt-builder-spec-v0.md
+++ b/docs/specifications/prompt-builder-spec-v0.md
@@ -45,3 +45,11 @@ Phase 1.2 records prompt lifecycle metadata in the run ledger, but it does not p
 `PromptBuilder` includes the mode policy summary in the prompt view. This is informational for Phase 1.3 only; permission enforcement is reserved for later runtime phases and remains authoritative over any LLM instruction.
 
 If no `ModeResolved` event is available, the materialized prompt input uses `Mode Policy:\n<unresolved>` as a fallback summary.
+
+## Phase 1.4 permission gate update
+
+Phase 1.4 adds the `RuntimePermissionGate` foundation. Runtime permission checks are based on compiled mode policy capabilities and override LLM instructions.
+
+Runtime actions are `ReadWorkspace`, `WriteWorkspace`, `ExecuteProcess`, `AccessNetwork`, `ControlService`, `DestructiveOperation`, and `SpawnSubtask`. Phase 1.4 records permission decisions only; it does not execute real tools, write files, apply patches, execute processes, call real LLM APIs, parse AgentModes YAML, fetch Mode Packs, or implement Qdrant/llama-server/indexer behavior.
+
+The runtime protocol includes `permission.check`. Task runs append `PermissionChecked` ledger events for minimum checks and append `PermissionDenied` when a checked action is denied. `ModeResolved` stores a full permission snapshot so prompt materialization can summarize active mode capabilities.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -171,3 +171,11 @@ Phase 1.3 adds `mode.list` and `mode.get` JSON-RPC methods backed by the built-i
 `mode.list` returns `{ "modes": ModeSummary[] }`, where each summary includes `mode_id`, `display_name`, `role_definition`, and permission booleans. `mode.get` accepts `{ "mode_id": string }` and returns one `ModeSummary`.
 
 Unknown mode IDs passed to `mode.get` return JSON-RPC `-32602 invalid params`. `task.start` applies the same unknown-mode rejection, while omitted or `null` `mode_id` defaults to `orchestrator`.
+
+## Phase 1.4 permission gate update
+
+Phase 1.4 adds the `RuntimePermissionGate` foundation. Runtime permission checks are based on compiled mode policy capabilities and override LLM instructions.
+
+Runtime actions are `ReadWorkspace`, `WriteWorkspace`, `ExecuteProcess`, `AccessNetwork`, `ControlService`, `DestructiveOperation`, and `SpawnSubtask`. Phase 1.4 records permission decisions only; it does not execute real tools, write files, apply patches, execute processes, call real LLM APIs, parse AgentModes YAML, fetch Mode Packs, or implement Qdrant/llama-server/indexer behavior.
+
+The runtime protocol includes `permission.check`. Task runs append `PermissionChecked` ledger events for minimum checks and append `PermissionDenied` when a checked action is denied. `ModeResolved` stores a full permission snapshot so prompt materialization can summarize active mode capabilities.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -106,3 +106,11 @@ Phase 1.2 still does not call a real LLM API, implement an OpenAI-compatible HTT
 If a caller supplies an unknown `mode_id`, `task.start` returns JSON-RPC `-32602 invalid params` and does not create a task. This prevents tasks from running without a resolved runtime policy.
 
 After task creation, the run ledger records `TaskStarted` followed by `ModeResolved`. The `ModeResolved` payload stores a compact policy summary rather than the full policy.
+
+## Phase 1.4 permission gate update
+
+Phase 1.4 adds the `RuntimePermissionGate` foundation. Runtime permission checks are based on compiled mode policy capabilities and override LLM instructions.
+
+Runtime actions are `ReadWorkspace`, `WriteWorkspace`, `ExecuteProcess`, `AccessNetwork`, `ControlService`, `DestructiveOperation`, and `SpawnSubtask`. Phase 1.4 records permission decisions only; it does not execute real tools, write files, apply patches, execute processes, call real LLM APIs, parse AgentModes YAML, fetch Mode Packs, or implement Qdrant/llama-server/indexer behavior.
+
+The runtime protocol includes `permission.check`. Task runs append `PermissionChecked` ledger events for minimum checks and append `PermissionDenied` when a checked action is denied. `ModeResolved` stores a full permission snapshot so prompt materialization can summarize active mode capabilities.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -36,6 +36,10 @@
       {
         "command": "brownie.taskRun",
         "title": "Brownie: Run Task"
+      },
+      {
+        "command": "brownie.permissionCheck",
+        "title": "Brownie: Check Permission"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { formatError } from './runtime/errors';
+import type { RuntimeActionName } from './runtime/protocol';
 import { createRuntimeClient } from './runtime/workspace';
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -76,6 +77,47 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
 
+  const permissionCheckCommand = vscode.commands.registerCommand('brownie.permissionCheck', async () => {
+    const modeId = await vscode.window.showInputBox({
+      prompt: 'Mode ID',
+      placeHolder: 'orchestrator',
+      ignoreFocusOut: true,
+    });
+
+    if (modeId === undefined) {
+      return;
+    }
+
+    const actions: RuntimeActionName[] = [
+      'ReadWorkspace',
+      'WriteWorkspace',
+      'ExecuteProcess',
+      'AccessNetwork',
+      'ControlService',
+      'DestructiveOperation',
+      'SpawnSubtask',
+    ];
+    const action = await vscode.window.showQuickPick(actions, {
+      placeHolder: 'Select a runtime action to check',
+    });
+
+    if (action === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.checkPermission(modeId.trim(), action as RuntimeActionName);
+      output.appendLine(`permission.check: ${JSON.stringify(result)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie permission ${result.allowed ? 'allowed' : 'denied'}: ${result.action}`,
+      );
+    } catch (error) {
+      output.appendLine(`permission.check failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie permission check failed: ${formatError(error)}`);
+    }
+  });
+
   const taskRunCommand = vscode.commands.registerCommand('brownie.taskRun', async () => {
     const taskId = await vscode.window.showInputBox({
       prompt: 'Task ID',
@@ -100,7 +142,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, taskRunCommand);
+  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -25,6 +25,15 @@ export interface RuntimeStatusResult {
 
 export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
+export type RuntimeActionName =
+  | 'ReadWorkspace'
+  | 'WriteWorkspace'
+  | 'ExecuteProcess'
+  | 'AccessNetwork'
+  | 'ControlService'
+  | 'DestructiveOperation'
+  | 'SpawnSubtask';
+
 
 export interface ModePermissionsSummary {
   read_only: boolean;
@@ -41,6 +50,13 @@ export interface ModeSummary {
   display_name: string;
   role_definition: string;
   permissions: ModePermissionsSummary;
+}
+
+export interface PermissionCheckResult {
+  mode_id: string;
+  action: RuntimeActionName;
+  allowed: boolean;
+  reason: string;
 }
 
 export interface TaskStartParams {
@@ -115,6 +131,16 @@ export function isModeListResult(value: unknown): value is { modes: ModeSummary[
   return isRecord(value) && Array.isArray(value.modes) && value.modes.every(isModeSummary);
 }
 
+export function isPermissionCheckResult(value: unknown): value is PermissionCheckResult {
+  return (
+    isRecord(value) &&
+    typeof value.mode_id === 'string' &&
+    isRuntimeActionName(value.action) &&
+    typeof value.allowed === 'boolean' &&
+    typeof value.reason === 'string'
+  );
+}
+
 export function isTaskStartResult(value: unknown): value is TaskStartResult {
   return (
     isRecord(value) &&
@@ -156,6 +182,18 @@ function isModePermissionsSummary(value: unknown): value is ModePermissionsSumma
     typeof value.service_control === 'boolean' &&
     typeof value.destructive === 'boolean' &&
     typeof value.can_spawn_subtasks === 'boolean'
+  );
+}
+
+function isRuntimeActionName(value: unknown): value is RuntimeActionName {
+  return (
+    value === 'ReadWorkspace' ||
+    value === 'WriteWorkspace' ||
+    value === 'ExecuteProcess' ||
+    value === 'AccessNetwork' ||
+    value === 'ControlService' ||
+    value === 'DestructiveOperation' ||
+    value === 'SpawnSubtask'
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, ModeSummary, RuntimeStatusResult, TaskRecord, TaskRunResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isModeListResult, isModeSummary, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, TaskRecord, TaskRunResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isModeListResult, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -38,6 +38,19 @@ export class RuntimeClient {
 
     if (!isModeSummary(result)) {
       throw new RuntimeProtocolError('mode.get returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async checkPermission(modeId: string, action: RuntimeActionName): Promise<PermissionCheckResult> {
+    const result = await this.call<PermissionCheckResult>('permission.check', {
+      mode_id: modeId,
+      action,
+    });
+
+    if (!isPermissionCheckResult(result)) {
+      throw new RuntimeProtocolError('permission.check returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isModeSummary, isRuntimeStatusResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -61,6 +61,15 @@ describe('protocol validation', () => {
   it('accepts runtime.status results with string fields', () => {
     expect(isRuntimeStatusResult({ name: 'brownie-runtime', version: '0.1.0', status: 'Ready' })).toBe(true);
   });
+
+  it('accepts valid permission.check results', () => {
+    expect(isPermissionCheckResult({ mode_id: 'orchestrator', action: 'WriteWorkspace', allowed: false, reason: 'denied' })).toBe(true);
+  });
+
+  it('rejects invalid permission.check result shapes', () => {
+    expect(isPermissionCheckResult({ mode_id: 'orchestrator', action: 'UnknownAction', allowed: false, reason: 'denied' })).toBe(false);
+    expect(isPermissionCheckResult({ mode_id: 'orchestrator', action: 'WriteWorkspace', allowed: 'false', reason: 'denied' })).toBe(false);
+  });
 });
 
 describe('RuntimeClient', () => {
@@ -94,6 +103,22 @@ describe('RuntimeClient', () => {
 
     await expect(client.getMode('orchestrator')).resolves.toEqual(modeSummary);
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'mode.get', params: { mode_id: 'orchestrator' } }]);
+  });
+
+  it('creates a permission.check request', async () => {
+    const result = { mode_id: 'orchestrator', action: 'WriteWorkspace', allowed: false, reason: 'Mode orchestrator does not allow workspace writes.' };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.checkPermission('orchestrator', 'WriteWorkspace')).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'permission.check', params: { mode_id: 'orchestrator', action: 'WriteWorkspace' } }]);
+  });
+
+  it('rejects invalid permission.check results', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', action: 'UnknownAction', allowed: false, reason: 'bad' } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.checkPermission('orchestrator', 'WriteWorkspace')).rejects.toThrow('permission.check returned an invalid result');
   });
 
   it('creates a task.start request', async () => {


### PR DESCRIPTION
### Motivation
- Provide the Phase 1.4 foundation for runtime-enforced permission decisions so runtime capability flags override LLM instructions. 
- Record permission decisions in the run ledger to make permission state auditable and materializable into prompts. 
- Expose a JSON-RPC boundary for external clients (VSIX) to validate permission decisions without executing real tools.

### Description
- Added `RuntimeAction`, `PermissionDecision`, and `RuntimePermissionGate` to `crates/brownie-agentmodes` and implemented capability-driven checks against `CompiledModePolicy` (e.g. `WriteWorkspace` -> `workspace_write`).
- Extended protocol types in `crates/brownie-protocol` with `PermissionCheckParams`, `PermissionCheckResult`, and `RuntimeActionName`, and added conversion helpers in the runtime.
- Implemented the `permission.check` JSON-RPC method in `crates/brownie-runtime` that resolves a built-in mode, converts action names, invokes `RuntimePermissionGate::check`, and returns a `PermissionCheckResult` (unknown `mode_id` returns `-32602`).
- Extended `ModeResolved` payload to include a full permission snapshot, added `PermissionChecked` and `PermissionDenied` `LedgerEventKind`s in `crates/brownie-store`, appended minimal permission checks (`ReadWorkspace`, `SpawnSubtask`, `WriteWorkspace`, `ExecuteProcess`) inside `task.run`, and wired permission summaries into `ContextMaterializer`/`PromptBuildInput`/`PromptBuilder`.
- Updated VSIX types and client (`extensions/brownie-vsix`) with `RuntimeActionName`, `PermissionCheckResult`, `RuntimeClient.checkPermission`, and added the `brownie.permissionCheck` command to call the runtime and display results.
- Added Rust and VSIX unit tests validating gate logic, `permission.check` behavior, ledger event appends, prompt materialization, and runtime-client protocol validation.

### Testing
- Ran `cargo fmt --check` and `cargo check --workspace` which succeeded. 
- Ran `cargo test --workspace` and all Rust unit tests passed (including new permission gate, `permission.check`, and `task.run` ledger assertions). 
- Ran VSIX pipeline: `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and the TypeScript checks, tests and build succeeded. 
- Performed manual smoke tests: `permission.check` for `orchestrator` returned `allowed: false` with a workspace-write denial reason and for `implementer` returned `allowed: true`, and a `task.start` -> `task.run` smoke run recorded `PermissionChecked` events (and `PermissionDenied` for denied checks) in the run ledger as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3c80c8f08328887af092a0332b5e)