### PR TITLE
Add structured runtime diagnostics API

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -50,6 +50,29 @@ pub struct RuntimeConfigGetResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeDiagnosticsResult {
+    pub config_source: String,
+    pub active_profile: Option<String>,
+    pub llm_status: LlmStatusResult,
+    pub diagnostics: Vec<RuntimeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RuntimeDiagnostic {
+    pub severity: DiagnosticSeverity,
+    pub code: String,
+    pub message: String,
+    pub subject: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DiagnosticSeverity {
+    Info,
+    Warning,
+    Error,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeStatus {
     pub name: String,
     pub version: String,

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -11,12 +11,13 @@ use brownie_llm::{
     OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv, OpenAiCompatibleLlmProvider,
 };
 use brownie_protocol::{
-    JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary, LlmStatusResult,
-    ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
-    PermissionCheckResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
-    RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult, RuntimeState, RuntimeStatus,
-    TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams,
-    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
+    DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
+    LlmStatusResult, ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary,
+    PermissionCheckParams, PermissionCheckResult, RunEventsParams, RunEventsResult,
+    RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
+    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
+    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult,
+    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
     ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentParseParams,
     ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
     ToolPlanParams, ToolPlanResult, ToolSummary,
@@ -33,6 +34,7 @@ const JSONRPC_VERSION: &str = "2.0";
 const METHOD_RUNTIME_STATUS: &str = "runtime.status";
 const METHOD_LLM_STATUS: &str = "llm.status";
 const METHOD_RUNTIME_CONFIG_GET: &str = "runtime.config.get";
+const METHOD_RUNTIME_DIAGNOSTICS_GET: &str = "runtime.diagnostics.get";
 const METHOD_TASK_START: &str = "task.start";
 const METHOD_TASK_GET: &str = "task.get";
 const METHOD_TASK_RUN: &str = "task.run";
@@ -79,6 +81,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_RUNTIME_STATUS => result_response(request.id, json!(runtime_status())),
         METHOD_LLM_STATUS => handle_llm_status(request.id),
         METHOD_RUNTIME_CONFIG_GET => handle_runtime_config_get(request.id),
+        METHOD_RUNTIME_DIAGNOSTICS_GET => handle_runtime_diagnostics_get(request.id),
         METHOD_TASK_START => handle_task_start(request.id, request.params),
         METHOD_TASK_GET => handle_task_get(request.id, request.params),
         METHOD_TASK_RUN => handle_task_run(request.id, request.params),
@@ -397,6 +400,226 @@ pub fn llm_provider_from_env_for_task_run() -> Result<Box<dyn LlmProvider>, Runt
     }
 }
 
+fn diagnostic(
+    severity: DiagnosticSeverity,
+    code: &str,
+    message: impl Into<String>,
+    subject: Option<&str>,
+) -> RuntimeDiagnostic {
+    RuntimeDiagnostic {
+        severity,
+        code: code.to_string(),
+        message: message.into(),
+        subject: subject.map(str::to_string),
+    }
+}
+
+pub fn runtime_diagnostics_from_workspace(
+    workspace_root: &std::path::Path,
+) -> RuntimeDiagnosticsResult {
+    let mut diagnostics = Vec::new();
+    let mut status = match llm_provider_status_from_workspace(workspace_root) {
+        Ok(status) => status,
+        Err(error) => RuntimeLlmProviderStatus {
+            status: LlmProviderStatus {
+                provider: LlmProviderKind::Unknown,
+                enabled: false,
+                model: String::new(),
+                base_url: None,
+                reason: Some(redact_secret(&error)),
+            },
+            strict: false,
+            will_fallback_to_fake: false,
+            config_source: RuntimeConfigSource::WorkspaceConfig,
+            active_profile: None,
+        },
+    };
+
+    let strict_env = matches!(
+        std::env::var("BROWNIE_LLM_STRICT").ok().as_deref(),
+        Some("true")
+    );
+    let env_provider = std::env::var("BROWNIE_LLM_PROVIDER")
+        .ok()
+        .filter(|v| !v.trim().is_empty());
+    if let Some(provider) = env_provider.as_deref() {
+        diagnostics.push(diagnostic(
+            DiagnosticSeverity::Info,
+            "PROVIDER_ENV_OVERRIDE",
+            format!(
+                "Using LLM provider override from BROWNIE_LLM_PROVIDER: {}.",
+                redact_secret(provider)
+            ),
+            Some("BROWNIE_LLM_PROVIDER"),
+        ));
+        if !matches!(provider, "fake" | "openai-compatible") {
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Error,
+                "PROVIDER_UNKNOWN",
+                format!("Unknown LLM provider: {}.", redact_secret(provider)),
+                Some("BROWNIE_LLM_PROVIDER"),
+            ));
+            if strict_env {
+                diagnostics.push(diagnostic(
+                    DiagnosticSeverity::Error,
+                    "PROVIDER_STRICT_FAILURE",
+                    "Strict mode will fail task.run for this provider configuration.",
+                    Some("BROWNIE_LLM_STRICT"),
+                ));
+            } else {
+                diagnostics.push(diagnostic(
+                    DiagnosticSeverity::Warning,
+                    "PROVIDER_FALLBACK_TO_FAKE",
+                    "Unknown provider will fall back to Fake because strict mode is disabled.",
+                    Some("BROWNIE_LLM_PROVIDER"),
+                ));
+            }
+        }
+    } else {
+        let path = workspace_root.join(CONFIG_RELATIVE_PATH);
+        if !path.exists() {
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Info,
+                "CONFIG_NOT_FOUND",
+                "No .brownie/config.json found; using default Fake provider.",
+                Some(CONFIG_RELATIVE_PATH),
+            ));
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Info,
+                "PROVIDER_DEFAULT_FAKE",
+                "Using default Fake LLM provider.",
+                None,
+            ));
+        } else {
+            match std::fs::read_to_string(&path) {
+                Err(e) => diagnostics.push(diagnostic(
+                    DiagnosticSeverity::Error,
+                    "CONFIG_MALFORMED",
+                    format!("Failed to read .brownie/config.json: {e}"),
+                    Some(CONFIG_RELATIVE_PATH),
+                )),
+                Ok(content) => match serde_json::from_str::<serde_json::Value>(&content) {
+                    Err(e) => diagnostics.push(diagnostic(
+                        DiagnosticSeverity::Error,
+                        "CONFIG_MALFORMED",
+                        format!("Failed to parse .brownie/config.json: {e}"),
+                        Some(CONFIG_RELATIVE_PATH),
+                    )),
+                    Ok(value) => {
+                        if contains_key_recursive(&value, "api_key") {
+                            diagnostics.push(diagnostic(
+                                DiagnosticSeverity::Error,
+                                "CONFIG_DIRECT_API_KEY_REJECTED",
+                                "Direct api_key fields are not allowed; use api_key_env.",
+                                Some(CONFIG_RELATIVE_PATH),
+                            ));
+                        }
+                        match serde_json::from_value::<BrownieConfig>(value) {
+                            Err(e) => diagnostics.push(diagnostic(
+                                DiagnosticSeverity::Error,
+                                "CONFIG_MALFORMED",
+                                format!("Failed to validate .brownie/config.json: {e}"),
+                                Some(CONFIG_RELATIVE_PATH),
+                            )),
+                            Ok(config) => {
+                                if config.version != 1 {
+                                    diagnostics.push(diagnostic(
+                                        DiagnosticSeverity::Error,
+                                        "CONFIG_UNSUPPORTED_VERSION",
+                                        format!(
+                                            "Unsupported runtime config version: {}.",
+                                            config.version
+                                        ),
+                                        Some(CONFIG_RELATIVE_PATH),
+                                    ));
+                                }
+                                match config.active_profile.as_deref() {
+                                    None => diagnostics.push(diagnostic(
+                                        DiagnosticSeverity::Error,
+                                        "ACTIVE_PROFILE_MISSING",
+                                        "active_profile is required when config exists.",
+                                        Some(CONFIG_RELATIVE_PATH),
+                                    )),
+                                    Some(active) => {
+                                        let profile = config
+                                            .llm
+                                            .as_ref()
+                                            .and_then(|l| l.profiles.get(active));
+                                        if profile.is_none() {
+                                            diagnostics.push(diagnostic(DiagnosticSeverity::Error, "ACTIVE_PROFILE_UNKNOWN", format!("active_profile references unknown profile: {active}."), Some("active_profile")));
+                                        } else {
+                                            diagnostics.push(diagnostic(
+                                                DiagnosticSeverity::Info,
+                                                "PROVIDER_WORKSPACE_PROFILE",
+                                                format!("Using workspace LLM profile {active}."),
+                                                Some(active),
+                                            ));
+                                            if let Some(LlmProfile::OpenAiCompatible {
+                                                api_key_env,
+                                                strict,
+                                                ..
+                                            }) = profile
+                                            {
+                                                let key_env =
+                                                    api_key_env.clone().unwrap_or_else(|| {
+                                                        "BROWNIE_LLM_API_KEY".to_string()
+                                                    });
+                                                let key_present = std::env::var(&key_env)
+                                                    .ok()
+                                                    .filter(|v| !v.trim().is_empty())
+                                                    .is_some();
+                                                if !key_present {
+                                                    diagnostics.push(diagnostic(DiagnosticSeverity::Warning, "API_KEY_ENV_MISSING", format!("API key environment variable is not set: {key_env}."), Some(&key_env)));
+                                                    if strict.unwrap_or(false) {
+                                                        diagnostics.push(diagnostic(DiagnosticSeverity::Error, "PROVIDER_STRICT_FAILURE", "Strict mode will fail task.run for this provider configuration.", Some("strict")));
+                                                    } else {
+                                                        diagnostics.push(diagnostic(DiagnosticSeverity::Warning, "PROVIDER_FALLBACK_TO_FAKE", "OpenAI-compatible provider will fall back to Fake because strict mode is disabled.", Some(active)));
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    if diagnostics.iter().any(|d| {
+        d.code == "CONFIG_DIRECT_API_KEY_REJECTED"
+            || d.code == "CONFIG_MALFORMED"
+            || d.code == "CONFIG_UNSUPPORTED_VERSION"
+            || d.code == "ACTIVE_PROFILE_UNKNOWN"
+            || d.code == "ACTIVE_PROFILE_MISSING"
+    }) {
+        status.status.provider = LlmProviderKind::Unknown;
+        status.status.enabled = false;
+        status.status.model.clear();
+        status.status.base_url = None;
+        status.will_fallback_to_fake = false;
+    }
+
+    RuntimeDiagnosticsResult {
+        config_source: status.config_source.as_str().to_string(),
+        active_profile: status.active_profile.clone(),
+        llm_status: llm_status_result(status),
+        diagnostics,
+    }
+}
+
+fn contains_key_recursive(value: &serde_json::Value, key: &str) -> bool {
+    match value {
+        serde_json::Value::Object(map) => map
+            .iter()
+            .any(|(k, v)| k == key || contains_key_recursive(v, key)),
+        serde_json::Value::Array(items) => items.iter().any(|v| contains_key_recursive(v, key)),
+        _ => false,
+    }
+}
+
 fn handle_llm_status(id: Value) -> JsonRpcResponse<Value> {
     let store = match BrownieStore::from_env_or_cwd() {
         Ok(store) => store,
@@ -410,6 +633,17 @@ fn handle_llm_status(id: Value) -> JsonRpcResponse<Value> {
             &format!("internal error: {}", redact_secret(&error)),
         ),
     }
+}
+
+fn handle_runtime_diagnostics_get(id: Value) -> JsonRpcResponse<Value> {
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    result_response(
+        id,
+        json!(runtime_diagnostics_from_workspace(store.workspace_root())),
+    )
 }
 
 fn handle_runtime_config_get(id: Value) -> JsonRpcResponse<Value> {
@@ -2412,6 +2646,92 @@ mod phase_2_2_tests {
         assert_eq!(status.active_profile.as_deref(), Some("local"));
         assert!(!status.status.enabled);
         assert!(status.strict);
+    }
+
+    fn diagnostic_codes(result: &RuntimeDiagnosticsResult) -> Vec<&str> {
+        result.diagnostics.iter().map(|d| d.code.as_str()).collect()
+    }
+
+    #[test]
+    fn diagnostics_no_config_reports_default_fake() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        assert_eq!(result.llm_status.provider, "Fake");
+        assert_eq!(result.config_source, "Default");
+        assert!(diagnostic_codes(&result).contains(&"CONFIG_NOT_FOUND"));
+    }
+
+    #[test]
+    fn diagnostics_unknown_env_provider_reports_strict_semantics() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("BROWNIE_LLM_PROVIDER", "mystery");
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        let codes = diagnostic_codes(&result);
+        assert_eq!(result.llm_status.provider, "Unknown");
+        assert!(codes.contains(&"PROVIDER_UNKNOWN"));
+        assert!(codes.contains(&"PROVIDER_FALLBACK_TO_FAKE"));
+
+        std::env::set_var("BROWNIE_LLM_STRICT", "true");
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        let codes = diagnostic_codes(&result);
+        assert!(codes.contains(&"PROVIDER_UNKNOWN"));
+        assert!(codes.contains(&"PROVIDER_STRICT_FAILURE"));
+    }
+
+    #[test]
+    fn diagnostics_direct_api_key_and_malformed_config_do_not_leak_raw_content() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"version":1,"active_profile":"bad","llm":{"profiles":{"bad":{"provider":"openai-compatible","base_url":"http://127.0.0.1:4141/v1","model":"qwen35","api_key":"DO_NOT_ALLOW"}}}}"#,
+        );
+        let response =
+            serde_json::to_string(&runtime_diagnostics_from_workspace(dir.path())).unwrap();
+        assert!(response.contains("CONFIG_DIRECT_API_KEY_REJECTED"));
+        assert!(!response.contains("DO_NOT_ALLOW"));
+        assert!(!response.contains("Authorization"));
+        assert!(!response.contains("Bearer"));
+
+        write_config(dir.path(), r#"{"secret":"RAW_SECRET""#);
+        let response =
+            serde_json::to_string(&runtime_diagnostics_from_workspace(dir.path())).unwrap();
+        assert!(response.contains("CONFIG_MALFORMED"));
+        assert!(!response.contains("RAW_SECRET"));
+    }
+
+    #[test]
+    fn diagnostics_workspace_profiles_and_missing_key() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"version":1,"active_profile":"fake","llm":{"profiles":{"fake":{"provider":"fake"}}}}"#,
+        );
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        assert!(diagnostic_codes(&result).contains(&"PROVIDER_WORKSPACE_PROFILE"));
+
+        write_config(
+            dir.path(),
+            r#"{"version":1,"active_profile":"local","llm":{"profiles":{"local":{"provider":"openai-compatible","base_url":"http://127.0.0.1:4141/v1","model":"qwen35","api_key_env":"MISSING_BROWNIE_KEY","strict":false}}}}"#,
+        );
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        let codes = diagnostic_codes(&result);
+        assert!(codes.contains(&"API_KEY_ENV_MISSING"));
+        assert!(codes.contains(&"PROVIDER_FALLBACK_TO_FAKE"));
+
+        write_config(
+            dir.path(),
+            r#"{"version":1,"active_profile":"missing","llm":{"profiles":{"fake":{"provider":"fake"}}}}"#,
+        );
+        let result = runtime_diagnostics_from_workspace(dir.path());
+        assert!(diagnostic_codes(&result).contains(&"ACTIVE_PROFILE_UNKNOWN"));
     }
 
     #[test]

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -51,3 +51,7 @@ CI must not require a live local or external LLM endpoint. Optional live local e
 Run inspection/event metadata may include provider, model, redacted base URL, and strict mode. It must not include API key values, `Authorization`, or `Bearer` token values.
 
 Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status reports `provider=Unknown`, `enabled=false`, and a safe explanatory reason; strict task runs fail.
+
+## Phase 2.4 diagnostics
+
+`runtime.diagnostics.get` reports provider-profile diagnostics without contacting external LLM endpoints. It explains default Fake selection, workspace profile selection, environment overrides, unknown providers, missing API key environment variables, fallback-to-Fake behavior, and strict failures. Diagnostics and status output must not expose API keys, Authorization headers, or Bearer tokens.

--- a/docs/specifications/openai-compatible-smoke-spec-v0.md
+++ b/docs/specifications/openai-compatible-smoke-spec-v0.md
@@ -81,3 +81,7 @@ Run inspection and event APIs may expose sanitized provider metadata needed for 
 ## Unknown provider handling
 
 If `BROWNIE_LLM_PROVIDER` contains an unknown value, Brownie must not silently report Fake as the selected provider. `llm.status` reports an explanatory disabled status with `provider=Unknown`, `enabled=false`, and `reason="unknown provider: <value>"`. In strict mode, `task.run` fails rather than falling back silently.
+
+## Phase 2.4 diagnostics smoke checks
+
+Use `runtime.diagnostics.get` to inspect OpenAI-compatible configuration completeness without contacting the endpoint. Missing API key environment variables produce `API_KEY_ENV_MISSING` and either fallback or strict-failure diagnostics. Direct `api_key` fields produce `CONFIG_DIRECT_API_KEY_REJECTED` without leaking the value.

--- a/docs/specifications/runtime-config-spec-v0.md
+++ b/docs/specifications/runtime-config-spec-v0.md
@@ -61,3 +61,7 @@ CI must not require a live local or external LLM endpoint. Optional live local e
 Run inspection/event metadata may include provider, model, redacted base URL, and strict mode. It must not include API key values, `Authorization`, or `Bearer` token values.
 
 Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status reports `provider=Unknown`, `enabled=false`, and a safe explanatory reason; strict task runs fail.
+
+## Phase 2.4 diagnostics
+
+`runtime.diagnostics.get` returns structured diagnostics for `.brownie/config.json` discovery, JSON parse and validation failures, unsupported versions, missing or unknown `active_profile`, and rejected direct `api_key` fields. Malformed config diagnostics must not include raw file content or secret values.

--- a/docs/specifications/runtime-diagnostics-spec-v0.md
+++ b/docs/specifications/runtime-diagnostics-spec-v0.md
@@ -1,0 +1,30 @@
+# Runtime diagnostics spec v0
+
+Phase 2.4 adds `runtime.diagnostics.get`, a read-only JSON-RPC method for structured inspection of Brownie's effective runtime and LLM provider configuration.
+
+## Method
+
+```json
+{"jsonrpc":"2.0","id":1,"method":"runtime.diagnostics.get"}
+```
+
+The method returns `config_source`, `active_profile`, sanitized `llm_status`, and a `diagnostics` array. It does not contact external LLM endpoints.
+
+Each diagnostic has:
+
+- `severity`: `Info`, `Warning`, or `Error`.
+- `code`: a stable machine-readable string.
+- `message`: a human-readable, redacted explanation.
+- `subject`: an optional config field, profile name, file path, or environment variable.
+
+## Diagnostic codes
+
+Phase 2.4 codes include `CONFIG_NOT_FOUND`, `CONFIG_MALFORMED`, `CONFIG_UNSUPPORTED_VERSION`, `CONFIG_DIRECT_API_KEY_REJECTED`, `ACTIVE_PROFILE_MISSING`, `ACTIVE_PROFILE_UNKNOWN`, `PROVIDER_DEFAULT_FAKE`, `PROVIDER_WORKSPACE_PROFILE`, `PROVIDER_ENV_OVERRIDE`, `PROVIDER_UNKNOWN`, `PROVIDER_FALLBACK_TO_FAKE`, `PROVIDER_STRICT_FAILURE`, and `API_KEY_ENV_MISSING`.
+
+## Secret handling
+
+Diagnostics must never return API key values, Authorization headers, Bearer tokens, or raw malformed config content. Direct `api_key` fields in `.brownie/config.json` are reported with `CONFIG_DIRECT_API_KEY_REJECTED`; callers must use `api_key_env` instead.
+
+## Endpoint health
+
+`runtime.diagnostics.get` performs no network calls. Any future endpoint health probe must be exposed as an explicit method such as `llm.health` and must continue to redact secrets.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -234,3 +234,7 @@ CI must not require a live local or external LLM endpoint. Optional live local e
 Run inspection/event metadata may include provider, model, redacted base URL, and strict mode. It must not include API key values, `Authorization`, or `Bearer` token values.
 
 Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status reports `provider=Unknown`, `enabled=false`, and a safe explanatory reason; strict task runs fail.
+
+## Phase 2.4 `runtime.diagnostics.get`
+
+`runtime.diagnostics.get` returns `config_source`, optional `active_profile`, sanitized `llm_status`, and diagnostics with `severity`, `code`, `message`, and optional `subject`. The method is read-only and does not contact external LLM endpoints. It prefers structured diagnostics over JSON-RPC errors when config parsing or validation fails.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -30,6 +30,10 @@
         "title": "Brownie: Runtime Config"
       },
       {
+        "command": "brownie.runtimeDiagnostics",
+        "title": "Brownie: Runtime Diagnostics"
+      },
+      {
         "command": "brownie.modeList",
         "title": "Brownie: List Modes"
       },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -56,6 +56,23 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const runtimeDiagnosticsCommand = vscode.commands.registerCommand('brownie.runtimeDiagnostics', async () => {
+    try {
+      const diagnostics = await runtimeClient.runtimeDiagnostics();
+      output.appendLine(`runtime.diagnostics.get:`);
+      output.appendLine(JSON.stringify(diagnostics, null, 2));
+      output.show(true);
+      const errors = diagnostics.diagnostics.filter((item) => item.severity === 'Error').length;
+      const warnings = diagnostics.diagnostics.filter((item) => item.severity === 'Warning').length;
+      await vscode.window.showInformationMessage(
+        `Brownie diagnostics: ${errors} errors, ${warnings} ${warnings === 1 ? 'warning' : 'warnings'}`,
+      );
+    } catch (error) {
+      output.appendLine(`runtime.diagnostics.get failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie runtime diagnostics failed: ${formatError(error)}`);
+    }
+  });
+
   const modeListCommand = vscode.commands.registerCommand('brownie.modeList', async () => {
     try {
       const modes = await runtimeClient.listModes();

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -42,6 +42,22 @@ export interface RuntimeConfigGetResult {
   llm_status: LlmStatusResult;
 }
 
+export type DiagnosticSeverity = 'Info' | 'Warning' | 'Error';
+
+export interface RuntimeDiagnostic {
+  severity: DiagnosticSeverity;
+  code: string;
+  message: string;
+  subject?: string | null;
+}
+
+export interface RuntimeDiagnosticsResult {
+  config_source: string;
+  active_profile?: string | null;
+  llm_status: LlmStatusResult;
+  diagnostics: RuntimeDiagnostic[];
+}
+
 export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
 export type RuntimeActionName =
@@ -223,6 +239,29 @@ export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
     typeof value.will_fallback_to_fake === 'boolean' &&
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
+    !Object.prototype.hasOwnProperty.call(value, 'api_key')
+  );
+}
+
+export function isRuntimeDiagnostic(value: unknown): value is RuntimeDiagnostic {
+  return (
+    isRecord(value) &&
+    (value.severity === 'Info' || value.severity === 'Warning' || value.severity === 'Error') &&
+    typeof value.code === 'string' &&
+    typeof value.message === 'string' &&
+    (value.subject === undefined || value.subject === null || typeof value.subject === 'string') &&
+    !Object.prototype.hasOwnProperty.call(value, 'api_key')
+  );
+}
+
+export function isRuntimeDiagnosticsResult(value: unknown): value is RuntimeDiagnosticsResult {
+  return (
+    isRecord(value) &&
+    typeof value.config_source === 'string' &&
+    (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
+    isLlmStatusResult(value.llm_status) &&
+    Array.isArray(value.diagnostics) &&
+    value.diagnostics.every(isRuntimeDiagnostic) &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')
   );
 }

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmStatusResult, RuntimeConfigGetResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmStatusResult, isRuntimeConfigGetResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -28,6 +28,16 @@ export class RuntimeClient {
 
     if (!isLlmStatusResult(result)) {
       throw new RuntimeProtocolError('llm.status returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async runtimeDiagnostics(): Promise<RuntimeDiagnosticsResult> {
+    const result = await this.call<RuntimeDiagnosticsResult>('runtime.diagnostics.get');
+
+    if (!isRuntimeDiagnosticsResult(result)) {
+      throw new RuntimeProtocolError('runtime.diagnostics.get returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeConfigGetResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -69,6 +69,14 @@ describe('protocol validation', () => {
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, active_profile: null })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', api_key: 'secret' })).toBe(false);
+  });
+
+  it('accepts valid runtime diagnostics results', () => {
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [], api_key: 'secret' })).toBe(false);
   });
 
   it('accepts valid runtime.config.get results', () => {
@@ -169,6 +177,15 @@ describe('RuntimeClient', () => {
     const client = new RuntimeClient(transport);
 
     await expect(client.llmStatus()).rejects.toThrow('llm.status returned an invalid result');
+  });
+
+  it('creates a runtime.diagnostics.get request', async () => {
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const result = { config_source: 'Default', active_profile: null, llm_status, diagnostics: [] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+    await expect(client.runtimeDiagnostics()).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'runtime.diagnostics.get' }]);
   });
 
   it('creates a runtime.config.get request', async () => {


### PR DESCRIPTION
### Motivation
- Provide a read-only, structured diagnostics API so VSIX and headless runtime can inspect effective provider/profile/config state without contacting external LLM endpoints. 
- Surface configuration problems (missing config, malformed config, unknown provider, direct api_key usage, missing API key env, strict/fallback semantics) as stable, machine-readable diagnostics while ensuring secrets are never leaked.

### Description
- Added protocol types for diagnostics: `RuntimeDiagnosticsResult`, `RuntimeDiagnostic`, and `DiagnosticSeverity` in `crates/brownie-protocol/src/lib.rs`.
- Implemented `runtime.diagnostics.get` JSON-RPC handler and diagnostics builder (`runtime_diagnostics_from_workspace`) in `crates/brownie-runtime/src/lib.rs`, covering env overrides, workspace config discovery/validation, unknown providers, direct `api_key` rejection, missing API key env, strict vs fallback behavior, and redaction of secrets.
- Wired the new method into the runtime dispatch and ensured it is read-only and performs no external LLM calls.
- Added VSIX surface: new command `brownie.runtimeDiagnostics` in `extensions/brownie-vsix/package.json`, a `runtimeDiagnostics()` client method in `extensions/brownie-vsix/src/runtime/runtimeClient.ts`, protocol types/validators in `extensions/brownie-vsix/src/runtime/protocol.ts`, and a command implementation to pretty-print diagnostics and show error/warning counts in `extensions/brownie-vsix/src/extension.ts`.
- Added Rust unit tests exercising diagnostics and redaction and updated VSIX protocol/unit tests and documentation (`docs/specifications/*`) including a new `runtime-diagnostics-spec-v0.md`.

### Testing
- Ran `cargo fmt --check` and `cargo check --workspace`, both succeeded.
- Ran `cargo test --workspace`, all Rust unit tests passed (including new diagnostics tests); `brownie-runtime` diagnostics tests passed locally (`4 passed` for targeted diagnostics tests; full workspace tests `45 passed` in runtime suite and overall workspace tests passed).
- Ran VSIX checks and tests: `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, all succeeded (TypeScript validation and `vitest` tests passed).
- Performed manual smoke tests using the runtime JSON-RPC:
  - No config: `runtime.diagnostics.get` reported default Fake provider and `CONFIG_NOT_FOUND` (passed).
  - Unknown env provider: `runtime.diagnostics.get` reported `PROVIDER_UNKNOWN` and appropriate fallback/strict diagnostics (passed).
  - Direct `api_key` in workspace config: `runtime.diagnostics.get` returned `CONFIG_DIRECT_API_KEY_REJECTED` and output did not contain the raw API key (passed).

All automated checks and manual smoke tests executed in this rollout completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe95a8174832894ce1d82042daa03)