### PR TITLE
Add llm.health JSON-RPC method and OpenAI-compatible /models health probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "time",
 ]
 
 [[package]]

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -1,6 +1,9 @@
 //! LLM client abstraction crate.
 
-use std::{env, time::Duration};
+use std::{
+    env,
+    time::{Duration, Instant},
+};
 
 use anyhow::anyhow;
 use serde::{Deserialize, Serialize};
@@ -145,6 +148,15 @@ pub struct OpenAiCompatibleLlmProvider {
     timeout: Duration,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LlmHealthProbeResult {
+    pub attempted: bool,
+    pub healthy: bool,
+    pub latency_ms: Option<u64>,
+    pub status_code: Option<u16>,
+    pub reason: Option<String>,
+}
+
 impl OpenAiCompatibleLlmProvider {
     pub fn new(config: OpenAiCompatibleConfig, api_key: String) -> Self {
         Self {
@@ -195,6 +207,50 @@ impl OpenAiCompatibleLlmProvider {
             model: model.expect("checked"),
             api_key_env,
         })
+    }
+
+    pub fn probe_models(&self, timeout: Duration) -> LlmHealthProbeResult {
+        let started = Instant::now();
+        let url = format!("{}/models", self.config.base_url.trim_end_matches('/'));
+        let client = match reqwest::blocking::Client::builder()
+            .no_proxy()
+            .timeout(timeout)
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                return LlmHealthProbeResult {
+                    attempted: false,
+                    healthy: false,
+                    latency_ms: None,
+                    status_code: None,
+                    reason: Some(redact_secret(&error.to_string())),
+                };
+            }
+        };
+        match client.get(url).bearer_auth(&self.api_key).send() {
+            Ok(response) => {
+                let status = response.status();
+                LlmHealthProbeResult {
+                    attempted: true,
+                    healthy: status.is_success(),
+                    latency_ms: Some(started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)),
+                    status_code: Some(status.as_u16()),
+                    reason: if status.is_success() {
+                        None
+                    } else {
+                        Some(format!("non-2xx HTTP status {}", status.as_u16()))
+                    },
+                }
+            }
+            Err(error) => LlmHealthProbeResult {
+                attempted: true,
+                healthy: false,
+                latency_ms: Some(started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)),
+                status_code: error.status().map(|status| status.as_u16()),
+                reason: Some(redact_secret(&error.to_string())),
+            },
+        }
     }
 }
 

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -58,6 +58,29 @@ pub struct RuntimeDiagnosticsResult {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmHealthParams {
+    pub allow_network: bool,
+    pub timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmHealthResult {
+    pub provider: String,
+    pub config_source: String,
+    pub active_profile: Option<String>,
+    pub enabled: bool,
+    pub attempted: bool,
+    pub healthy: bool,
+    pub model: String,
+    pub base_url: Option<String>,
+    pub checked_at: String,
+    pub latency_ms: Option<u64>,
+    pub status_code: Option<u16>,
+    pub reason: Option<String>,
+    pub diagnostics: Vec<RuntimeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RuntimeDiagnostic {
     pub severity: DiagnosticSeverity,
     pub code: String,

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -18,6 +18,7 @@ brownie-store = { path = "../brownie-store" }
 brownie-tools = { path = "../brownie-tools" }
 serde.workspace = true
 serde_json.workspace = true
+time.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -12,15 +12,15 @@ use brownie_llm::{
 };
 use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
-    LlmStatusResult, ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary,
-    PermissionCheckParams, PermissionCheckResult, RunEventsParams, RunEventsResult,
-    RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
-    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
-    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult,
-    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
-    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentParseParams,
-    ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
-    ToolPlanParams, ToolPlanResult, ToolSummary,
+    LlmHealthParams, LlmHealthResult, LlmStatusResult, ModeGetParams, ModeListResult,
+    ModePermissionsSummary, ModeSummary, PermissionCheckParams, PermissionCheckResult,
+    RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary,
+    RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult,
+    RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult,
+    TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
+    ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary,
+    ToolIntentParseParams, ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult,
+    ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -33,6 +33,7 @@ use serde_json::{json, Value};
 const JSONRPC_VERSION: &str = "2.0";
 const METHOD_RUNTIME_STATUS: &str = "runtime.status";
 const METHOD_LLM_STATUS: &str = "llm.status";
+const METHOD_LLM_HEALTH: &str = "llm.health";
 const METHOD_RUNTIME_CONFIG_GET: &str = "runtime.config.get";
 const METHOD_RUNTIME_DIAGNOSTICS_GET: &str = "runtime.diagnostics.get";
 const METHOD_TASK_START: &str = "task.start";
@@ -80,6 +81,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
     match request.method.as_str() {
         METHOD_RUNTIME_STATUS => result_response(request.id, json!(runtime_status())),
         METHOD_LLM_STATUS => handle_llm_status(request.id),
+        METHOD_LLM_HEALTH => handle_llm_health(request.id, request.params),
         METHOD_RUNTIME_CONFIG_GET => handle_runtime_config_get(request.id),
         METHOD_RUNTIME_DIAGNOSTICS_GET => handle_runtime_diagnostics_get(request.id),
         METHOD_TASK_START => handle_task_start(request.id, request.params),
@@ -610,6 +612,161 @@ pub fn runtime_diagnostics_from_workspace(
     }
 }
 
+pub fn llm_health_from_workspace(
+    workspace_root: &std::path::Path,
+    allow_network: bool,
+    timeout: std::time::Duration,
+) -> Result<LlmHealthResult, String> {
+    let selection = llm_provider_status_from_workspace(workspace_root)?;
+    let checked_at = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(|e| e.to_string())?;
+    let mut result = LlmHealthResult {
+        provider: provider_kind_name(&selection.status.provider).to_string(),
+        config_source: selection.config_source.as_str().to_string(),
+        active_profile: selection.active_profile.clone(),
+        enabled: selection.status.enabled,
+        attempted: false,
+        healthy: false,
+        model: selection.status.model.clone(),
+        base_url: selection.status.base_url.clone(),
+        checked_at,
+        latency_ms: None,
+        status_code: None,
+        reason: selection.status.reason.clone().map(|v| redact_secret(&v)),
+        diagnostics: Vec::new(),
+    };
+
+    match selection.status.provider {
+        LlmProviderKind::Fake => {
+            result.enabled = true;
+            result.healthy = true;
+            result.reason = None;
+            result.diagnostics.push(diagnostic(
+                DiagnosticSeverity::Info,
+                "PROVIDER_FAKE_HEALTHY",
+                "Fake provider is healthy without network access.",
+                None,
+            ));
+            Ok(result)
+        }
+        LlmProviderKind::OpenAiCompatible if !selection.status.enabled => {
+            result.diagnostics.push(diagnostic(
+                DiagnosticSeverity::Error,
+                "HEALTH_PROVIDER_DISABLED",
+                selection
+                    .status
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| "OpenAI-compatible provider is disabled.".to_string()),
+                None,
+            ));
+            Ok(result)
+        }
+        LlmProviderKind::OpenAiCompatible if !allow_network => {
+            result.diagnostics.push(diagnostic(
+                DiagnosticSeverity::Warning,
+                "HEALTH_NETWORK_NOT_ALLOWED",
+                "Network probe was not attempted because allow_network=false.",
+                None,
+            ));
+            Ok(result)
+        }
+        LlmProviderKind::OpenAiCompatible => {
+            let provider = openai_provider_from_workspace_for_health(workspace_root, &selection)?;
+            let probe = provider.probe_models(timeout);
+            result.attempted = probe.attempted;
+            result.healthy = probe.healthy;
+            result.latency_ms = probe.latency_ms;
+            result.status_code = probe.status_code;
+            result.reason = probe.reason.map(|v| redact_secret(&v));
+            result.diagnostics.push(diagnostic(
+                if result.healthy {
+                    DiagnosticSeverity::Info
+                } else {
+                    DiagnosticSeverity::Error
+                },
+                if result.healthy {
+                    "HEALTH_PROBE_OK"
+                } else {
+                    "HEALTH_PROBE_FAILED"
+                },
+                if result.healthy {
+                    "OpenAI-compatible /models probe returned a 2xx status.".to_string()
+                } else {
+                    result
+                        .reason
+                        .clone()
+                        .unwrap_or_else(|| "OpenAI-compatible /models probe failed.".to_string())
+                },
+                result.base_url.as_deref(),
+            ));
+            Ok(result)
+        }
+        LlmProviderKind::Unknown => {
+            result.diagnostics.push(diagnostic(
+                DiagnosticSeverity::Error,
+                "HEALTH_PROVIDER_UNSUPPORTED",
+                selection
+                    .status
+                    .reason
+                    .clone()
+                    .unwrap_or_else(|| "Unsupported LLM provider.".to_string()),
+                None,
+            ));
+            Ok(result)
+        }
+    }
+}
+
+fn openai_provider_from_workspace_for_health(
+    workspace_root: &std::path::Path,
+    selection: &RuntimeLlmProviderStatus,
+) -> Result<OpenAiCompatibleLlmProvider, String> {
+    if selection.config_source == RuntimeConfigSource::Env {
+        return match OpenAiCompatibleLlmProvider::from_env() {
+            OpenAiCompatibleConfigFromEnv::Enabled(config) => {
+                let api_key = std::env::var(&config.api_key_env).unwrap_or_default();
+                Ok(OpenAiCompatibleLlmProvider::new(config, api_key))
+            }
+            OpenAiCompatibleConfigFromEnv::Disabled(status) => Err(status
+                .reason
+                .unwrap_or_else(|| "OpenAI-compatible provider disabled".to_string())),
+        };
+    }
+    let config =
+        RuntimeConfigLoader::load_from_workspace(workspace_root).map_err(|e| e.to_string())?;
+    let config = config.ok_or_else(|| "workspace config missing".to_string())?;
+    let profile_name = selection.active_profile.clone().unwrap_or_default();
+    let profile = config
+        .llm
+        .as_ref()
+        .and_then(|llm| llm.profiles.get(&profile_name))
+        .ok_or_else(|| "active_profile references unknown profile".to_string())?;
+    let LlmProfile::OpenAiCompatible {
+        base_url,
+        model,
+        api_key_env,
+        ..
+    } = profile
+    else {
+        return Err("active provider is not OpenAI-compatible".to_string());
+    };
+    let api_key_env = api_key_env
+        .clone()
+        .unwrap_or_else(|| "BROWNIE_LLM_API_KEY".to_string());
+    let api_key =
+        std::env::var(&api_key_env).map_err(|_| format!("missing config: {api_key_env}"))?;
+    Ok(OpenAiCompatibleLlmProvider::new(
+        OpenAiCompatibleConfig {
+            base_url: base_url.clone(),
+            model: model.clone(),
+            api_key_env,
+        },
+        api_key,
+    ))
+}
+
 fn contains_key_recursive(value: &serde_json::Value, key: &str) -> bool {
     match value {
         serde_json::Value::Object(map) => map
@@ -644,6 +801,37 @@ fn handle_runtime_diagnostics_get(id: Value) -> JsonRpcResponse<Value> {
         id,
         json!(runtime_diagnostics_from_workspace(store.workspace_root())),
     )
+}
+
+fn handle_llm_health(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: LlmHealthParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    let timeout_ms = params.timeout_ms.unwrap_or(5000);
+    if !(1000..=30000).contains(&timeout_ms) {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: timeout_ms must be between 1000 and 30000",
+        );
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match llm_health_from_workspace(
+        store.workspace_root(),
+        params.allow_network,
+        std::time::Duration::from_millis(timeout_ms),
+    ) {
+        Ok(result) => result_response(id, json!(result)),
+        Err(error) => error_response(
+            id,
+            -32603,
+            &format!("internal error: {}", redact_secret(&error)),
+        ),
+    }
 }
 
 fn handle_runtime_config_get(id: Value) -> JsonRpcResponse<Value> {
@@ -1826,7 +2014,7 @@ mod tests {
 
     pub(super) static ENV_LOCK: Mutex<()> = Mutex::new(());
 
-    fn parse_line(line: &str) -> JsonRpcResponse<Value> {
+    pub(super) fn parse_line(line: &str) -> JsonRpcResponse<Value> {
         serde_json::from_str(&handle_jsonrpc_input_line(line).expect("response line"))
             .expect("valid response")
     }
@@ -2750,6 +2938,174 @@ mod phase_2_2_tests {
         assert!(response.contains("error"));
         assert!(!response.contains("DO_NOT_ALLOW"));
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+}
+
+#[cfg(test)]
+mod phase_2_5_tests {
+    use super::*;
+    use std::{
+        fs,
+        io::{Read, Write},
+        net::TcpListener,
+        thread,
+    };
+
+    struct EnvGuard;
+    impl EnvGuard {
+        fn clear_env() {
+            for key in [
+                "BROWNIE_WORKSPACE_ROOT",
+                "BROWNIE_LLM_PROVIDER",
+                "BROWNIE_LLM_BASE_URL",
+                "BROWNIE_LLM_MODEL",
+                "BROWNIE_LLM_API_KEY_ENV",
+                "BROWNIE_LLM_API_KEY",
+                "BROWNIE_LLM_STRICT",
+            ] {
+                std::env::remove_var(key);
+            }
+        }
+        fn clear() -> Self {
+            Self::clear_env();
+            Self
+        }
+    }
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            Self::clear_env();
+        }
+    }
+
+    fn write_config(dir: &std::path::Path, body: &str) {
+        fs::create_dir_all(dir.join(".brownie")).unwrap();
+        fs::write(dir.join(".brownie/config.json"), body).unwrap();
+    }
+
+    fn mock_models_server(status: u16) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buffer = [0; 2048];
+            let _ = stream.read(&mut buffer);
+            let response = format!(
+                "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: 13\r\n\r\n{{\"data\":[]}}"
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        format!("http://{addr}/v1")
+    }
+
+    #[test]
+    fn llm_health_fake_returns_healthy_without_network() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        let result =
+            llm_health_from_workspace(dir.path(), false, std::time::Duration::from_secs(5))
+                .unwrap();
+        assert_eq!(result.provider, "Fake");
+        assert!(!result.attempted);
+        assert!(result.healthy);
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "PROVIDER_FAKE_HEALTHY"));
+    }
+
+    #[test]
+    fn llm_health_openai_network_not_allowed_does_not_probe() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("BROWNIE_LLM_PROVIDER", "openai-compatible");
+        std::env::set_var("BROWNIE_LLM_BASE_URL", "http://127.0.0.1:9/v1");
+        std::env::set_var("BROWNIE_LLM_MODEL", "qwen35");
+        std::env::set_var("BROWNIE_LLM_API_KEY_ENV", "BROWNIE_LLM_API_KEY");
+        std::env::set_var("BROWNIE_LLM_API_KEY", "local-secret");
+        let result =
+            llm_health_from_workspace(dir.path(), false, std::time::Duration::from_secs(5))
+                .unwrap();
+        assert_eq!(result.provider, "OpenAiCompatible");
+        assert!(!result.attempted);
+        assert!(!result.healthy);
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "HEALTH_NETWORK_NOT_ALLOWED"));
+    }
+
+    #[test]
+    fn llm_health_rejects_timeout_bounds() {
+        let below = super::tests::parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"llm.health","params":{"allow_network":true,"timeout_ms":999}}"#,
+        );
+        assert_eq!(below.error.unwrap().code, -32602);
+        let above = super::tests::parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"llm.health","params":{"allow_network":true,"timeout_ms":30001}}"#,
+        );
+        assert_eq!(above.error.unwrap().code, -32602);
+    }
+
+    #[test]
+    fn llm_health_missing_openai_config_is_disabled() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        std::env::set_var("BROWNIE_LLM_PROVIDER", "openai-compatible");
+        let result =
+            llm_health_from_workspace(dir.path(), true, std::time::Duration::from_secs(5)).unwrap();
+        assert_eq!(result.provider, "OpenAiCompatible");
+        assert!(!result.attempted);
+        assert!(!result.healthy);
+        assert!(result.reason.unwrap().contains("missing config"));
+    }
+
+    #[test]
+    fn llm_health_openai_2xx_and_500_mock_server() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        for (status, healthy) in [(200, true), (500, false)] {
+            let base_url = mock_models_server(status);
+            std::env::set_var("BROWNIE_LLM_PROVIDER", "openai-compatible");
+            std::env::set_var("BROWNIE_LLM_BASE_URL", &base_url);
+            std::env::set_var("BROWNIE_LLM_MODEL", "qwen35");
+            std::env::set_var("BROWNIE_LLM_API_KEY_ENV", "BROWNIE_LLM_API_KEY");
+            std::env::set_var("BROWNIE_LLM_API_KEY", "local-secret");
+            let result =
+                llm_health_from_workspace(dir.path(), true, std::time::Duration::from_secs(5))
+                    .unwrap();
+            assert!(result.attempted);
+            assert_eq!(result.healthy, healthy);
+            assert_eq!(result.status_code, Some(status));
+            let serialized = serde_json::to_string(&result).unwrap();
+            assert!(!serialized.contains("local-secret"));
+            assert!(!serialized.contains("Authorization"));
+            assert!(!serialized.contains(r#"{"data":[]}"#));
+        }
+    }
+
+    #[test]
+    fn llm_health_redacts_connection_failure_and_query_secret() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let dir = tempfile::tempdir().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"version":1,"active_profile":"local","llm":{"profiles":{"local":{"provider":"openai-compatible","base_url":"http://127.0.0.1:9/v1?api_key=secret-query","model":"qwen35","api_key_env":"BROWNIE_LLM_API_KEY","strict":true}}}}"#,
+        );
+        std::env::set_var("BROWNIE_LLM_API_KEY", "local-secret");
+        let result =
+            llm_health_from_workspace(dir.path(), true, std::time::Duration::from_millis(1000))
+                .unwrap();
+        assert!(result.attempted);
+        assert!(!result.healthy);
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(serialized.contains("?[REDACTED]"));
+        assert!(!serialized.contains("secret-query"));
+        assert!(!serialized.contains("local-secret"));
     }
 }
 

--- a/docs/specifications/llm-health-spec-v0.md
+++ b/docs/specifications/llm-health-spec-v0.md
@@ -1,0 +1,29 @@
+# LLM health spec v0
+
+Phase 2.5 adds `llm.health`, an explicit JSON-RPC readiness probe for the selected LLM provider.
+
+## Request
+
+`llm.health` requires params with `allow_network` and accepts optional `timeout_ms`.
+
+```json
+{"allow_network": true, "timeout_ms": 5000}
+```
+
+`allow_network` is mandatory. `timeout_ms` defaults to 5000 and must be between 1000 and 30000 inclusive; values outside that range return JSON-RPC `-32602`.
+
+## No-network behavior
+
+The default Fake provider never performs network access. It returns `attempted=false`, `healthy=true`, `enabled=true`, and a `PROVIDER_FAKE_HEALTHY` diagnostic.
+
+For OpenAI-compatible providers, `allow_network=false` never contacts the endpoint. The result returns `attempted=false`, `healthy=false`, and a `HEALTH_NETWORK_NOT_ALLOWED` warning.
+
+Disabled or incomplete OpenAI-compatible configuration also returns `attempted=false` and `healthy=false`.
+
+## OpenAI-compatible probe
+
+When the selected provider is OpenAI-compatible, enabled, and `allow_network=true`, the runtime sends `GET {base_url}/models` using bearer authorization and the validated timeout. A 2xx HTTP status is healthy. Response bodies are not persisted or returned, and JSON parsing is not required for Phase 2.5.
+
+## Redaction and persistence
+
+`llm.health` is a global inspection API, not a task run event. It does not write to the run ledger. Health results, reasons, diagnostics, errors, status, and inspection data must not expose API keys, Authorization headers, Bearer tokens, or URL query-string secrets. Health responses contain only high-level metadata such as provider, model, redacted base URL, status code, latency, and redacted reason.

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -55,3 +55,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.4 diagnostics
 
 `runtime.diagnostics.get` reports provider-profile diagnostics without contacting external LLM endpoints. It explains default Fake selection, workspace profile selection, environment overrides, unknown providers, missing API key environment variables, fallback-to-Fake behavior, and strict failures. Diagnostics and status output must not expose API keys, Authorization headers, or Bearer tokens.
+
+## Phase 2.5 LLM health
+
+Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.

--- a/docs/specifications/runtime-config-spec-v0.md
+++ b/docs/specifications/runtime-config-spec-v0.md
@@ -65,3 +65,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.4 diagnostics
 
 `runtime.diagnostics.get` returns structured diagnostics for `.brownie/config.json` discovery, JSON parse and validation failures, unsupported versions, missing or unknown `active_profile`, and rejected direct `api_key` fields. Malformed config diagnostics must not include raw file content or secret values.
+
+## Phase 2.5 LLM health
+
+Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.

--- a/docs/specifications/runtime-diagnostics-spec-v0.md
+++ b/docs/specifications/runtime-diagnostics-spec-v0.md
@@ -28,3 +28,7 @@ Diagnostics must never return API key values, Authorization headers, Bearer toke
 ## Endpoint health
 
 `runtime.diagnostics.get` performs no network calls. Any future endpoint health probe must be exposed as an explicit method such as `llm.health` and must continue to redact secrets.
+
+## Phase 2.5 LLM health
+
+Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -238,3 +238,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.4 `runtime.diagnostics.get`
 
 `runtime.diagnostics.get` returns `config_source`, optional `active_profile`, sanitized `llm_status`, and diagnostics with `severity`, `code`, `message`, and optional `subject`. The method is read-only and does not contact external LLM endpoints. It prefers structured diagnostics over JSON-RPC errors when config parsing or validation fails.
+
+## Phase 2.5 LLM health
+
+Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -26,6 +26,10 @@
         "title": "Brownie: LLM Status"
       },
       {
+        "command": "brownie.llmHealth",
+        "title": "Brownie: LLM Health"
+      },
+      {
         "command": "brownie.runtimeConfig",
         "title": "Brownie: Runtime Config"
       },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -41,6 +41,31 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const llmHealthCommand = vscode.commands.registerCommand('brownie.llmHealth', async () => {
+    const confirm = await vscode.window.showWarningMessage(
+      'Brownie will connect to the configured LLM endpoint to check /models readiness. Continue?',
+      { modal: true },
+      'Confirm',
+    );
+
+    if (confirm !== 'Confirm') {
+      return;
+    }
+
+    try {
+      const health = await runtimeClient.llmHealth({ allow_network: true, timeout_ms: 5000 });
+      output.appendLine(`llm.health:`);
+      output.appendLine(JSON.stringify(health, null, 2));
+      output.show(true);
+      await vscode.window.showInformationMessage(
+        `Brownie LLM health: provider=${health.provider} healthy=${String(health.healthy)} latency=${health.latency_ms ?? 'n/a'}ms`,
+      );
+    } catch (error) {
+      output.appendLine(`llm.health failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie LLM health failed: ${formatError(error)}`);
+    }
+  });
+
   const runtimeConfigCommand = vscode.commands.registerCommand('brownie.runtimeConfig', async () => {
     try {
       const config = await runtimeClient.runtimeConfig();
@@ -344,7 +369,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, llmStatusCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -58,6 +58,22 @@ export interface RuntimeDiagnosticsResult {
   diagnostics: RuntimeDiagnostic[];
 }
 
+export interface LlmHealthResult {
+  provider: string;
+  config_source: string;
+  active_profile?: string | null;
+  enabled: boolean;
+  attempted: boolean;
+  healthy: boolean;
+  model: string;
+  base_url?: string | null;
+  checked_at: string;
+  latency_ms?: number | null;
+  status_code?: number | null;
+  reason?: string | null;
+  diagnostics: RuntimeDiagnostic[];
+}
+
 export type TaskStatus = 'Created' | 'Running' | 'Completed' | 'Failed' | 'Cancelled';
 
 export type RuntimeActionName =
@@ -260,6 +276,27 @@ export function isRuntimeDiagnosticsResult(value: unknown): value is RuntimeDiag
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
     isLlmStatusResult(value.llm_status) &&
+    Array.isArray(value.diagnostics) &&
+    value.diagnostics.every(isRuntimeDiagnostic) &&
+    !Object.prototype.hasOwnProperty.call(value, 'api_key')
+  );
+}
+
+export function isLlmHealthResult(value: unknown): value is LlmHealthResult {
+  return (
+    isRecord(value) &&
+    typeof value.provider === 'string' &&
+    typeof value.config_source === 'string' &&
+    (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
+    typeof value.enabled === 'boolean' &&
+    typeof value.attempted === 'boolean' &&
+    typeof value.healthy === 'boolean' &&
+    typeof value.model === 'string' &&
+    (value.base_url === undefined || value.base_url === null || typeof value.base_url === 'string') &&
+    typeof value.checked_at === 'string' &&
+    (value.latency_ms === undefined || value.latency_ms === null || typeof value.latency_ms === 'number') &&
+    (value.status_code === undefined || value.status_code === null || typeof value.status_code === 'number') &&
+    (value.reason === undefined || value.reason === null || typeof value.reason === 'string') &&
     Array.isArray(value.diagnostics) &&
     value.diagnostics.every(isRuntimeDiagnostic) &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -38,6 +38,16 @@ export class RuntimeClient {
 
     if (!isRuntimeDiagnosticsResult(result)) {
       throw new RuntimeProtocolError('runtime.diagnostics.get returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async llmHealth(params: { allow_network: boolean; timeout_ms?: number }): Promise<LlmHealthResult> {
+    const result = await this.call<LlmHealthResult>('llm.health', params);
+
+    if (!isLlmHealthResult(result)) {
+      throw new RuntimeProtocolError('llm.health returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -77,6 +77,28 @@ describe('protocol validation', () => {
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [], api_key: 'secret' })).toBe(false);
+  });
+
+  it('accepts valid llm.health results and rejects invalid health fields', () => {
+    const result = {
+      provider: 'Fake',
+      config_source: 'Default',
+      active_profile: null,
+      enabled: true,
+      attempted: false,
+      healthy: true,
+      model: 'brownie-fake-llm',
+      base_url: null,
+      checked_at: '2026-06-28T00:00:00Z',
+      latency_ms: null,
+      status_code: null,
+      reason: null,
+      diagnostics: [{ severity: 'Info', code: 'PROVIDER_FAKE_HEALTHY', message: 'ok', subject: null }],
+    };
+    expect(isLlmHealthResult(result)).toBe(true);
+    expect(isLlmHealthResult({ ...result, attempted: undefined })).toBe(false);
+    expect(isLlmHealthResult({ ...result, healthy: undefined })).toBe(false);
+    expect(isLlmHealthResult({ ...result, latency_ms: '1' })).toBe(false);
   });
 
   it('accepts valid runtime.config.get results', () => {
@@ -170,6 +192,15 @@ describe('RuntimeClient', () => {
 
     await expect(client.llmStatus()).resolves.toEqual(result);
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'llm.status' }]);
+  });
+
+  it('creates an llm.health request', async () => {
+    const result = { provider: 'Fake', config_source: 'Default', active_profile: null, enabled: true, attempted: false, healthy: true, model: 'brownie-fake-llm', base_url: null, checked_at: '2026-06-28T00:00:00Z', latency_ms: null, status_code: null, reason: null, diagnostics: [] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.llmHealth({ allow_network: false })).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'llm.health', params: { allow_network: false } }]);
   });
 
   it('rejects invalid llm.status results', async () => {


### PR DESCRIPTION
### Motivation
- Provide an explicit, opt-in health probe for configured LLM endpoints so callers can verify readiness without changing `runtime.diagnostics.get` behavior. 
- Ensure network access is strictly guarded by `allow_network` and that API keys, Authorization headers, and query-string secrets are never exposed in results. 
- Keep Fake provider behavior no-network and maintain that health probes do not write to the run ledger. 

### Description
- Added protocol types `LlmHealthParams` and `LlmHealthResult` in `crates/brownie-protocol/src/lib.rs` to model the `llm.health` request and response. 
- Implemented `probe_models` in `OpenAiCompatibleLlmProvider` in `crates/brownie-llm/src/lib.rs` to `GET {base_url}/models` with bearer auth, timeout control, and redacted failure reasons. 
- Added `llm_health_from_workspace` and `handle_llm_health` in `crates/brownie-runtime/src/lib.rs` to select provider/config source, validate `timeout_ms`, respect `allow_network`, and construct redacted `LlmHealthResult` for Fake, OpenAI-compatible, and Unknown providers. 
- Added runtime tests (mock `/models` server) in `crates/brownie-runtime` covering Fake/no-network, OpenAI-compatible `allow_network=false`, timeout bounds, missing config, 2xx/5xx mock responses, and redaction of query-string/API key secrets. 
- Extended VSIX protocol and client (`extensions/brownie-vsix/src/runtime/protocol.ts`, `runtimeClient.ts`) with `LlmHealthResult`/`llmHealth`, added `brownie.llmHealth` command to `package.json`, and added a VSIX command implementation that confirms before probing and prints JSON to the output channel. 
- Added docs `docs/specifications/llm-health-spec-v0.md` and linked Phase 2.5 behavior into existing spec documents. 

### Testing
- Ran `cargo fmt --check` and `cargo check --workspace` which both passed. 
- Ran `cargo test --workspace` and all Rust unit tests (including new Phase 2.5 tests with local mock `/models` server) passed. 
- Ran VSIX checks and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and they all passed. 
- Performed manual smoke runs of the runtime JSON-RPC: Fake provider `llm.health` with `allow_network=false` returned `attempted=false` and `healthy=true`, OpenAI-compatible configured with `allow_network=false` returned `attempted=false` and a `HEALTH_NETWORK_NOT_ALLOWED` warning, and a request with out-of-range `timeout_ms` returned JSON-RPC `-32602` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40abe9519c8328977805b6efe59e87)