### PR TITLE
Add Phase 1.10 run inspection APIs

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -205,6 +205,21 @@ pub struct TaskRunParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunEventsParams {
+    pub run_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunInspectParams {
+    pub run_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskInspectParams {
+    pub task_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskRunResult {
     pub task_id: String,
     pub run_id: String,
@@ -214,6 +229,45 @@ pub struct TaskRunResult {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskListResult {
     pub tasks: Vec<TaskRecord>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunEventsResult {
+    pub run_id: String,
+    pub events: Vec<LedgerEventSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunInspectResult {
+    pub run: RunInspectSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskInspectResult {
+    pub task: TaskRecord,
+    pub run: RunInspectSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RunInspectSummary {
+    pub run_id: String,
+    pub task_id: Option<String>,
+    pub status: Option<TaskStatus>,
+    pub event_count: usize,
+    pub has_tool_execution_completed: bool,
+    pub has_second_pass: bool,
+    pub final_response_preview: Option<String>,
+    pub timeline: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LedgerEventSummary {
+    pub event_id: String,
+    pub task_id: String,
+    pub run_id: String,
+    pub kind: String,
+    pub timestamp: String,
+    pub payload: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -6,15 +6,17 @@ use brownie_agentmodes::{
 };
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_protocol::{
-    JsonRpcError, JsonRpcRequest, JsonRpcResponse, ModeGetParams, ModeListResult,
-    ModePermissionsSummary, ModeSummary, PermissionCheckParams, PermissionCheckResult,
-    RuntimeActionName, RuntimeState, RuntimeStatus, TaskGetParams, TaskListResult, TaskRunParams,
-    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
-    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentParseParams,
-    ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
-    ToolPlanParams, ToolPlanResult, ToolSummary,
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary, ModeGetParams,
+    ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
+    PermissionCheckResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
+    RunInspectSummary, RuntimeActionName, RuntimeState, RuntimeStatus, TaskGetParams,
+    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult,
+    TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult,
+    ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentParseParams, ToolIntentParseResult,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary,
 };
-use brownie_store::{BrownieStore, LedgerEventKind};
+use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
     BuiltinToolRegistry, RejectedToolIntent, ToolExecutionRequest, ToolExecutionStatus,
     ToolExecutor, ToolIntentDecision, ToolIntentEvaluator, ToolIntentParser, ToolPlanDecision,
@@ -27,6 +29,7 @@ const METHOD_RUNTIME_STATUS: &str = "runtime.status";
 const METHOD_TASK_START: &str = "task.start";
 const METHOD_TASK_GET: &str = "task.get";
 const METHOD_TASK_RUN: &str = "task.run";
+const METHOD_TASK_INSPECT: &str = "task.inspect";
 const METHOD_TASK_LIST: &str = "task.list";
 const METHOD_MODE_LIST: &str = "mode.list";
 const METHOD_MODE_GET: &str = "mode.get";
@@ -35,6 +38,8 @@ const METHOD_TOOL_LIST: &str = "tool.list";
 const METHOD_TOOL_PLAN: &str = "tool.plan";
 const METHOD_TOOL_INTENT_PARSE: &str = "tool.intent.parse";
 const METHOD_TOOL_EXECUTE: &str = "tool.execute";
+const METHOD_RUN_EVENTS: &str = "run.events";
+const METHOD_RUN_INSPECT: &str = "run.inspect";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -68,6 +73,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TASK_START => handle_task_start(request.id, request.params),
         METHOD_TASK_GET => handle_task_get(request.id, request.params),
         METHOD_TASK_RUN => handle_task_run(request.id, request.params),
+        METHOD_TASK_INSPECT => handle_task_inspect(request.id, request.params),
         METHOD_TASK_LIST => handle_task_list(request.id),
         METHOD_MODE_LIST => handle_mode_list(request.id),
         METHOD_MODE_GET => handle_mode_get(request.id, request.params),
@@ -76,6 +82,8 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TOOL_PLAN => handle_tool_plan(request.id, request.params),
         METHOD_TOOL_INTENT_PARSE => handle_tool_intent_parse(request.id, request.params),
         METHOD_TOOL_EXECUTE => handle_tool_execute(request.id, request.params),
+        METHOD_RUN_EVENTS => handle_run_events(request.id, request.params),
+        METHOD_RUN_INSPECT => handle_run_inspect(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -313,6 +321,72 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     }
 }
 
+fn handle_run_events(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: RunEventsParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: run_id must not be empty");
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    let events = match read_existing_run_events(&store, &params.run_id) {
+        Ok(events) => events,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    result_response(
+        id,
+        json!(RunEventsResult {
+            run_id: params.run_id,
+            events: events.into_iter().map(ledger_event_summary).collect(),
+        }),
+    )
+}
+
+fn handle_run_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: RunInspectParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: run_id must not be empty");
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match inspect_run(&store, &params.run_id) {
+        Ok(run) => result_response(id, json!(RunInspectResult { run })),
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
+fn handle_task_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: TaskInspectParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.task_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: task_id must not be empty");
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    let task = match store.tasks().get_task(&params.task_id) {
+        Ok(Some(record)) => record,
+        Ok(None) => return error_response(id, -32602, "invalid params: task not found"),
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match inspect_run(&store, &task.run_id) {
+        Ok(run) => result_response(id, json!(TaskInspectResult { task, run })),
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
 fn handle_task_list(id: Value) -> JsonRpcResponse<Value> {
     let store = match BrownieStore::from_env_or_cwd() {
         Ok(store) => store,
@@ -473,6 +547,133 @@ fn handle_mode_get(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Some(policy) => result_response(id, json!(mode_summary(policy))),
         None => error_response(id, -32602, "invalid params: unknown mode_id"),
     }
+}
+
+fn read_existing_run_events(
+    store: &BrownieStore,
+    run_id: &str,
+) -> Result<Vec<LedgerEvent>, String> {
+    match store.tasks().get_task_by_run_id(run_id) {
+        Ok(Some(_)) => {}
+        Ok(None) => return Err("invalid params: run not found".to_string()),
+        Err(error) => return Err(format!("invalid params: {error}")),
+    }
+    store
+        .tasks()
+        .read_ledger_events(run_id)
+        .map_err(|error| format!("invalid params: {error}"))
+}
+
+fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, String> {
+    let events = read_existing_run_events(store, run_id)?;
+    let task = store
+        .tasks()
+        .get_task_by_run_id(run_id)
+        .map_err(|error| format!("invalid params: {error}"))?;
+    let has_tool_execution_completed = events
+        .iter()
+        .any(|event| event.kind == LedgerEventKind::ToolExecutionCompleted);
+    let has_second_pass = events
+        .iter()
+        .any(|event| event.kind == LedgerEventKind::SecondPassLlmResponseReceived);
+    let final_response_preview =
+        latest_content_preview(&events, LedgerEventKind::SecondPassLlmResponseReceived)
+            .or_else(|| latest_content_preview(&events, LedgerEventKind::LlmResponseReceived));
+    Ok(RunInspectSummary {
+        run_id: run_id.to_string(),
+        task_id: task.as_ref().map(|task| task.task_id.clone()),
+        status: task.as_ref().map(|task| task.status.clone()),
+        event_count: events.len(),
+        has_tool_execution_completed,
+        has_second_pass,
+        final_response_preview,
+        timeline: events.iter().map(timeline_entry).collect(),
+    })
+}
+
+fn latest_content_preview(events: &[LedgerEvent], kind: LedgerEventKind) -> Option<String> {
+    events
+        .iter()
+        .rev()
+        .find(|event| event.kind == kind)
+        .and_then(|event| {
+            event
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.get("content_preview"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+}
+
+fn ledger_event_summary(event: LedgerEvent) -> LedgerEventSummary {
+    let kind = format!("{:?}", event.kind);
+    LedgerEventSummary {
+        event_id: event.event_id,
+        task_id: event.task_id,
+        run_id: event.run_id,
+        kind,
+        timestamp: event.timestamp,
+        payload: sanitize_ledger_payload(event.payload),
+    }
+}
+
+fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
+    let Value::Object(map) = payload? else {
+        return None;
+    };
+    const ALLOWED_KEYS: &[&str] = &[
+        "tool_id",
+        "status",
+        "reason",
+        "output_preview",
+        "prompt_preview",
+        "content_preview",
+        "bytes_read",
+        "truncated",
+        "model",
+        "message_count",
+        "mode_id",
+        "display_name",
+        "permissions",
+        "required_action",
+        "allowed",
+        "request_reason",
+        "tool_ids",
+    ];
+    let sanitized = map
+        .into_iter()
+        .filter(|(key, _)| ALLOWED_KEYS.contains(&key.as_str()))
+        .collect::<serde_json::Map<_, _>>();
+    if sanitized.is_empty() {
+        None
+    } else {
+        Some(Value::Object(sanitized))
+    }
+}
+
+fn timeline_entry(event: &LedgerEvent) -> String {
+    let mut parts = vec![format!("{:?}", event.kind)];
+    if let Some(Value::Object(payload)) = sanitize_ledger_payload(event.payload.clone()) {
+        for key in [
+            "tool_id",
+            "status",
+            "bytes_read",
+            "truncated",
+            "reason",
+            "model",
+            "message_count",
+        ] {
+            if let Some(value) = payload.get(key) {
+                let value = value
+                    .as_str()
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| value.to_string());
+                parts.push(format!("{key}={value}"));
+            }
+        }
+    }
+    parts.join(" ")
 }
 
 fn resolve_task_start_policy(mode_id: Option<&str>) -> Result<CompiledModePolicy, String> {
@@ -1032,6 +1233,106 @@ mod tests {
         assert!(!preview.contains("Workspace read smoke content"));
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn run_inspection_methods_return_sanitized_summaries() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("README.md"),
+            "# Brownie\n\nsecret full content",
+        )
+        .expect("write");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Inspect README before final response","mode_id":"orchestrator"}}"#,
+        );
+        let start_result = start.result.expect("start result");
+        let task_id = start_result["task_id"]
+            .as_str()
+            .expect("task id")
+            .to_string();
+        let run_id = start_result["run_id"].as_str().expect("run id").to_string();
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert!(run.error.is_none());
+
+        let events = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
+        ));
+        assert!(events.error.is_none());
+        let events_result = events.result.expect("events result");
+        assert_eq!(events_result["run_id"], run_id);
+        let serialized = serde_json::to_string(&events_result).expect("serialize");
+        assert!(serialized.contains("output_preview"));
+        assert!(serialized.contains("bytes_read"));
+        assert!(serialized.contains("truncated"));
+        assert!(!serialized.contains("secret full content"));
+        assert!(!serialized.contains("\"content\""));
+        assert!(!serialized.contains("full_content"));
+        assert!(!serialized.contains("file_content"));
+        assert!(!serialized.contains("raw_output"));
+
+        let inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"run.inspect","params":{{"run_id":"{run_id}"}}}}"#
+        ));
+        let summary = inspect.result.expect("inspect result")["run"].clone();
+        assert!(summary["event_count"].as_u64().expect("event_count") > 0);
+        assert_eq!(summary["has_tool_execution_completed"], true);
+        assert_eq!(summary["has_second_pass"], true);
+        assert!(summary["final_response_preview"]
+            .as_str()
+            .expect("preview")
+            .contains("Fake LLM final response"));
+
+        let task_inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.inspect","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert_eq!(
+            task_inspect.result.expect("task inspect result")["task"]["task_id"],
+            task_id
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn run_inspect_unknown_run_returns_invalid_params() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"run.inspect","params":{"run_id":"run_missing"}}"#,
+        );
+        assert!(response.result.is_none());
+        assert_eq!(response.error.expect("error").code, -32602);
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn sanitizer_preserves_allowlisted_metadata_only() {
+        let sanitized = sanitize_ledger_payload(Some(json!({
+            "output_preview": "safe",
+            "bytes_read": 42,
+            "truncated": false,
+            "reason": "ok",
+            "content": "secret",
+            "full_content": "secret",
+            "file_content": "secret",
+            "raw_output": "secret"
+        })))
+        .expect("sanitized");
+        assert_eq!(sanitized["output_preview"], "safe");
+        assert_eq!(sanitized["bytes_read"], 42);
+        assert_eq!(sanitized["truncated"], false);
+        assert_eq!(sanitized["reason"], "ok");
+        assert!(sanitized.get("content").is_none());
+        assert!(sanitized.get("full_content").is_none());
+        assert!(sanitized.get("file_content").is_none());
+        assert!(sanitized.get("raw_output").is_none());
     }
 
     #[test]

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -103,6 +103,15 @@ impl TaskStore {
         Ok(None)
     }
 
+    pub fn get_task_by_run_id(&self, run_id: &str) -> Result<Option<TaskRecord>> {
+        for record in self.list_tasks()? {
+            if record.run_id == run_id {
+                return Ok(Some(record));
+            }
+        }
+        Ok(None)
+    }
+
     pub fn list_tasks(&self) -> Result<Vec<TaskRecord>> {
         let runs_dir = self.runs_dir();
         if !runs_dir.exists() {

--- a/docs/specifications/run-inspection-spec-v0.md
+++ b/docs/specifications/run-inspection-spec-v0.md
@@ -1,0 +1,32 @@
+# Brownie Run Inspection Protocol v0
+
+Phase 1.10 adds read-only inspection APIs for completed or in-progress task runs. These APIs are intended for the VSIX output channel and future progress UI, not for modifying runtime state.
+
+## JSON-RPC methods
+
+- `run.events` accepts `{ "run_id": string }` and returns `{ "run_id": string, "events": LedgerEventSummary[] }`.
+- `run.inspect` accepts `{ "run_id": string }` and returns `{ "run": RunInspectSummary }`.
+- `task.inspect` accepts `{ "task_id": string }` and returns `{ "task": TaskRecord, "run": RunInspectSummary }`.
+
+Unknown `run_id` or `task_id` values return JSON-RPC `-32602 invalid params` errors so clients can distinguish typos from empty runs.
+
+## Sanitized event summaries
+
+`LedgerEventSummary` contains event identity, task/run identity, kind, timestamp, and a sanitized optional payload. Inspection never returns full file content. Payloads are allowlisted to preview and metadata keys such as `output_preview`, `prompt_preview`, `content_preview`, `bytes_read`, `truncated`, `reason`, `model`, `message_count`, mode metadata, permission decisions, and tool IDs.
+
+Keys such as `content`, `full_content`, `file_content`, and `raw_output` are removed even if future ledger producers accidentally include them.
+
+## Run inspection summary
+
+`RunInspectSummary` reports:
+
+- `run_id`
+- optional `task_id`
+- optional task `status`
+- `event_count`
+- `has_tool_execution_completed`
+- `has_second_pass`
+- `final_response_preview`, preferring `SecondPassLlmResponseReceived.content_preview` over `LlmResponseReceived.content_preview`
+- a compact human-readable `timeline`
+
+The APIs do not call real LLM services, do not execute tools, and do not perform writes.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -205,3 +205,7 @@ For approved `workspace.read` intents with explicit `input.path`, the runtime re
 Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` after an approved `workspace.read` execution completes. The runtime re-reads the task ledger, materializes the tool execution summary into the next prompt, builds a second-pass prompt, and records `SecondPassPromptBuilt`, `SecondPassLlmRequestCreated`, and `SecondPassLlmResponseReceived` ledger events.
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
+
+## Phase 1.10 run inspection methods
+
+The runtime exposes read-only `run.events`, `run.inspect`, and `task.inspect` JSON-RPC methods. They return sanitized ledger previews and run summaries only; full file content and raw tool output are not returned through inspection responses. Unknown run or task IDs return `-32602 invalid params`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -140,3 +140,7 @@ For approved `workspace.read` intents with explicit `input.path`, the runtime re
 Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` after an approved `workspace.read` execution completes. The runtime re-reads the task ledger, materializes the tool execution summary into the next prompt, builds a second-pass prompt, and records `SecondPassPromptBuilt`, `SecondPassLlmRequestCreated`, and `SecondPassLlmResponseReceived` ledger events.
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
+
+## Phase 1.10 task inspection
+
+`task.inspect` is the preferred task-centric inspection method for VSIX clients. It returns the persisted `TaskRecord` plus the associated sanitized `RunInspectSummary` without changing task state or executing additional work.

--- a/docs/specifications/tool-feedback-loop-spec-v0.md
+++ b/docs/specifications/tool-feedback-loop-spec-v0.md
@@ -17,3 +17,7 @@ Phase 1.9 adds the first same-run tool feedback loop for `workspace.read`:
 ## Privacy and safety
 
 Full file content is not persisted in the ledger. Tool execution payloads are limited to `output_preview`, `bytes_read`, `truncated`, and failure/denial reasons. Phase 1.9 does not implement workspace writes, patch application, process execution, network access, service control, destructive actions, subtask execution, real LLM API calls, Mode Pack fetching, AgentModes YAML parsing, Qdrant, llama-server, or indexing.
+
+## Phase 1.10 inspection visibility
+
+The tool feedback loop can now be inspected through `run.events` and `run.inspect`. Tool execution payloads are exposed only as sanitized metadata/previews such as `tool_id`, `status`, `output_preview`, `bytes_read`, and `truncated`; full file content is excluded.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -38,6 +38,14 @@
         "title": "Brownie: Run Task"
       },
       {
+        "command": "brownie.taskInspect",
+        "title": "Brownie: Inspect Task"
+      },
+      {
+        "command": "brownie.runInspect",
+        "title": "Brownie: Inspect Run"
+      },
+      {
         "command": "brownie.permissionCheck",
         "title": "Brownie: Check Permission"
       },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -143,6 +143,55 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
 
+  const taskInspectCommand = vscode.commands.registerCommand('brownie.taskInspect', async () => {
+    const taskId = await vscode.window.showInputBox({
+      prompt: 'Task ID',
+      placeHolder: 'task_...',
+      ignoreFocusOut: true,
+    });
+
+    if (taskId === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.inspectTask(taskId.trim());
+      output.appendLine(`task.inspect: ${JSON.stringify(result, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie task inspect: ${result.task.status}, events=${result.run.event_count}, second_pass=${result.run.has_second_pass}`,
+      );
+    } catch (error) {
+      output.appendLine(`task.inspect failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie task inspect failed: ${formatError(error)}`);
+    }
+  });
+
+  const runInspectCommand = vscode.commands.registerCommand('brownie.runInspect', async () => {
+    const runId = await vscode.window.showInputBox({
+      prompt: 'Run ID',
+      placeHolder: 'run_...',
+      ignoreFocusOut: true,
+    });
+
+    if (runId === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.inspectRun(runId.trim());
+      output.appendLine(`run.inspect: ${JSON.stringify(result, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie run inspect: events=${result.event_count}, second_pass=${result.has_second_pass}`,
+      );
+    } catch (error) {
+      output.appendLine(`run.inspect failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie run inspect failed: ${formatError(error)}`);
+    }
+  });
+
+
   const toolPlanCommand = vscode.commands.registerCommand('brownie.toolPlan', async () => {
     const taskId = await vscode.window.showInputBox({
       prompt: 'Task ID',
@@ -242,7 +291,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand);
+  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -127,6 +127,40 @@ export interface TaskRecord {
   updated_at: string;
 }
 
+export interface LedgerEventSummary {
+  event_id: string;
+  task_id: string;
+  run_id: string;
+  kind: string;
+  timestamp: string;
+  payload?: unknown;
+}
+
+export interface RunInspectSummary {
+  run_id: string;
+  task_id?: string | null;
+  status?: TaskStatus | null;
+  event_count: number;
+  has_tool_execution_completed: boolean;
+  has_second_pass: boolean;
+  final_response_preview?: string | null;
+  timeline: string[];
+}
+
+export interface RunEventsResult {
+  run_id: string;
+  events: LedgerEventSummary[];
+}
+
+export interface RunInspectResult {
+  run: RunInspectSummary;
+}
+
+export interface TaskInspectResult {
+  task: TaskRecord;
+  run: RunInspectSummary;
+}
+
 export function isJsonRpcResponse(value: unknown): value is JsonRpcResponse<unknown> {
   if (!isRecord(value)) {
     return false;
@@ -271,6 +305,46 @@ export function isTaskRecord(value: unknown): value is TaskRecord {
     typeof value.created_at === 'string' &&
     typeof value.updated_at === 'string'
   );
+}
+
+export function isLedgerEventSummary(value: unknown): value is LedgerEventSummary {
+  return (
+    isRecord(value) &&
+    typeof value.event_id === 'string' &&
+    typeof value.task_id === 'string' &&
+    typeof value.run_id === 'string' &&
+    typeof value.kind === 'string' &&
+    typeof value.timestamp === 'string'
+  );
+}
+
+export function isRunEventsResult(value: unknown): value is RunEventsResult {
+  return isRecord(value) && typeof value.run_id === 'string' && Array.isArray(value.events) && value.events.every(isLedgerEventSummary);
+}
+
+export function isRunInspectSummary(value: unknown): value is RunInspectSummary {
+  return (
+    isRecord(value) &&
+    typeof value.run_id === 'string' &&
+    (value.task_id === undefined || value.task_id === null || typeof value.task_id === 'string') &&
+    (value.status === undefined || value.status === null || isTaskStatus(value.status)) &&
+    typeof value.event_count === 'number' &&
+    Number.isInteger(value.event_count) &&
+    value.event_count >= 0 &&
+    typeof value.has_tool_execution_completed === 'boolean' &&
+    typeof value.has_second_pass === 'boolean' &&
+    (value.final_response_preview === undefined || value.final_response_preview === null || typeof value.final_response_preview === 'string') &&
+    Array.isArray(value.timeline) &&
+    value.timeline.every((entry) => typeof entry === 'string')
+  );
+}
+
+export function isRunInspectResult(value: unknown): value is RunInspectResult {
+  return isRecord(value) && isRunInspectSummary(value.run);
+}
+
+export function isTaskInspectResult(value: unknown): value is TaskInspectResult {
+  return isRecord(value) && isTaskRecord(value.task) && isRunInspectSummary(value.run);
 }
 
 function isModePermissionsSummary(value: unknown): value is ModePermissionsSummary {

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isModeListResult, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -74,6 +74,36 @@ export class RuntimeClient {
 
     if (!isTaskRunResult(result)) {
       throw new RuntimeProtocolError('task.run returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async getRunEvents(runId: string): Promise<RunEventsResult> {
+    const result = await this.call<RunEventsResult>('run.events', { run_id: runId });
+
+    if (!isRunEventsResult(result)) {
+      throw new RuntimeProtocolError('run.events returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async inspectRun(runId: string): Promise<RunInspectSummary> {
+    const result = await this.call<RunInspectResult>('run.inspect', { run_id: runId });
+
+    if (!isRunInspectResult(result)) {
+      throw new RuntimeProtocolError('run.inspect returned an invalid result');
+    }
+
+    return result.run;
+  }
+
+  async inspectTask(taskId: string): Promise<TaskInspectResult> {
+    const result = await this.call<TaskInspectResult>('task.inspect', { task_id: taskId });
+
+    if (!isTaskInspectResult(result)) {
+      throw new RuntimeProtocolError('task.inspect returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isModeSummary, isPermissionCheckResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -92,6 +92,30 @@ describe('protocol validation', () => {
     expect(isToolPlanResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'Nope', allowed: true, reason: 'ok' }] })).toBe(false);
   });
 
+  it('accepts run inspection summaries and sanitized event payloads', () => {
+    const summary = {
+      run_id: 'run_1',
+      task_id: 'task_1',
+      status: 'Completed',
+      event_count: 3,
+      has_tool_execution_completed: true,
+      has_second_pass: true,
+      final_response_preview: 'done',
+      timeline: ['TaskStarted'],
+    };
+    expect(isRunInspectSummary(summary)).toBe(true);
+    expect(isRunInspectSummary({ ...summary, has_second_pass: 'true' })).toBe(false);
+    expect(isRunInspectSummary({ ...summary, event_count: -1 })).toBe(false);
+    expect(isLedgerEventSummary({
+      event_id: 'event_1',
+      task_id: 'task_1',
+      run_id: 'run_1',
+      kind: 'ToolExecutionCompleted',
+      timestamp: '2026-06-26T00:00:00Z',
+      payload: { output_preview: 'safe', bytes_read: 4, truncated: false },
+    })).toBe(true);
+  });
+
   it('validates tool.execute results', () => {
     expect(isToolExecuteResult({ tool_id: 'workspace.read', status: 'Completed', output: { content: 'ok' } })).toBe(true);
     expect(isToolExecuteResult({ tool_id: 'workspace.write', status: 'Denied', output: { reason: 'no' } })).toBe(true);
@@ -180,6 +204,36 @@ describe('RuntimeClient', () => {
     const client = new RuntimeClient(transport);
 
     await expect(client.runTask('task_missing')).rejects.toBeInstanceOf(RuntimeJsonRpcError);
+  });
+
+  it('creates a task.inspect request', async () => {
+    const result = {
+      task: { ...taskRecord, status: 'Completed' },
+      run: { run_id: 'run_1', task_id: 'task_1', status: 'Completed', event_count: 2, has_tool_execution_completed: true, has_second_pass: true, final_response_preview: 'done', timeline: ['TaskStarted'] },
+    };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.inspectTask('task_1')).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'task.inspect', params: { task_id: 'task_1' } }]);
+  });
+
+  it('creates a run.inspect request', async () => {
+    const run = { run_id: 'run_1', task_id: 'task_1', status: 'Completed', event_count: 2, has_tool_execution_completed: true, has_second_pass: false, final_response_preview: 'done', timeline: ['TaskStarted'] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { run } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.inspectRun('run_1')).resolves.toEqual(run);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'run.inspect', params: { run_id: 'run_1' } }]);
+  });
+
+  it('creates a run.events request', async () => {
+    const result = { run_id: 'run_1', events: [{ event_id: 'event_1', task_id: 'task_1', run_id: 'run_1', kind: 'TaskStarted', timestamp: '2026-06-26T00:00:00Z', payload: { reason: 'ok' } }] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.getRunEvents('run_1')).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'run.events', params: { run_id: 'run_1' } }]);
   });
 
   it('creates a tool.intent.parse request', async () => {


### PR DESCRIPTION
### Motivation
- Provide read-only runtime APIs so VSIX/clients can inspect task runs, ledger events, and run summaries without exposing full file content or changing runtime state.
- Expose compact, forward-compatible summaries (event counts, timeline, second-pass detection, final preview) for progress UI and debugging.
- Ensure inspection responses never return full content/raw outputs by applying a sanitization allowlist to ledger payloads.

### Description
- Added protocol types for inspection RPCs and summaries in `crates/brownie-protocol/src/lib.rs` including `RunEventsParams/Result`, `RunInspectParams/Result`, `TaskInspectParams/Result`, `RunInspectSummary`, and `LedgerEventSummary`.
- Implemented `run.events`, `run.inspect`, and `task.inspect` JSON-RPC handlers in `crates/brownie-runtime/src/lib.rs` with input validation and read-only semantics, plus helper functions `inspect_run`, `ledger_event_summary`, `sanitize_ledger_payload`, and `timeline_entry` to build sanitized summaries.
- Added a store helper `TaskStore::get_task_by_run_id` in `crates/brownie-store/src/lib.rs` and a `read_existing_run_events` flow to reliably find runs and fail unknown IDs with `-32602`.
- Updated VSIX protocol and client: new TypeScript interfaces and validators in `extensions/brownie-vsix/src/runtime/protocol.ts`, `RuntimeClient` methods `getRunEvents`, `inspectRun`, and `inspectTask` in `extensions/brownie-vsix/src/runtime/runtimeClient.ts`, and new commands `Brownie: Inspect Task` and `Brownie: Inspect Run` wired into `extensions/brownie-vsix/src/extension.ts` and `package.json`.
- Added documentation `docs/specifications/run-inspection-spec-v0.md` and updated runtime/task/tool spec files to describe the new read-only inspection APIs and sanitization rules.
- Added Rust unit tests for inspection behavior and sanitizer, and VSIX tests validating protocol shapes and client calls.

### Testing
- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all Rust checks and unit tests completed successfully.
- Ran VSIX checks and tests with `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and all TypeScript validation and unit tests passed.
- Manual smoke test executed: `task.start` -> `task.run` -> `task.inspect` -> `run.inspect` -> `run.events` succeeded and returned sanitized events; an unknown-run `run.inspect` returned `-32602` as expected; the workspace README full content was not exposed in inspection results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f8679ab788328a98e9f28815e2b5c)