### PR TITLE
Add read-only workspace.read tool execution (Phase 1.7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,9 +112,11 @@ dependencies = [
 name = "brownie-tools"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "brownie-agentmodes",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -160,6 +160,27 @@ pub struct ToolSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolExecuteParams {
+    pub mode_id: String,
+    pub tool_id: String,
+    pub input: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolExecuteResult {
+    pub tool_id: String,
+    pub status: ToolExecuteStatus,
+    pub output: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ToolExecuteStatus {
+    Completed,
+    Denied,
+    Failed,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskStartParams {
     pub goal: String,
     pub mode_id: Option<String>,

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -9,14 +9,16 @@ use brownie_protocol::{
     JsonRpcError, JsonRpcRequest, JsonRpcResponse, ModeGetParams, ModeListResult,
     ModePermissionsSummary, ModeSummary, PermissionCheckParams, PermissionCheckResult,
     RuntimeActionName, RuntimeState, RuntimeStatus, TaskGetParams, TaskListResult, TaskRunParams,
-    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolIntentDecisionSummary,
-    ToolIntentParseParams, ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult,
-    ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
+    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
+    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentParseParams,
+    ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
+    ToolPlanParams, ToolPlanResult, ToolSummary,
 };
 use brownie_store::{BrownieStore, LedgerEventKind};
 use brownie_tools::{
-    BuiltinToolRegistry, RejectedToolIntent, ToolIntentDecision, ToolIntentEvaluator,
-    ToolIntentParser, ToolPlanDecision, ToolPlanEvaluator, ToolPlanner, ToolPlanningInput,
+    BuiltinToolRegistry, RejectedToolIntent, ToolExecutionRequest, ToolExecutionStatus,
+    ToolExecutor, ToolIntentDecision, ToolIntentEvaluator, ToolIntentParser, ToolPlanDecision,
+    ToolPlanEvaluator, ToolPlanner, ToolPlanningInput,
 };
 use serde_json::{json, Value};
 
@@ -32,6 +34,7 @@ const METHOD_PERMISSION_CHECK: &str = "permission.check";
 const METHOD_TOOL_LIST: &str = "tool.list";
 const METHOD_TOOL_PLAN: &str = "tool.plan";
 const METHOD_TOOL_INTENT_PARSE: &str = "tool.intent.parse";
+const METHOD_TOOL_EXECUTE: &str = "tool.execute";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -72,6 +75,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TOOL_LIST => handle_tool_list(request.id),
         METHOD_TOOL_PLAN => handle_tool_plan(request.id, request.params),
         METHOD_TOOL_INTENT_PARSE => handle_tool_intent_parse(request.id, request.params),
+        METHOD_TOOL_EXECUTE => handle_tool_execute(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -328,6 +332,53 @@ fn handle_tool_intent_parse(id: Value, params: Option<Value>) -> JsonRpcResponse
     )
 }
 
+fn handle_tool_execute(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ToolExecuteParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    let policy = match BuiltinModeRegistry::get(&params.mode_id) {
+        Some(policy) => policy,
+        None => return error_response(id, -32602, "invalid params: unknown mode_id"),
+    };
+    let Some(definition) = BuiltinToolRegistry::get(&params.tool_id) else {
+        return result_response(
+            id,
+            json!(ToolExecuteResult {
+                tool_id: params.tool_id,
+                status: ToolExecuteStatus::Failed,
+                output: json!({ "reason": "Unknown tool id." }),
+            }),
+        );
+    };
+    let decision = RuntimePermissionGate::check(&policy, definition.required_action);
+    if !decision.allowed {
+        return result_response(
+            id,
+            json!(ToolExecuteResult {
+                tool_id: definition.tool_id,
+                status: ToolExecuteStatus::Denied,
+                output: json!({ "reason": decision.reason }),
+            }),
+        );
+    }
+
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match ToolExecutor::execute_read_only(
+        store.workspace_root(),
+        ToolExecutionRequest {
+            tool_id: definition.tool_id,
+            input: params.input,
+        },
+    ) {
+        Ok(result) => result_response(id, json!(tool_execute_result(result))),
+        Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
+    }
+}
+
 fn handle_mode_list(id: Value) -> JsonRpcResponse<Value> {
     let modes = BuiltinModeRegistry::list()
         .into_iter()
@@ -492,6 +543,18 @@ fn tool_intent_rejected_summary(rejected: RejectedToolIntent) -> ToolIntentRejec
     ToolIntentRejectedSummary {
         tool_id: rejected.tool_id,
         reason: rejected.reason,
+    }
+}
+
+fn tool_execute_result(result: brownie_tools::ToolExecutionResult) -> ToolExecuteResult {
+    ToolExecuteResult {
+        tool_id: result.tool_id,
+        status: match result.status {
+            ToolExecutionStatus::Completed => ToolExecuteStatus::Completed,
+            ToolExecutionStatus::Denied => ToolExecuteStatus::Denied,
+            ToolExecutionStatus::Failed => ToolExecuteStatus::Failed,
+        },
+        output: result.output,
     }
 }
 
@@ -739,6 +802,62 @@ mod tests {
             response.result.expect("status result")["name"],
             "brownie-runtime"
         );
+    }
+
+    #[test]
+    fn tool_execute_workspace_read_returns_completed() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("README.md"), "hello brownie").expect("write");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tool.execute","params":{"mode_id":"orchestrator","tool_id":"workspace.read","input":{"path":"README.md"}}}"#,
+        );
+
+        assert!(response.error.is_none());
+        let result = response.result.expect("result");
+        assert_eq!(result["status"], "Completed");
+        assert_eq!(result["output"]["content"], "hello brownie");
+        assert_eq!(result["output"]["truncated"], false);
+    }
+
+    #[test]
+    fn tool_execute_workspace_read_path_traversal_fails() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":2,"method":"tool.execute","params":{"mode_id":"orchestrator","tool_id":"workspace.read","input":{"path":"../secret.txt"}}}"#,
+        );
+
+        assert!(response.error.is_none());
+        assert_eq!(response.result.expect("result")["status"], "Failed");
+    }
+
+    #[test]
+    fn tool_execute_unknown_mode_returns_invalid_params() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":3,"method":"tool.execute","params":{"mode_id":"unknown","tool_id":"workspace.read","input":{"path":"README.md"}}}"#,
+        );
+
+        assert_eq!(response.error.expect("error").code, -32602);
+    }
+
+    #[test]
+    fn tool_execute_workspace_write_is_denied_without_writing() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":4,"method":"tool.execute","params":{"mode_id":"implementer","tool_id":"workspace.write","input":{"path":"created.txt","content":"nope"}}}"#,
+        );
+
+        assert!(response.error.is_none());
+        assert_eq!(response.result.expect("result")["status"], "Denied");
+        assert!(!temp.path().join("created.txt").exists());
     }
 
     #[test]

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -36,6 +36,10 @@ impl BrownieStore {
     pub fn tasks(&self) -> &TaskStore {
         &self.task_store
     }
+
+    pub fn workspace_root(&self) -> &std::path::Path {
+        self.task_store.workspace_root()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -176,6 +180,10 @@ impl TaskStore {
     fn runs_dir(&self) -> PathBuf {
         self.workspace_root.join(WORKSPACE_STATE_DIR).join(RUNS_DIR)
     }
+
+    pub fn workspace_root(&self) -> &std::path::Path {
+        &self.workspace_root
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -253,6 +261,11 @@ pub enum LedgerEventKind {
     ToolIntentPermissionChecked,
     ToolIntentApproved,
     ToolIntentDenied,
+    ToolExecutionRequested,
+    ToolExecutionPermissionChecked,
+    ToolExecutionCompleted,
+    ToolExecutionDenied,
+    ToolExecutionFailed,
     TaskRunning,
     PromptBuilt,
     LlmRequestCreated,

--- a/crates/brownie-tools/Cargo.toml
+++ b/crates/brownie-tools/Cargo.toml
@@ -13,3 +13,7 @@ path = "src/lib.rs"
 brownie-agentmodes = { path = "../brownie-agentmodes" }
 serde.workspace = true
 serde_json.workspace = true
+anyhow.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/brownie-tools/src/lib.rs
+++ b/crates/brownie-tools/src/lib.rs
@@ -1,8 +1,15 @@
 //! Runtime tool abstraction crate.
 
+use std::fs;
+use std::path::{Component, Path};
+
+use anyhow::{bail, Context};
 use brownie_agentmodes::{CompiledModePolicy, RuntimeAction, RuntimePermissionGate};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{json, Value};
+
+pub const WORKSPACE_READ_TOOL_ID: &str = "workspace.read";
+pub const MAX_WORKSPACE_READ_BYTES: usize = 65_536;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolSideEffectLevel {
@@ -65,6 +72,147 @@ impl BuiltinToolRegistry {
         Self::list()
             .into_iter()
             .find(|tool| tool.tool_id == tool_id)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolExecutionRequest {
+    pub tool_id: String,
+    pub input: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolExecutionResult {
+    pub tool_id: String,
+    pub status: ToolExecutionStatus,
+    pub output: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum ToolExecutionStatus {
+    Completed,
+    Denied,
+    Failed,
+}
+
+pub struct WorkspaceReadExecutor;
+
+impl WorkspaceReadExecutor {
+    pub fn read(
+        workspace_root: &Path,
+        relative_path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<ToolExecutionResult> {
+        match Self::try_read(workspace_root, relative_path, max_bytes) {
+            Ok(result) => Ok(result),
+            Err(error) => Ok(ToolExecutionResult {
+                tool_id: WORKSPACE_READ_TOOL_ID.to_string(),
+                status: ToolExecutionStatus::Failed,
+                output: json!({ "reason": error.to_string() }),
+            }),
+        }
+    }
+
+    fn try_read(
+        workspace_root: &Path,
+        relative_path: &str,
+        max_bytes: usize,
+    ) -> anyhow::Result<ToolExecutionResult> {
+        if relative_path.trim().is_empty() {
+            bail!("path must not be empty");
+        }
+        let requested_path = Path::new(relative_path);
+        if requested_path.is_absolute() {
+            bail!("absolute paths are not allowed");
+        }
+        for component in requested_path.components() {
+            match component {
+                Component::ParentDir => bail!("path traversal is not allowed"),
+                Component::Normal(name)
+                    if is_blocked_component(name.to_string_lossy().as_ref()) =>
+                {
+                    bail!("reading protected workspace paths is not allowed")
+                }
+                Component::Prefix(_) | Component::RootDir => {
+                    bail!("absolute paths are not allowed")
+                }
+                _ => {}
+            }
+        }
+
+        let root = workspace_root.canonicalize().with_context(|| {
+            format!(
+                "failed to canonicalize workspace root {}",
+                workspace_root.display()
+            )
+        })?;
+        let target = root.join(requested_path);
+        let canonical_target = target
+            .canonicalize()
+            .with_context(|| format!("failed to canonicalize {}", relative_path))?;
+        if !canonical_target.starts_with(&root) {
+            bail!("path escapes workspace root");
+        }
+        if canonical_target.is_dir() {
+            bail!("directory reads are not supported in Phase 1.7");
+        }
+
+        let bytes = fs::read(&canonical_target)
+            .with_context(|| format!("failed to read {}", relative_path))?;
+        let truncated = bytes.len() > max_bytes;
+        let read_len = bytes.len().min(max_bytes);
+        let content = std::str::from_utf8(&bytes[..read_len])
+            .context("workspace.read supports UTF-8 text files only")?
+            .to_string();
+
+        Ok(ToolExecutionResult {
+            tool_id: WORKSPACE_READ_TOOL_ID.to_string(),
+            status: ToolExecutionStatus::Completed,
+            output: json!({
+                "path": relative_path,
+                "content": content,
+                "truncated": truncated,
+                "bytes_read": read_len,
+            }),
+        })
+    }
+}
+
+fn is_blocked_component(component: &str) -> bool {
+    matches!(component, ".git" | ".brownie" | "node_modules" | "target")
+}
+
+pub struct ToolExecutor;
+
+impl ToolExecutor {
+    pub fn execute_read_only(
+        workspace_root: &Path,
+        request: ToolExecutionRequest,
+    ) -> anyhow::Result<ToolExecutionResult> {
+        if BuiltinToolRegistry::get(&request.tool_id).is_none() {
+            return Ok(ToolExecutionResult {
+                tool_id: request.tool_id,
+                status: ToolExecutionStatus::Failed,
+                output: json!({ "reason": "Unknown tool id." }),
+            });
+        }
+        if request.tool_id != WORKSPACE_READ_TOOL_ID {
+            return Ok(ToolExecutionResult {
+                tool_id: request.tool_id,
+                status: ToolExecutionStatus::Denied,
+                output: json!({
+                    "reason": "Tool execution is not enabled for this tool in Phase 1.7."
+                }),
+            });
+        }
+        let Some(path) = request.input.get("path").and_then(Value::as_str) else {
+            return Ok(ToolExecutionResult {
+                tool_id: request.tool_id,
+                status: ToolExecutionStatus::Failed,
+                output: json!({ "reason": "workspace.read input.path must be a string." }),
+            });
+        };
+        WorkspaceReadExecutor::read(workspace_root, path, MAX_WORKSPACE_READ_BYTES)
     }
 }
 
@@ -423,5 +571,88 @@ mod tests {
             .items
             .iter()
             .any(|item| item.tool_id == "workspace.write" && !item.allowed));
+    }
+
+    #[test]
+    fn workspace_read_executor_reads_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("README.md"), "hello brownie").expect("write");
+
+        let result =
+            WorkspaceReadExecutor::read(temp.path(), "README.md", MAX_WORKSPACE_READ_BYTES)
+                .expect("read result");
+
+        assert_eq!(result.status, ToolExecutionStatus::Completed);
+        assert_eq!(result.output["content"], "hello brownie");
+        assert_eq!(result.output["truncated"], false);
+    }
+
+    #[test]
+    fn workspace_read_executor_rejects_absolute_paths() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let result =
+            WorkspaceReadExecutor::read(temp.path(), "/etc/passwd", MAX_WORKSPACE_READ_BYTES)
+                .expect("read result");
+        assert_eq!(result.status, ToolExecutionStatus::Failed);
+    }
+
+    #[test]
+    fn workspace_read_executor_rejects_path_traversal() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let result =
+            WorkspaceReadExecutor::read(temp.path(), "../secret.txt", MAX_WORKSPACE_READ_BYTES)
+                .expect("read result");
+        assert_eq!(result.status, ToolExecutionStatus::Failed);
+    }
+
+    #[test]
+    fn workspace_read_executor_rejects_protected_directories() {
+        for dir in [".brownie", ".git", "node_modules", "target"] {
+            let temp = tempfile::tempdir().expect("tempdir");
+            std::fs::create_dir(temp.path().join(dir)).expect("mkdir");
+            std::fs::write(temp.path().join(dir).join("file.txt"), "secret").expect("write");
+            let result = WorkspaceReadExecutor::read(
+                temp.path(),
+                &format!("{dir}/file.txt"),
+                MAX_WORKSPACE_READ_BYTES,
+            )
+            .expect("read result");
+            assert_eq!(result.status, ToolExecutionStatus::Failed, "{dir}");
+        }
+    }
+
+    #[test]
+    fn workspace_read_executor_truncates_large_file() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("large.log"), "abcdef").expect("write");
+        let result = WorkspaceReadExecutor::read(temp.path(), "large.log", 3).expect("read result");
+        assert_eq!(result.status, ToolExecutionStatus::Completed);
+        assert_eq!(result.output["content"], "abc");
+        assert_eq!(result.output["truncated"], true);
+        assert_eq!(result.output["bytes_read"], 3);
+    }
+
+    #[test]
+    fn workspace_read_executor_fails_invalid_utf8() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("binary.bin"), [0xff, 0xfe, 0xfd]).expect("write");
+        let result =
+            WorkspaceReadExecutor::read(temp.path(), "binary.bin", MAX_WORKSPACE_READ_BYTES)
+                .expect("read result");
+        assert_eq!(result.status, ToolExecutionStatus::Failed);
+    }
+
+    #[test]
+    fn tool_executor_denies_non_workspace_read_tools() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let result = ToolExecutor::execute_read_only(
+            temp.path(),
+            ToolExecutionRequest {
+                tool_id: "workspace.write".into(),
+                input: serde_json::json!({"path":"README.md"}),
+            },
+        )
+        .expect("execute");
+        assert_eq!(result.status, ToolExecutionStatus::Denied);
     }
 }

--- a/docs/specifications/permission-gate-spec-v0.md
+++ b/docs/specifications/permission-gate-spec-v0.md
@@ -33,3 +33,7 @@ Phase 1.5 adds dry-run tool planning before future tool execution. Tool definiti
 ## Phase 1.6 assistant tool intent dry-run
 
 Phase 1.6 adds assistant tool intent parsing from fenced `brownie-tool-intent` JSON blocks. The runtime validates all requested tool IDs against `BuiltinToolRegistry` and evaluates valid requests with `RuntimePermissionGate`. Denied or rejected assistant tool intent is recorded for inspection, but no tool is executed and `task.run` remains allowed to complete in this phase.
+
+## Phase 1.7 read-only tool execution note
+
+Phase 1.7 adds standalone `tool.execute` for permission-gated `workspace.read` execution only. All writes, process execution, subtasks, network access, service control, and destructive operations remain non-executable. `task.run` does not automatically execute tools in Phase 1.7. See `docs/specifications/tool-execution-spec-v0.md` for workspace boundary, protected path, truncation, UTF-8, and ledger behavior.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -187,3 +187,7 @@ Phase 1.5 adds dry-run tool planning before future tool execution. Tool definiti
 ## Phase 1.6 assistant tool intent dry-run
 
 Phase 1.6 adds assistant tool intent parsing from fenced `brownie-tool-intent` JSON blocks. The runtime validates all requested tool IDs against `BuiltinToolRegistry` and evaluates valid requests with `RuntimePermissionGate`. Denied or rejected assistant tool intent is recorded for inspection, but no tool is executed and `task.run` remains allowed to complete in this phase.
+
+## Phase 1.7 read-only tool execution note
+
+Phase 1.7 adds standalone `tool.execute` for permission-gated `workspace.read` execution only. All writes, process execution, subtasks, network access, service control, and destructive operations remain non-executable. `task.run` does not automatically execute tools in Phase 1.7. See `docs/specifications/tool-execution-spec-v0.md` for workspace boundary, protected path, truncation, UTF-8, and ledger behavior.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -122,3 +122,7 @@ Phase 1.5 adds dry-run tool planning before future tool execution. Tool definiti
 ## Phase 1.6 assistant tool intent dry-run
 
 Phase 1.6 adds assistant tool intent parsing from fenced `brownie-tool-intent` JSON blocks. The runtime validates all requested tool IDs against `BuiltinToolRegistry` and evaluates valid requests with `RuntimePermissionGate`. Denied or rejected assistant tool intent is recorded for inspection, but no tool is executed and `task.run` remains allowed to complete in this phase.
+
+## Phase 1.7 read-only tool execution note
+
+Phase 1.7 adds standalone `tool.execute` for permission-gated `workspace.read` execution only. All writes, process execution, subtasks, network access, service control, and destructive operations remain non-executable. `task.run` does not automatically execute tools in Phase 1.7. See `docs/specifications/tool-execution-spec-v0.md` for workspace boundary, protected path, truncation, UTF-8, and ledger behavior.

--- a/docs/specifications/tool-execution-spec-v0.md
+++ b/docs/specifications/tool-execution-spec-v0.md
@@ -1,0 +1,63 @@
+# Brownie Tool Execution Spec v0
+
+## Phase 1.7 scope
+
+Phase 1.7 introduces the minimum read-only execution foundation. The only executable tool is `workspace.read`.
+
+All write, patch, process, subtask, network, service-control, and destructive tools remain non-executable. `task.run` continues to parse and dry-run evaluate assistant tool intents, but it does not automatically execute tools.
+
+## `tool.execute`
+
+`tool.execute` is a standalone JSON-RPC method for explicit tool execution. Because it has no task context in Phase 1.7, callers must provide `mode_id` so the runtime can evaluate the request through `RuntimePermissionGate` before any execution dispatch.
+
+Example request:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tool.execute",
+  "params": {
+    "mode_id": "orchestrator",
+    "tool_id": "workspace.read",
+    "input": { "path": "README.md" }
+  }
+}
+```
+
+Unknown `mode_id` is rejected as invalid params (`-32602`). Permission denial returns a tool result with status `Denied` and a reason in `output`.
+
+## `workspace.read`
+
+Input:
+
+```json
+{ "path": "README.md" }
+```
+
+Completed output:
+
+```json
+{
+  "path": "README.md",
+  "content": "...",
+  "truncated": false,
+  "bytes_read": 123
+}
+```
+
+Large files are capped at 65536 bytes and return `truncated: true`.
+
+## Workspace boundary and protected paths
+
+`workspace.read` treats `path` as workspace-root relative. Absolute paths and `..` path traversal are rejected. The runtime canonicalizes both workspace root and target path, then rejects any target outside the workspace root.
+
+Phase 1.7 does not list directories. It rejects protected workspace paths under `.git`, `.brownie`, `node_modules`, and `target`. `.brownie` is protected because run ledgers and internal runtime state require explicit future diagnostics rather than broad tool access.
+
+Binary or invalid UTF-8 files fail safely instead of returning raw bytes.
+
+## Ledger behavior
+
+The store defines future task-scoped event kinds: `ToolExecutionRequested`, `ToolExecutionPermissionChecked`, `ToolExecutionCompleted`, `ToolExecutionDenied`, and `ToolExecutionFailed`.
+
+Standalone `tool.execute` does not write run ledger events in Phase 1.7 because it is not attached to a task/run. A future task-scoped execution path may use these event kinds when automatic execution is introduced.

--- a/docs/specifications/tool-intent-spec-v0.md
+++ b/docs/specifications/tool-intent-spec-v0.md
@@ -7,3 +7,7 @@ The runtime parses these blocks without executing any tool. Every assistant-requ
 Validated assistant tool intent is evaluated by `RuntimePermissionGate` using the compiled mode policy. Runtime permissions take precedence over assistant intent. Denied and rejected tool intent does not execute and does not fail `task.run` in Phase 1.6.
 
 Real tool execution, file reads, file writes, patch application, process command execution, subtask spawning, real LLM API calls, and OpenAI-compatible HTTP clients remain non-goals for this phase.
+
+## Phase 1.7 read-only tool execution note
+
+Phase 1.7 adds standalone `tool.execute` for permission-gated `workspace.read` execution only. All writes, process execution, subtasks, network access, service control, and destructive operations remain non-executable. `task.run` does not automatically execute tools in Phase 1.7. See `docs/specifications/tool-execution-spec-v0.md` for workspace boundary, protected path, truncation, UTF-8, and ledger behavior.

--- a/docs/specifications/tool-planning-spec-v0.md
+++ b/docs/specifications/tool-planning-spec-v0.md
@@ -39,3 +39,7 @@ A denied dry-run tool plan does not fail `task.run` in Phase 1.5 because no actu
 ## Phase 1.6 assistant tool intent dry-run
 
 Phase 1.6 adds assistant tool intent parsing from fenced `brownie-tool-intent` JSON blocks. The runtime validates all requested tool IDs against `BuiltinToolRegistry` and evaluates valid requests with `RuntimePermissionGate`. Denied or rejected assistant tool intent is recorded for inspection, but no tool is executed and `task.run` remains allowed to complete in this phase.
+
+## Phase 1.7 read-only tool execution note
+
+Phase 1.7 adds standalone `tool.execute` for permission-gated `workspace.read` execution only. All writes, process execution, subtasks, network access, service control, and destructive operations remain non-executable. `task.run` does not automatically execute tools in Phase 1.7. See `docs/specifications/tool-execution-spec-v0.md` for workspace boundary, protected path, truncation, UTF-8, and ledger behavior.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -48,6 +48,10 @@
       {
         "command": "brownie.toolIntentParse",
         "title": "Brownie: Parse Tool Intent"
+      },
+      {
+        "command": "brownie.toolExecuteRead",
+        "title": "Brownie: Execute Read Tool"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -207,8 +207,42 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const toolExecuteReadCommand = vscode.commands.registerCommand('brownie.toolExecuteRead', async () => {
+    const modeIdInput = await vscode.window.showInputBox({
+      prompt: 'Mode ID',
+      value: 'orchestrator',
+      ignoreFocusOut: true,
+    });
 
-  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand);
+    if (modeIdInput === undefined) {
+      return;
+    }
+
+    const path = await vscode.window.showInputBox({
+      prompt: 'Workspace-relative path to read',
+      placeHolder: 'README.md',
+      ignoreFocusOut: true,
+    });
+
+    if (path === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.executeTool(modeIdInput.trim() || 'orchestrator', 'workspace.read', { path: path.trim() });
+      output.appendLine(`tool.execute workspace.read: ${JSON.stringify(result, null, 2)}`);
+      output.show(true);
+      const outputValue = result.output as { bytes_read?: unknown; truncated?: unknown };
+      await vscode.window.showInformationMessage(
+        `Brownie workspace.read ${result.status}: bytes_read=${String(outputValue.bytes_read ?? 'n/a')}, truncated=${String(outputValue.truncated ?? 'n/a')}`,
+      );
+    } catch (error) {
+      output.appendLine(`tool.execute workspace.read failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie execute read tool failed: ${formatError(error)}`);
+    }
+  });
+
+  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -92,6 +92,14 @@ export interface ToolIntentParseResult {
   rejected: ToolIntentRejectedSummary[];
 }
 
+export type ToolExecuteStatus = 'Completed' | 'Denied' | 'Failed';
+
+export interface ToolExecuteResult {
+  tool_id: string;
+  status: ToolExecuteStatus;
+  output: unknown;
+}
+
 export interface TaskStartParams {
   goal: string;
   modeId?: string;
@@ -196,6 +204,15 @@ export function isToolPlanResult(value: unknown): value is ToolPlanResult {
   );
 }
 
+export function isToolExecuteResult(value: unknown): value is ToolExecuteResult {
+  return (
+    isRecord(value) &&
+    typeof value.tool_id === 'string' &&
+    isToolExecuteStatus(value.status) &&
+    Object.prototype.hasOwnProperty.call(value, 'output')
+  );
+}
+
 function isToolIntentDecisionSummary(value: unknown): value is ToolIntentDecisionSummary {
   return (
     isRecord(value) &&
@@ -283,6 +300,10 @@ function isRuntimeActionName(value: unknown): value is RuntimeActionName {
 
 function isTaskStatus(value: unknown): value is TaskStatus {
   return value === 'Created' || value === 'Running' || value === 'Completed' || value === 'Failed' || value === 'Cancelled';
+}
+
+function isToolExecuteStatus(value: unknown): value is ToolExecuteStatus {
+  return value === 'Completed' || value === 'Denied' || value === 'Failed';
 }
 
 function isJsonRpcError(value: unknown): value is JsonRpcError {

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, TaskRecord, TaskRunResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isModeListResult, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isModeListResult, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -97,6 +97,20 @@ export class RuntimeClient {
 
     if (!isToolPlanResult(result)) {
       throw new RuntimeProtocolError('tool.plan returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async executeTool(modeId: string, toolId: string, input: unknown): Promise<ToolExecuteResult> {
+    const result = await this.call<ToolExecuteResult>('tool.execute', {
+      mode_id: modeId,
+      tool_id: toolId,
+      input,
+    });
+
+    if (!isToolExecuteResult(result)) {
+      throw new RuntimeProtocolError('tool.execute returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -90,6 +90,12 @@ describe('protocol validation', () => {
     };
     expect(isToolPlanResult(result)).toBe(true);
     expect(isToolPlanResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'Nope', allowed: true, reason: 'ok' }] })).toBe(false);
+  });
+
+  it('validates tool.execute results', () => {
+    expect(isToolExecuteResult({ tool_id: 'workspace.read', status: 'Completed', output: { content: 'ok' } })).toBe(true);
+    expect(isToolExecuteResult({ tool_id: 'workspace.write', status: 'Denied', output: { reason: 'no' } })).toBe(true);
+    expect(isToolExecuteResult({ tool_id: 'workspace.read', status: 'Unknown', output: {} })).toBe(false);
   });
 });
 
@@ -215,6 +221,26 @@ describe('RuntimeClient', () => {
     const client = new RuntimeClient(transport);
 
     await expect(client.planTools('task_1')).rejects.toThrow('tool.plan returned an invalid result');
+  });
+
+  it('creates a tool.execute request', async () => {
+    const result = {
+      tool_id: 'workspace.read',
+      status: 'Completed',
+      output: { path: 'README.md', content: 'hello', truncated: false, bytes_read: 5 },
+    };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.executeTool('orchestrator', 'workspace.read', { path: 'README.md' })).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'tool.execute', params: { mode_id: 'orchestrator', tool_id: 'workspace.read', input: { path: 'README.md' } } }]);
+  });
+
+  it('rejects invalid tool.execute results', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { tool_id: 'workspace.read', status: 'Invalid', output: {} } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.executeTool('orchestrator', 'workspace.read', { path: 'README.md' })).rejects.toThrow('tool.execute returned an invalid result');
   });
 
   it('creates a task.get request', async () => {


### PR DESCRIPTION
### Motivation
- Provide the minimal read-only tool execution foundation required for Phase 1.7 so the runtime can safely serve workspace reads without enabling writes, process execution, network, or other destructive capabilities.
- Enforce runtime permission checks per mode policy and the workspace root boundary to prevent path traversal and accidental exposure of internal state (e.g. `.brownie`).

### Description
- Added execution types and dispatch: `ToolExecutionRequest`, `ToolExecutionResult`, and `ToolExecutionStatus` in `crates/brownie-tools` and corresponding `ToolExecuteParams`, `ToolExecuteResult`, `ToolExecuteStatus` in `crates/brownie-protocol`.
- Implemented `WorkspaceReadExecutor` that canonicalizes paths, rejects absolute paths and `..` traversal, blocks `.git`, `.brownie`, `node_modules`, and `target`, truncates reads to `65_536` bytes, and fails safely on non-UTF-8.
- Added `ToolExecutor::execute_read_only` that only executes `workspace.read` (denies other known tools and fails unknown tool ids), and wired a new `tool.execute` JSON-RPC method in the runtime that resolves `mode_id`, enforces `RuntimePermissionGate`, and dispatches read-only execution using the store workspace root.
- Exposed `BrownieStore::workspace_root()` and added future ledger event kinds for tool execution (`ToolExecutionRequested`, `ToolExecutionPermissionChecked`, `ToolExecutionCompleted`, `ToolExecutionDenied`, `ToolExecutionFailed`) while keeping standalone `tool.execute` ledger-free in Phase 1.7; updated VSIX protocol and client with `ToolExecuteResult` and `RuntimeClient.executeTool`, and added the `Brownie: Execute Read Tool` command and tests and documentation (`docs/specifications/tool-execution-spec-v0.md`).

### Testing
- Rust checks and unit tests: ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all passed.
- VSIX toolchain: ran `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and all passed.
- The runtime `tool.execute` JSON-RPC behavior was exercised by the automated unit tests added for `tool.execute` (unknown mode, workspace.read success, path traversal failure, and denied write-case) and those tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f71f702a483289461f5f67df02a44)