### PR TITLE
Phase 2: Add LLM provider boundary, llm.status, and VSIX LLM Status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +30,7 @@ checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 name = "brownie-agent-loop"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "brownie-context",
  "brownie-llm",
 ]
@@ -59,6 +72,8 @@ version = "0.1.0"
 name = "brownie-llm"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "reqwest",
  "serde",
  "serde_json",
 ]
@@ -87,6 +102,7 @@ dependencies = [
  "brownie-agent-loop",
  "brownie-agentmodes",
  "brownie-context",
+ "brownie-llm",
  "brownie-protocol",
  "brownie-store",
  "brownie-tools",
@@ -126,10 +142,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+
+[[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "deranged"
@@ -138,13 +176,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -154,10 +203,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -172,9 +258,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
+ "futures-io",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -185,8 +301,215 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
+
+[[package]]
+name = "http"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itoa"
@@ -218,10 +541,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mio"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-conv"
@@ -236,10 +588,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -248,12 +615,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -267,9 +698,104 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -281,7 +807,42 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -289,6 +850,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "serde"
@@ -334,10 +901,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "socket2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -351,16 +964,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -394,10 +1047,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
@@ -405,9 +1201,33 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -421,6 +1241,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -456,10 +1286,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -468,6 +1345,250 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crates/brownie-agent-loop/Cargo.toml
+++ b/crates/brownie-agent-loop/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 brownie-context = { path = "../brownie-context" }
 brownie-llm = { path = "../brownie-llm" }
 

--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -1,9 +1,7 @@
 //! Agent loop state-machine crate.
 
 use brownie_context::{PromptBuildInput, PromptBuilder, PromptRole, PromptView};
-use brownie_llm::{FakeLlm, LlmMessage, LlmRequest, LlmResponse};
-
-pub const FAKE_LLM_MODEL: &str = "brownie-fake-llm";
+use brownie_llm::{FakeLlmProvider, LlmMessage, LlmProvider, LlmRequest, LlmResponse};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentLoopState {
@@ -64,36 +62,54 @@ impl AgentLoop {
         }
     }
 
-    pub fn run_with_fake_llm(prompt_input: PromptBuildInput) -> AgentLoopRunOutput {
-        let (task_id, prompt, llm_request, llm_response) = run_fake_llm(prompt_input);
-        AgentLoopRunOutput {
+    pub fn run_with_llm(
+        prompt_input: PromptBuildInput,
+        provider: &dyn LlmProvider,
+    ) -> anyhow::Result<AgentLoopRunOutput> {
+        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider)?;
+        Ok(AgentLoopRunOutput {
             final_state: AgentLoopState::Completed,
             prompt,
             llm_request,
-            completion_summary: format!("Fake LLM agent loop completed for {task_id}"),
+            completion_summary: format!("LLM agent loop completed for {task_id}"),
             llm_response,
-        }
+        })
+    }
+
+    pub fn run_second_pass_with_llm(
+        prompt_input: PromptBuildInput,
+        provider: &dyn LlmProvider,
+    ) -> anyhow::Result<AgentLoopSecondPassOutput> {
+        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider)?;
+        Ok(AgentLoopSecondPassOutput {
+            final_state: AgentLoopState::Completed,
+            prompt,
+            llm_request,
+            completion_summary: format!("Second-pass LLM agent loop completed for {task_id}"),
+            llm_response,
+        })
+    }
+
+    pub fn run_with_fake_llm(prompt_input: PromptBuildInput) -> AgentLoopRunOutput {
+        Self::run_with_llm(prompt_input, &FakeLlmProvider).expect("fake provider should not fail")
     }
 
     pub fn run_second_pass_with_fake_llm(
         prompt_input: PromptBuildInput,
     ) -> AgentLoopSecondPassOutput {
-        let (task_id, prompt, llm_request, llm_response) = run_fake_llm(prompt_input);
-        AgentLoopSecondPassOutput {
-            final_state: AgentLoopState::Completed,
-            prompt,
-            llm_request,
-            completion_summary: format!("Second-pass Fake LLM agent loop completed for {task_id}"),
-            llm_response,
-        }
+        Self::run_second_pass_with_llm(prompt_input, &FakeLlmProvider)
+            .expect("fake provider should not fail")
     }
 }
 
-fn run_fake_llm(prompt_input: PromptBuildInput) -> (String, PromptView, LlmRequest, LlmResponse) {
+fn run_llm(
+    prompt_input: PromptBuildInput,
+    provider: &dyn LlmProvider,
+) -> anyhow::Result<(String, PromptView, LlmRequest, LlmResponse)> {
     let task_id = prompt_input.task_id.clone();
     let prompt = PromptBuilder::build(prompt_input);
     let llm_request = LlmRequest {
-        model: FAKE_LLM_MODEL.to_string(),
+        model: provider.status().model,
         messages: prompt
             .messages
             .iter()
@@ -103,8 +119,8 @@ fn run_fake_llm(prompt_input: PromptBuildInput) -> (String, PromptView, LlmReque
             })
             .collect(),
     };
-    let llm_response = FakeLlm::complete(&llm_request);
-    (task_id, prompt, llm_request, llm_response)
+    let llm_response = provider.complete(&llm_request)?;
+    Ok((task_id, prompt, llm_request, llm_response))
 }
 
 fn prompt_role_to_llm_role(role: &PromptRole) -> &'static str {
@@ -119,6 +135,7 @@ fn prompt_role_to_llm_role(role: &PromptRole) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use brownie_llm::FAKE_LLM_MODEL;
 
     #[test]
     fn run_noop_completes() {

--- a/crates/brownie-llm/Cargo.toml
+++ b/crates/brownie-llm/Cargo.toml
@@ -7,8 +7,11 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -1,8 +1,12 @@
 //! LLM client abstraction crate.
 
+use std::{env, time::Duration};
+
+use anyhow::{anyhow, Context};
 use serde::{Deserialize, Serialize};
 
 pub const OPENAI_COMPATIBLE_API_VERSION: &str = "v1";
+pub const FAKE_LLM_MODEL: &str = "brownie-fake-llm";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmRequest {
@@ -19,6 +23,39 @@ pub struct LlmMessage {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmResponse {
     pub content: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum LlmProviderKind {
+    Fake,
+    OpenAiCompatible,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmProviderStatus {
+    pub provider: LlmProviderKind,
+    pub enabled: bool,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub reason: Option<String>,
+}
+
+pub trait LlmProvider {
+    fn status(&self) -> LlmProviderStatus;
+    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenAiCompatibleConfig {
+    pub base_url: String,
+    pub model: String,
+    pub api_key_env: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenAiCompatibleConfigFromEnv {
+    Enabled(OpenAiCompatibleConfig),
+    Disabled(LlmProviderStatus),
 }
 
 pub struct FakeLlm;
@@ -81,6 +118,164 @@ impl FakeLlm {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FakeLlmProvider;
+
+impl LlmProvider for FakeLlmProvider {
+    fn status(&self) -> LlmProviderStatus {
+        LlmProviderStatus {
+            provider: LlmProviderKind::Fake,
+            enabled: true,
+            model: FAKE_LLM_MODEL.to_string(),
+            base_url: None,
+            reason: None,
+        }
+    }
+
+    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse> {
+        Ok(FakeLlm::complete(request))
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatibleLlmProvider {
+    config: OpenAiCompatibleConfig,
+    api_key: String,
+    timeout: Duration,
+}
+
+impl OpenAiCompatibleLlmProvider {
+    pub fn new(config: OpenAiCompatibleConfig, api_key: String) -> Self {
+        Self {
+            config,
+            api_key,
+            timeout: Duration::from_secs(30),
+        }
+    }
+
+    pub fn from_env() -> OpenAiCompatibleConfigFromEnv {
+        let base_url = env::var("BROWNIE_LLM_BASE_URL")
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+        let model = env::var("BROWNIE_LLM_MODEL")
+            .ok()
+            .filter(|v| !v.trim().is_empty());
+        let api_key_env = env::var("BROWNIE_LLM_API_KEY_ENV")
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .unwrap_or_else(|| "BROWNIE_LLM_API_KEY".to_string());
+        let api_key_present = env::var(&api_key_env)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .is_some();
+
+        let mut missing = Vec::new();
+        if base_url.is_none() {
+            missing.push("BROWNIE_LLM_BASE_URL");
+        }
+        if model.is_none() {
+            missing.push("BROWNIE_LLM_MODEL");
+        }
+        if !api_key_present {
+            missing.push(api_key_env.as_str());
+        }
+
+        if !missing.is_empty() {
+            return OpenAiCompatibleConfigFromEnv::Disabled(LlmProviderStatus {
+                provider: LlmProviderKind::OpenAiCompatible,
+                enabled: false,
+                model: model.unwrap_or_default(),
+                base_url,
+                reason: Some(format!("missing config: {}", missing.join(", "))),
+            });
+        }
+        OpenAiCompatibleConfigFromEnv::Enabled(OpenAiCompatibleConfig {
+            base_url: base_url.expect("checked"),
+            model: model.expect("checked"),
+            api_key_env,
+        })
+    }
+}
+
+impl LlmProvider for OpenAiCompatibleLlmProvider {
+    fn status(&self) -> LlmProviderStatus {
+        LlmProviderStatus {
+            provider: LlmProviderKind::OpenAiCompatible,
+            enabled: true,
+            model: self.config.model.clone(),
+            base_url: Some(self.config.base_url.clone()),
+            reason: None,
+        }
+    }
+
+    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse> {
+        let url = format!(
+            "{}/chat/completions",
+            self.config.base_url.trim_end_matches('/')
+        );
+        let client = reqwest::blocking::Client::builder()
+            .timeout(self.timeout)
+            .build()
+            .context("failed to build OpenAI-compatible HTTP client")?;
+        let response: ChatCompletionResponse = client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(&serde_json::json!({ "model": request.model, "messages": request.messages }))
+            .send()
+            .map_err(|e| {
+                anyhow!(
+                    "OpenAI-compatible request failed: {}",
+                    redact_secret(&e.to_string())
+                )
+            })?
+            .error_for_status()
+            .map_err(|e| {
+                anyhow!(
+                    "OpenAI-compatible response failed: {}",
+                    redact_secret(&e.to_string())
+                )
+            })?
+            .json()
+            .context("failed to parse OpenAI-compatible response")?;
+        response
+            .choices
+            .into_iter()
+            .next()
+            .map(|choice| LlmResponse {
+                content: choice.message.content,
+            })
+            .ok_or_else(|| anyhow!("OpenAI-compatible response contained no choices"))
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ChatCompletionResponse {
+    choices: Vec<ChatChoice>,
+}
+#[derive(Debug, Deserialize)]
+struct ChatChoice {
+    message: ChatMessage,
+}
+#[derive(Debug, Deserialize)]
+struct ChatMessage {
+    content: String,
+}
+
+pub fn redact_secret(value: &str) -> String {
+    let mut redacted = value.replace("Authorization", "[REDACTED_HEADER]");
+    for marker in ["Bearer ", "bearer "] {
+        while let Some(start) = redacted.find(marker) {
+            let token_start = start + marker.len();
+            let token_end = redacted[token_start..]
+                .find(|c: char| c.is_whitespace() || c == '\'' || c == '"' || c == ',')
+                .map(|i| token_start + i)
+                .unwrap_or(redacted.len());
+            redacted.replace_range(start..token_end, "[REDACTED_BEARER]");
+        }
+    }
+    redacted
+}
+
 fn contains_any(haystack: &str, needles: &[&str]) -> bool {
     needles.iter().any(|needle| haystack.contains(needle))
 }
@@ -89,10 +284,37 @@ fn contains_any(haystack: &str, needles: &[&str]) -> bool {
 mod tests {
     use super::*;
 
+    fn clear_env() {
+        for key in [
+            "BROWNIE_LLM_PROVIDER",
+            "BROWNIE_LLM_BASE_URL",
+            "BROWNIE_LLM_MODEL",
+            "BROWNIE_LLM_API_KEY_ENV",
+            "BROWNIE_LLM_API_KEY",
+        ] {
+            env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn fake_provider_returns_status_and_deterministic_response() {
+        let provider = FakeLlmProvider;
+        assert_eq!(provider.status().provider, LlmProviderKind::Fake);
+        let request = LlmRequest {
+            model: FAKE_LLM_MODEL.into(),
+            messages: vec![LlmMessage {
+                role: "user".into(),
+                content: "user".into(),
+            }],
+        };
+        let content = provider.complete(&request).unwrap().content;
+        assert!(content.starts_with("Fake LLM completed request with 1 messages."));
+    }
+
     #[test]
     fn fake_llm_returns_deterministic_response() {
         let request = LlmRequest {
-            model: "brownie-fake-llm".into(),
+            model: FAKE_LLM_MODEL.into(),
             messages: vec![
                 LlmMessage {
                     role: "system".into(),
@@ -104,17 +326,17 @@ mod tests {
                 },
             ],
         };
-
         let content = FakeLlm::complete(&request).content;
         assert!(content.starts_with("Fake LLM completed request with 2 messages."));
         assert!(content.contains("```brownie-tool-intent"));
         assert!(content.contains("workspace.read"));
         assert!(content.contains(r#""path": "README.md""#));
     }
+
     #[test]
     fn fake_llm_second_pass_returns_final_response_without_tool_intent() {
         let request = LlmRequest {
-            model: "brownie-fake-llm".into(),
+            model: FAKE_LLM_MODEL.into(),
             messages: vec![LlmMessage {
                 role: "user".into(),
                 content:
@@ -122,12 +344,33 @@ mod tests {
                         .into(),
             }],
         };
-
         let content = FakeLlm::complete(&request).content;
         assert_eq!(
             content,
             "Fake LLM final response after reading workspace context."
         );
         assert!(!content.contains("brownie-tool-intent"));
+    }
+
+    #[test]
+    fn openai_config_disabled_when_required_env_missing() {
+        clear_env();
+        env::set_var("BROWNIE_LLM_PROVIDER", "openai-compatible");
+        match OpenAiCompatibleLlmProvider::from_env() {
+            OpenAiCompatibleConfigFromEnv::Disabled(status) => {
+                assert_eq!(status.provider, LlmProviderKind::OpenAiCompatible);
+                assert!(!status.enabled);
+                assert!(status.reason.unwrap().contains("missing config"));
+            }
+            OpenAiCompatibleConfigFromEnv::Enabled(_) => panic!("expected disabled config"),
+        }
+        clear_env();
+    }
+
+    #[test]
+    fn redacts_bearer_tokens() {
+        let redacted = redact_secret("Authorization: Bearer secret-token-123 failed");
+        assert!(!redacted.contains("secret-token-123"));
+        assert!(redacted.contains("[REDACTED"));
     }
 }

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -29,6 +29,15 @@ pub struct JsonRpcError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmStatusResult {
+    pub provider: String,
+    pub enabled: bool,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeStatus {
     pub name: String,
     pub version: String,

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 brownie-agentmodes = { path = "../brownie-agentmodes" }
 brownie-agent-loop = { path = "../brownie-agent-loop" }
 brownie-context = { path = "../brownie-context" }
+brownie-llm = { path = "../brownie-llm" }
 brownie-protocol = { path = "../brownie-protocol" }
 brownie-store = { path = "../brownie-store" }
 brownie-tools = { path = "../brownie-tools" }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -5,9 +5,13 @@ use brownie_agentmodes::{
     BuiltinModeRegistry, CompiledModePolicy, RuntimeAction, RuntimePermissionGate,
 };
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
+use brownie_llm::{
+    FakeLlmProvider, LlmProvider, LlmProviderKind, LlmProviderStatus,
+    OpenAiCompatibleConfigFromEnv, OpenAiCompatibleLlmProvider,
+};
 use brownie_protocol::{
-    JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary, ModeGetParams,
-    ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
+    JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary, LlmStatusResult,
+    ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
     PermissionCheckResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
     RunInspectSummary, RuntimeActionName, RuntimeState, RuntimeStatus, TaskGetParams,
     TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult,
@@ -26,6 +30,7 @@ use serde_json::{json, Value};
 
 const JSONRPC_VERSION: &str = "2.0";
 const METHOD_RUNTIME_STATUS: &str = "runtime.status";
+const METHOD_LLM_STATUS: &str = "llm.status";
 const METHOD_TASK_START: &str = "task.start";
 const METHOD_TASK_GET: &str = "task.get";
 const METHOD_TASK_RUN: &str = "task.run";
@@ -70,6 +75,10 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
 
     match request.method.as_str() {
         METHOD_RUNTIME_STATUS => result_response(request.id, json!(runtime_status())),
+        METHOD_LLM_STATUS => result_response(
+            request.id,
+            json!(llm_status_result(llm_provider_from_env().status())),
+        ),
         METHOD_TASK_START => handle_task_start(request.id, request.params),
         METHOD_TASK_GET => handle_task_get(request.id, request.params),
         METHOD_TASK_RUN => handle_task_run(request.id, request.params),
@@ -85,6 +94,68 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_RUN_EVENTS => handle_run_events(request.id, request.params),
         METHOD_RUN_INSPECT => handle_run_inspect(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
+    }
+}
+
+fn llm_status_result(status: LlmProviderStatus) -> LlmStatusResult {
+    LlmStatusResult {
+        provider: provider_kind_name(&status.provider).to_string(),
+        enabled: status.enabled,
+        model: status.model,
+        base_url: status.base_url,
+        reason: status.reason,
+    }
+}
+
+fn provider_kind_name(kind: &LlmProviderKind) -> &'static str {
+    match kind {
+        LlmProviderKind::Fake => "Fake",
+        LlmProviderKind::OpenAiCompatible => "OpenAiCompatible",
+    }
+}
+
+pub fn llm_provider_from_env() -> Box<dyn LlmProvider> {
+    match std::env::var("BROWNIE_LLM_PROVIDER").ok().as_deref() {
+        Some("openai-compatible") => match OpenAiCompatibleLlmProvider::from_env() {
+            OpenAiCompatibleConfigFromEnv::Enabled(config) => {
+                let api_key = std::env::var(&config.api_key_env).unwrap_or_default();
+                Box::new(OpenAiCompatibleLlmProvider::new(config, api_key))
+            }
+            OpenAiCompatibleConfigFromEnv::Disabled(status) => {
+                Box::new(DisabledLlmProvider { status })
+            }
+        },
+        _ => Box::new(FakeLlmProvider),
+    }
+}
+
+fn llm_provider_from_env_for_task_run() -> Box<dyn LlmProvider> {
+    let provider = llm_provider_from_env();
+    if provider.status().enabled {
+        provider
+    } else {
+        Box::new(FakeLlmProvider)
+    }
+}
+
+struct DisabledLlmProvider {
+    status: LlmProviderStatus,
+}
+
+impl LlmProvider for DisabledLlmProvider {
+    fn status(&self) -> LlmProviderStatus {
+        self.status.clone()
+    }
+
+    fn complete(
+        &self,
+        _request: &brownie_llm::LlmRequest,
+    ) -> anyhow::Result<brownie_llm::LlmResponse> {
+        anyhow::bail!(self
+            .status
+            .reason
+            .clone()
+            .unwrap_or_else(|| "LLM provider disabled".to_string()))
     }
 }
 
@@ -202,7 +273,18 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         task: running.clone(),
         ledger_events,
     });
-    let result = AgentLoop::run_with_fake_llm(prompt_input);
+    let provider = llm_provider_from_env_for_task_run();
+    let provider_status = provider.status();
+    let result = match AgentLoop::run_with_llm(prompt_input, provider.as_ref()) {
+        Ok(result) => result,
+        Err(error) => {
+            return error_response(
+                id,
+                -32603,
+                &format!("internal error: LLM request failed: {error}"),
+            )
+        }
+    };
 
     if let Err(error) = store.tasks().append_task_event_with_payload(
         &running,
@@ -218,6 +300,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         &running,
         LedgerEventKind::LlmRequestCreated,
         Some(json!({
+            "provider": provider_kind_name(&provider_status.provider),
             "model": result.llm_request.model.clone(),
             "message_count": result.llm_request.messages.len(),
         })),
@@ -242,6 +325,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         &running,
         LedgerEventKind::LlmResponseReceived,
         Some(json!({
+            "provider": provider_kind_name(&provider_status.provider),
             "content_preview": preview(&result.llm_response.content),
         })),
     ) {
@@ -260,7 +344,19 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             task: running.clone(),
             ledger_events: second_pass_events,
         });
-        let second_pass = AgentLoop::run_second_pass_with_fake_llm(second_pass_prompt_input);
+        let second_pass = match AgentLoop::run_second_pass_with_llm(
+            second_pass_prompt_input,
+            provider.as_ref(),
+        ) {
+            Ok(result) => result,
+            Err(error) => {
+                return error_response(
+                    id,
+                    -32603,
+                    &format!("internal error: LLM request failed: {error}"),
+                )
+            }
+        };
         if let Err(error) = store.tasks().append_task_event_with_payload(
             &running,
             LedgerEventKind::SecondPassPromptBuilt,
@@ -275,6 +371,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             &running,
             LedgerEventKind::SecondPassLlmRequestCreated,
             Some(json!({
+                "provider": provider_kind_name(&provider_status.provider),
                 "model": second_pass.llm_request.model.clone(),
                 "message_count": second_pass.llm_request.messages.len(),
             })),
@@ -285,6 +382,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             &running,
             LedgerEventKind::SecondPassLlmResponseReceived,
             Some(json!({
+                "provider": provider_kind_name(&provider_status.provider),
                 "content_preview": preview(&second_pass.llm_response.content),
             })),
         ) {
@@ -631,6 +729,7 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "content_preview",
         "bytes_read",
         "truncated",
+        "provider",
         "model",
         "message_count",
         "mode_id",
@@ -661,6 +760,7 @@ fn timeline_entry(event: &LedgerEvent) -> String {
             "bytes_read",
             "truncated",
             "reason",
+            "provider",
             "model",
             "message_count",
         ] {
@@ -1418,6 +1518,41 @@ mod tests {
         );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn llm_status_returns_fake_when_env_unset() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::remove_var("BROWNIE_LLM_PROVIDER");
+        std::env::remove_var("BROWNIE_LLM_BASE_URL");
+        std::env::remove_var("BROWNIE_LLM_MODEL");
+        std::env::remove_var("BROWNIE_LLM_API_KEY_ENV");
+        std::env::remove_var("BROWNIE_LLM_API_KEY");
+        let response =
+            handle_jsonrpc_input_line(r#"{"jsonrpc":"2.0","id":1,"method":"llm.status"}"#).unwrap();
+        assert!(response.contains(r#""provider":"Fake""#));
+        assert!(response.contains(r#""enabled":true"#));
+        assert!(response.contains(r#""model":"brownie-fake-llm""#));
+    }
+
+    #[test]
+    fn llm_status_does_not_expose_api_key_for_incomplete_config() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::set_var("BROWNIE_LLM_PROVIDER", "openai-compatible");
+        std::env::remove_var("BROWNIE_LLM_BASE_URL");
+        std::env::set_var("BROWNIE_LLM_MODEL", "qwen35");
+        std::env::set_var("BROWNIE_LLM_API_KEY_ENV", "BROWNIE_LLM_API_KEY");
+        std::env::set_var("BROWNIE_LLM_API_KEY", "super-secret-key");
+        let response =
+            handle_jsonrpc_input_line(r#"{"jsonrpc":"2.0","id":1,"method":"llm.status"}"#).unwrap();
+        assert!(response.contains(r#""provider":"OpenAiCompatible""#));
+        assert!(response.contains(r#""enabled":false"#));
+        assert!(response.contains("missing config"));
+        assert!(!response.contains("super-secret-key"));
+        std::env::remove_var("BROWNIE_LLM_PROVIDER");
+        std::env::remove_var("BROWNIE_LLM_MODEL");
+        std::env::remove_var("BROWNIE_LLM_API_KEY_ENV");
+        std::env::remove_var("BROWNIE_LLM_API_KEY");
     }
 
     #[test]

--- a/docs/specifications/agent-loop-spec-v0.md
+++ b/docs/specifications/agent-loop-spec-v0.md
@@ -104,3 +104,8 @@ Phase 1.2 adds `AgentLoop::run_with_fake_llm` as the minimal executable prompt p
 This path is local-only. It does not call a real LLM API, open an OpenAI-compatible HTTP client, parse AgentModes, execute tools, fetch or activate Mode Packs, use Qdrant, use llama-server, or run an indexer.
 
 The runtime records prompt and fake-LLM lifecycle metadata in the run ledger around this path. Full prompt text is not persisted by default; the ledger stores counts and short previews only.
+
+
+## Phase 2.0 LLM provider boundary
+
+Phase 2.0 routes LLM calls through a provider abstraction. The Fake provider remains the default and no external LLM API is contacted unless `BROWNIE_LLM_PROVIDER=openai-compatible` and the required OpenAI-compatible environment configuration are present. The `llm.status` JSON-RPC method reports provider, enabled state, model, base URL, and a non-secret reason; it never returns API keys or Authorization headers. Task ledger LLM request events store only provider/model/message_count metadata, and response events store only provider/content_preview. Streaming and additional tool execution capabilities remain out of scope. See `docs/specifications/llm-provider-spec-v0.md`.

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -1,0 +1,27 @@
+# Brownie LLM Provider Spec v0
+
+Phase 2.0 introduces a configurable LLM provider boundary for connecting real LLM adapters safely while preserving the deterministic Fake provider as the default.
+
+## Provider selection
+
+- `BROWNIE_LLM_PROVIDER` unset or `fake` selects the Fake provider.
+- `BROWNIE_LLM_PROVIDER=openai-compatible` opts in to the OpenAI-compatible provider.
+- OpenAI-compatible configuration is read from environment variables only:
+  - `BROWNIE_LLM_BASE_URL`
+  - `BROWNIE_LLM_MODEL`
+  - `BROWNIE_LLM_API_KEY_ENV` (defaults to `BROWNIE_LLM_API_KEY`)
+  - the API key variable named by `BROWNIE_LLM_API_KEY_ENV`
+- If required OpenAI-compatible configuration is missing, `llm.status` reports `enabled=false` with a missing-config reason, and `task.run` falls back to Fake for Phase 2.0 stability.
+
+## Safety rules
+
+- No real LLM API is contacted without explicit OpenAI-compatible configuration.
+- API keys and Authorization/Bearer values are never returned by `llm.status`, ledger inspection, or error messages.
+- Phase 2.0 supports non-streaming chat completions only.
+- Phase 2.0 does not add tool execution capability.
+
+## Ledger metadata
+
+LLM request events store only safe metadata: `provider`, `model`, and `message_count`.
+LLM response events store only `provider` and `content_preview`.
+Full prompts, full responses, API keys, and Authorization headers are not persisted for inspection.

--- a/docs/specifications/run-inspection-spec-v0.md
+++ b/docs/specifications/run-inspection-spec-v0.md
@@ -12,7 +12,7 @@ Unknown `run_id` or `task_id` values return JSON-RPC `-32602 invalid params` err
 
 ## Sanitized event summaries
 
-`LedgerEventSummary` contains event identity, task/run identity, kind, timestamp, and a sanitized optional payload. Inspection never returns full file content. Payloads are allowlisted to preview and metadata keys such as `output_preview`, `prompt_preview`, `content_preview`, `bytes_read`, `truncated`, `reason`, `model`, `message_count`, mode metadata, permission decisions, and tool IDs.
+`LedgerEventSummary` contains event identity, task/run identity, kind, timestamp, and a sanitized optional payload. Inspection never returns full file content. Payloads are allowlisted to preview and metadata keys such as `output_preview`, `prompt_preview`, `content_preview`, `bytes_read`, `truncated`, `reason`, `model`, `message_count`, `provider`, mode metadata, permission decisions, and tool IDs.
 
 Keys such as `content`, `full_content`, `file_content`, and `raw_output` are removed even if future ledger producers accidentally include them.
 

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -209,3 +209,8 @@ The second pass runs only when at least one `ToolExecutionCompleted` event exist
 ## Phase 1.10 run inspection methods
 
 The runtime exposes read-only `run.events`, `run.inspect`, and `task.inspect` JSON-RPC methods. They return sanitized ledger previews and run summaries only; full file content and raw tool output are not returned through inspection responses. Unknown run or task IDs return `-32602 invalid params`.
+
+
+## Phase 2.0 LLM provider boundary
+
+Phase 2.0 routes LLM calls through a provider abstraction. The Fake provider remains the default and no external LLM API is contacted unless `BROWNIE_LLM_PROVIDER=openai-compatible` and the required OpenAI-compatible environment configuration are present. The `llm.status` JSON-RPC method reports provider, enabled state, model, base URL, and a non-secret reason; it never returns API keys or Authorization headers. Task ledger LLM request events store only provider/model/message_count metadata, and response events store only provider/content_preview. Streaming and additional tool execution capabilities remain out of scope. See `docs/specifications/llm-provider-spec-v0.md`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -95,7 +95,7 @@ TaskFailed
 TaskCancelled
 ```
 
-`LedgerEvent` may include an optional `payload` object. Prompt and fake-LLM events store metadata such as `message_count`, `model`, `prompt_preview`, and `content_preview`. Full prompt text is not persisted by default.
+`LedgerEvent` may include an optional `payload` object. Prompt and LLM events store safe metadata such as `provider`, `message_count`, `model`, `prompt_preview`, and `content_preview`. Full prompt text is not persisted by default.
 
 Phase 1.2 still does not call a real LLM API, implement an OpenAI-compatible HTTP client, execute tools, parse AgentModes, fetch or activate Mode Packs, use Qdrant, use llama-server, or run an indexer.
 
@@ -144,3 +144,8 @@ The second pass runs only when at least one `ToolExecutionCompleted` event exist
 ## Phase 1.10 task inspection
 
 `task.inspect` is the preferred task-centric inspection method for VSIX clients. It returns the persisted `TaskRecord` plus the associated sanitized `RunInspectSummary` without changing task state or executing additional work.
+
+
+## Phase 2.0 LLM provider boundary
+
+Phase 2.0 routes LLM calls through a provider abstraction. The Fake provider remains the default and no external LLM API is contacted unless `BROWNIE_LLM_PROVIDER=openai-compatible` and the required OpenAI-compatible environment configuration are present. The `llm.status` JSON-RPC method reports provider, enabled state, model, base URL, and a non-secret reason; it never returns API keys or Authorization headers. Task ledger LLM request events store only provider/model/message_count metadata, and response events store only provider/content_preview. Streaming and additional tool execution capabilities remain out of scope. See `docs/specifications/llm-provider-spec-v0.md`.

--- a/docs/specifications/tool-feedback-loop-spec-v0.md
+++ b/docs/specifications/tool-feedback-loop-spec-v0.md
@@ -21,3 +21,8 @@ Full file content is not persisted in the ledger. Tool execution payloads are li
 ## Phase 1.10 inspection visibility
 
 The tool feedback loop can now be inspected through `run.events` and `run.inspect`. Tool execution payloads are exposed only as sanitized metadata/previews such as `tool_id`, `status`, `output_preview`, `bytes_read`, and `truncated`; full file content is excluded.
+
+
+## Phase 2.0 LLM provider boundary
+
+Phase 2.0 routes LLM calls through a provider abstraction. The Fake provider remains the default and no external LLM API is contacted unless `BROWNIE_LLM_PROVIDER=openai-compatible` and the required OpenAI-compatible environment configuration are present. The `llm.status` JSON-RPC method reports provider, enabled state, model, base URL, and a non-secret reason; it never returns API keys or Authorization headers. Task ledger LLM request events store only provider/model/message_count metadata, and response events store only provider/content_preview. Streaming and additional tool execution capabilities remain out of scope. See `docs/specifications/llm-provider-spec-v0.md`.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -22,6 +22,10 @@
         "title": "Brownie: Runtime Status"
       },
       {
+        "command": "brownie.llmStatus",
+        "title": "Brownie: LLM Status"
+      },
+      {
         "command": "brownie.modeList",
         "title": "Brownie: List Modes"
       },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -20,6 +20,20 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const llmStatusCommand = vscode.commands.registerCommand('brownie.llmStatus', async () => {
+    try {
+      const status = await runtimeClient.llmStatus();
+      output.appendLine(`llm.status: ${JSON.stringify(status, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie LLM: ${status.provider} ${status.model} enabled=${String(status.enabled)}`,
+      );
+    } catch (error) {
+      output.appendLine(`llm.status failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie LLM status failed: ${formatError(error)}`);
+    }
+  });
+
   const modeListCommand = vscode.commands.registerCommand('brownie.modeList', async () => {
     try {
       const modes = await runtimeClient.listModes();
@@ -291,7 +305,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -23,6 +23,14 @@ export interface RuntimeStatusResult {
   status: string;
 }
 
+export interface LlmStatusResult {
+  provider: string;
+  enabled: boolean;
+  model: string;
+  base_url?: string | null;
+  reason?: string | null;
+}
+
 export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
 export type RuntimeActionName =
@@ -189,6 +197,17 @@ export function isRuntimeStatusResult(value: unknown): value is RuntimeStatusRes
     typeof value.name === 'string' &&
     typeof value.version === 'string' &&
     typeof value.status === 'string'
+  );
+}
+
+export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
+  return (
+    isRecord(value) &&
+    typeof value.provider === 'string' &&
+    typeof value.enabled === 'boolean' &&
+    typeof value.model === 'string' &&
+    (value.base_url === undefined || value.base_url === null || typeof value.base_url === 'string') &&
+    (value.reason === undefined || value.reason === null || typeof value.reason === 'string')
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmStatusResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmStatusResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -18,6 +18,16 @@ export class RuntimeClient {
 
     if (!isRuntimeStatusResult(result)) {
       throw new RuntimeProtocolError('runtime.status returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async llmStatus(): Promise<LlmStatusResult> {
+    const result = await this.call<LlmStatusResult>('llm.status');
+
+    if (!isLlmStatusResult(result)) {
+      throw new RuntimeProtocolError('llm.status returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -60,6 +60,12 @@ describe('protocol validation', () => {
 
   it('accepts runtime.status results with string fields', () => {
     expect(isRuntimeStatusResult({ name: 'brownie-runtime', version: '0.1.0', status: 'Ready' })).toBe(true);
+  });
+
+  it('accepts valid llm.status results and rejects missing required fields', () => {
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Fake', model: 'brownie-fake-llm' })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true })).toBe(false);
   });
 
   it('accepts valid permission.check results', () => {
@@ -138,6 +144,22 @@ describe('RuntimeClient', () => {
       status: 'Ready',
     });
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'runtime.status' }]);
+  });
+
+  it('creates an llm.status request', async () => {
+    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.llmStatus()).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'llm.status' }]);
+  });
+
+  it('rejects invalid llm.status results', async () => {
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { provider: 'Fake', enabled: true } });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.llmStatus()).rejects.toThrow('llm.status returned an invalid result');
   });
 
   it('creates a mode.list request', async () => {


### PR DESCRIPTION
### Motivation
- Introduce a safe provider boundary so real LLM adapters can be opt‑in while keeping the deterministic Fake LLM as the default. 
- Record only non-secret LLM metadata in the ledger and ensure API keys / Authorization headers are never exposed.
- Surface provider status to the VSIX client via a new `llm.status` JSON‑RPC method and add a corresponding VSIX command.

### Description
- Added a provider abstraction in `crates/brownie-llm` including `LlmProviderKind`, `LlmProviderStatus`, the `LlmProvider` trait, a `FakeLlmProvider`, and an `OpenAiCompatibleLlmProvider` with `OpenAiCompatibleConfig` and env helpers. 
- Implemented secret redaction helper `redact_secret` and safe error handling for OpenAI‑compatible adapter failures (non‑streaming chat completions only). 
- Routed `AgentLoop` through the provider abstraction (`AgentLoop::run_with_llm` / `run_second_pass_with_llm`) while keeping Fake provider helpers for tests in `crates/brownie-agent-loop`. 
- Added provider selection helpers in the runtime and a disabled‑provider fallback to Fake for Phase 2 (`llm_provider_from_env` / `llm_provider_from_env_for_task_run`) in `crates/brownie-runtime`. 
- Added `llm.status` JSON‑RPC method and protocol type `LlmStatusResult` in `crates/brownie-protocol`, and extended ledger event payloads to include safe provider metadata (`provider`, `model`, `message_count`, `content_preview`). 
- Wired VSIX: added `LlmStatusResult` type/validator, `RuntimeClient.llmStatus()` method, `brownie.llmStatus` command, and UI command handler to show status in the output channel and an information message. 
- Added documentation `docs/specifications/llm-provider-spec-v0.md` and updated related spec pages to describe Phase 2 provider behavior and safety rules. 

### Testing
- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all Rust checks and tests completed successfully. 
- Ran VSIX checks and tests: `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and all succeeded. 
- Performed manual smoke tests against the runtime: `llm.status` with default (unset) provider returned Fake enabled/model as expected, `task.start` + `task.run` exercised the Fake provider and ledger events include provider/model/message_count and previews only, and `llm.status` with `BROWNIE_LLM_PROVIDER=openai-compatible` but missing env vars returned `enabled=false` with a non‑secret missing config reason; all manual checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc85f22088328b9a7a2249056535d)