### PR TITLE
Add guarded OpenAI-compatible task.run network guard and diagnostics

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -37,6 +37,7 @@ pub struct LlmStatusResult {
     pub reason: Option<String>,
     pub strict: bool,
     pub will_fallback_to_fake: bool,
+    pub task_run_network_allowed: bool,
     pub config_source: String,
     pub active_profile: Option<String>,
 }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -109,6 +109,7 @@ pub struct RuntimeLlmProviderStatus {
     will_fallback_to_fake: bool,
     config_source: RuntimeConfigSource,
     active_profile: Option<String>,
+    task_run_network_allowed: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -134,6 +135,19 @@ pub struct RuntimeLlmProviderError {
     message: String,
 }
 
+fn task_run_network_allowed() -> bool {
+    matches!(
+        std::env::var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK")
+            .ok()
+            .as_deref(),
+        Some("true")
+    )
+}
+
+fn task_run_network_guard_reason() -> &'static str {
+    "real-provider task.run requires BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true"
+}
+
 fn llm_status_result(selection: RuntimeLlmProviderStatus) -> LlmStatusResult {
     LlmStatusResult {
         provider: provider_kind_name(&selection.status.provider).to_string(),
@@ -145,6 +159,7 @@ fn llm_status_result(selection: RuntimeLlmProviderStatus) -> LlmStatusResult {
         will_fallback_to_fake: selection.will_fallback_to_fake,
         config_source: selection.config_source.as_str().to_string(),
         active_profile: selection.active_profile,
+        task_run_network_allowed: selection.task_run_network_allowed,
     }
 }
 
@@ -193,6 +208,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 will_fallback_to_fake: false,
                 config_source: RuntimeConfigSource::Env,
                 active_profile: None,
+                task_run_network_allowed: task_run_network_allowed(),
             },
             OpenAiCompatibleConfigFromEnv::Disabled(status) => RuntimeLlmProviderStatus {
                 status,
@@ -200,6 +216,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 will_fallback_to_fake: !strict,
                 config_source: RuntimeConfigSource::Env,
                 active_profile: None,
+                task_run_network_allowed: task_run_network_allowed(),
             },
         },
         Some("fake") | None => RuntimeLlmProviderStatus {
@@ -218,6 +235,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
             will_fallback_to_fake: !strict,
             config_source: RuntimeConfigSource::Env,
             active_profile: None,
+            task_run_network_allowed: task_run_network_allowed(),
         },
     }
 }
@@ -239,6 +257,7 @@ fn fake_status_with_profile(
         will_fallback_to_fake: false,
         config_source: RuntimeConfigSource::WorkspaceConfig,
         active_profile,
+        task_run_network_allowed: task_run_network_allowed(),
     }
 }
 
@@ -290,6 +309,7 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
                 will_fallback_to_fake: !strict && !enabled,
                 config_source: RuntimeConfigSource::WorkspaceConfig,
                 active_profile: Some(profile_name),
+                task_run_network_allowed: task_run_network_allowed(),
             }
         }
     })
@@ -334,6 +354,15 @@ pub fn llm_provider_from_workspace_for_task_run(
         }
         return Ok(Box::new(FakeLlmProvider));
     }
+    if !selection.strict {
+        return Ok(Box::new(FakeLlmProvider));
+    }
+    if !selection.task_run_network_allowed {
+        return Err(RuntimeLlmProviderError {
+            message: task_run_network_guard_reason().to_string(),
+            status: selection,
+        });
+    }
     let profile_name = selection.active_profile.clone().unwrap_or_default();
     let profile = config
         .llm
@@ -369,6 +398,16 @@ pub fn llm_provider_from_env_for_task_run() -> Result<Box<dyn LlmProvider>, Runt
     match std::env::var("BROWNIE_LLM_PROVIDER").ok().as_deref() {
         Some("openai-compatible") => match OpenAiCompatibleLlmProvider::from_env() {
             OpenAiCompatibleConfigFromEnv::Enabled(config) => {
+                let selection = llm_provider_status_from_env();
+                if !selection.strict {
+                    return Ok(Box::new(FakeLlmProvider));
+                }
+                if !selection.task_run_network_allowed {
+                    return Err(RuntimeLlmProviderError {
+                        message: task_run_network_guard_reason().to_string(),
+                        status: selection,
+                    });
+                }
                 let api_key = std::env::var(&config.api_key_env).unwrap_or_default();
                 Ok(Box::new(OpenAiCompatibleLlmProvider::new(config, api_key)))
             }
@@ -434,6 +473,7 @@ pub fn runtime_diagnostics_from_workspace(
             will_fallback_to_fake: false,
             config_source: RuntimeConfigSource::WorkspaceConfig,
             active_profile: None,
+            task_run_network_allowed: task_run_network_allowed(),
         },
     };
 
@@ -587,6 +627,27 @@ pub fn runtime_diagnostics_from_workspace(
                     }
                 },
             }
+        }
+    }
+
+    if status.status.provider == LlmProviderKind::OpenAiCompatible
+        && status.status.enabled
+        && status.strict
+    {
+        if status.task_run_network_allowed {
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Info,
+                "TASK_RUN_NETWORK_ALLOWED",
+                "OpenAI-compatible task.run network calls are explicitly allowed.",
+                Some("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK"),
+            ));
+        } else {
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Warning,
+                "TASK_RUN_NETWORK_NOT_ALLOWED",
+                task_run_network_guard_reason(),
+                Some("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK"),
+            ));
         }
     }
 
@@ -1014,6 +1075,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                     will_fallback_to_fake: false,
                     config_source: provider_selection.config_source.clone(),
                     active_profile: provider_selection.active_profile.clone(),
+                    task_run_network_allowed: provider_selection.task_run_network_allowed,
                 },
                 &error.to_string(),
                 LedgerEventKind::LlmRequestFailed,
@@ -1097,6 +1159,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                         will_fallback_to_fake: false,
                         config_source: provider_selection.config_source.clone(),
                         active_profile: provider_selection.active_profile.clone(),
+                        task_run_network_allowed: provider_selection.task_run_network_allowed,
                     },
                     &error.to_string(),
                     LedgerEventKind::SecondPassLlmRequestFailed,
@@ -2311,6 +2374,7 @@ mod tests {
         std::env::remove_var("BROWNIE_LLM_API_KEY_ENV");
         std::env::remove_var("BROWNIE_LLM_API_KEY");
         std::env::remove_var("BROWNIE_LLM_STRICT");
+        std::env::remove_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK");
         let response =
             handle_jsonrpc_input_line(r#"{"jsonrpc":"2.0","id":1,"method":"llm.status"}"#).unwrap();
         assert!(response.contains(r#""provider":"Fake""#));
@@ -2318,6 +2382,18 @@ mod tests {
         assert!(response.contains(r#""model":"brownie-fake-llm""#));
         assert!(response.contains(r#""strict":false"#));
         assert!(response.contains(r#""will_fallback_to_fake":false"#));
+        assert!(response.contains(r#""task_run_network_allowed":false"#));
+    }
+
+    #[test]
+    fn llm_status_reports_task_run_network_allowed_when_guard_true() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        std::env::remove_var("BROWNIE_LLM_PROVIDER");
+        std::env::set_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK", "true");
+        let response =
+            handle_jsonrpc_input_line(r#"{"jsonrpc":"2.0","id":1,"method":"llm.status"}"#).unwrap();
+        assert!(response.contains(r#""task_run_network_allowed":true"#));
+        std::env::remove_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK");
     }
 
     #[test]
@@ -2774,6 +2850,7 @@ mod phase_2_2_tests {
                 "BROWNIE_LLM_API_KEY_ENV",
                 "BROWNIE_LLM_API_KEY",
                 "BROWNIE_LLM_STRICT",
+                "BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK",
             ] {
                 std::env::remove_var(key);
             }
@@ -2962,6 +3039,7 @@ mod phase_2_5_tests {
                 "BROWNIE_LLM_API_KEY_ENV",
                 "BROWNIE_LLM_API_KEY",
                 "BROWNIE_LLM_STRICT",
+                "BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK",
             ] {
                 std::env::remove_var(key);
             }
@@ -3130,6 +3208,7 @@ mod phase_2_3_tests {
                 "BROWNIE_LLM_API_KEY_ENV",
                 "BROWNIE_LLM_API_KEY",
                 "BROWNIE_LLM_STRICT",
+                "BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK",
                 "BROWNIE_TEST_LLM_API_KEY",
             ] {
                 std::env::remove_var(key);
@@ -3147,6 +3226,7 @@ mod phase_2_3_tests {
                 "BROWNIE_LLM_API_KEY_ENV",
                 "BROWNIE_LLM_API_KEY",
                 "BROWNIE_LLM_STRICT",
+                "BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK",
                 "BROWNIE_TEST_LLM_API_KEY",
             ] {
                 std::env::remove_var(key);
@@ -3212,18 +3292,57 @@ mod phase_2_3_tests {
         (format!("http://{addr}/v1"), handle)
     }
 
+    fn spawn_mock_two(
+        first_body: &'static str,
+        second_body: &'static str,
+    ) -> (String, thread::JoinHandle<Vec<serde_json::Value>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let handle = thread::spawn(move || {
+            let mut observed = Vec::new();
+            for body in [first_body, second_body] {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut buf = [0_u8; 8192];
+                let n = stream.read(&mut buf).unwrap();
+                let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                let header_end = req.find("\r\n\r\n").unwrap();
+                let (headers, request_body) = req.split_at(header_end + 4);
+                assert!(headers.starts_with("POST /v1/chat/completions HTTP/1.1"));
+                assert!(headers.lines().any(|line| line
+                    .to_ascii_lowercase()
+                    .starts_with("authorization: bearer ")));
+                let json: serde_json::Value = serde_json::from_str(request_body).unwrap();
+                assert_eq!(json["model"], "mock-model");
+                observed.push(json);
+                let response = format!(
+                    "HTTP/1.1 200 OK
+content-type: application/json
+content-length: {}
+
+{}",
+                    body.len(),
+                    body
+                );
+                stream.write_all(response.as_bytes()).unwrap();
+            }
+            observed
+        });
+        (format!("http://{addr}/v1"), handle)
+    }
+
     #[test]
     fn config_profile_openai_mock_task_run_completes_and_is_sanitized() {
         let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
         let _guard = EnvGuard::clear();
         let temp = tempfile::tempdir().unwrap();
-        let (base_url, handle) = spawn_mock(
-            "200 OK",
-            r#"{"choices":[{"message":{"content":"Mock OpenAI-compatible final response."}}]}"#,
+        let (base_url, handle) = spawn_mock_two(
+            r#"{"choices":[{"message":{"content":"Mock LLM first pass.\n\n```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Read README\",\"input\":{\"path\":\"README.md\"}}]}\n```"}}]}"#,
+            r#"{"choices":[{"message":{"content":"Mock LLM final response after tool feedback."}}]}"#,
         );
         write_mock_config(temp.path(), &base_url);
         std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
         std::env::set_var("BROWNIE_TEST_LLM_API_KEY", "test-key");
+        std::env::set_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK", "true");
 
         let status = parse_line(r#"{"jsonrpc":"2.0","id":1,"method":"llm.status"}"#)
             .result
@@ -3245,7 +3364,8 @@ mod phase_2_3_tests {
         }
         assert_eq!(run.result.unwrap()["status"], "Completed");
         let observed = handle.join().unwrap();
-        assert_eq!(observed["model"], "mock-model");
+        assert_eq!(observed.len(), 2);
+        assert_eq!(observed[0]["model"], "mock-model");
 
         let events = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":4,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
@@ -3267,6 +3387,22 @@ mod phase_2_3_tests {
             .any(|e| e["kind"] == "LlmRequestCreated"
                 && e["payload"]["provider"] == "OpenAiCompatible"
                 && e["payload"]["model"] == "mock-model"));
+        assert!(events["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["kind"] == "ToolExecutionCompleted"));
+        assert!(events["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["kind"] == "SecondPassLlmRequestCreated"));
+        assert!(events["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|e| e["kind"] == "SecondPassLlmResponseReceived"));
+        assert!(serialized.contains("Mock LLM final response after tool feedback"));
     }
 
     fn assert_strict_failure(status_line: &str, body: &'static str, expected_reason: &str) {
@@ -3276,6 +3412,7 @@ mod phase_2_3_tests {
         write_mock_config(temp.path(), &base_url);
         std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
         std::env::set_var("BROWNIE_TEST_LLM_API_KEY", "test-key");
+        std::env::set_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK", "true");
         let start = parse_line(r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Fail strictly","mode_id":"orchestrator"}}"#).result.unwrap();
         let task_id = start["task_id"].as_str().unwrap();
         let run_id = start["run_id"].as_str().unwrap();
@@ -3293,6 +3430,36 @@ mod phase_2_3_tests {
         assert!(serialized.contains("LlmRequestFailed"));
         assert!(serialized.contains("TaskFailed"));
         assert!(serialized.contains(expected_reason));
+        assert!(!serialized.contains("test-key"));
+    }
+
+    #[test]
+    fn strict_openai_task_run_without_guard_fails_before_network() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let temp = tempfile::tempdir().unwrap();
+        write_mock_config(temp.path(), "http://127.0.0.1:9/v1");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        std::env::set_var("BROWNIE_TEST_LLM_API_KEY", "test-key");
+
+        let start = parse_line(r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Guard failure","mode_id":"orchestrator"}}"#).result.unwrap();
+        let task_id = start["task_id"].as_str().unwrap();
+        let run_id = start["run_id"].as_str().unwrap();
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        let error = run.error.unwrap();
+        assert_eq!(error.code, -32603);
+        assert!(error.message.contains(task_run_network_guard_reason()));
+        let events = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
+        ))
+        .result
+        .unwrap();
+        let serialized = serde_json::to_string(&events).unwrap();
+        assert!(serialized.contains("LlmRequestFailed"));
+        assert!(serialized.contains("TaskFailed"));
+        assert!(serialized.contains(task_run_network_guard_reason()));
         assert!(!serialized.contains("test-key"));
     }
 

--- a/docs/specifications/llm-health-spec-v0.md
+++ b/docs/specifications/llm-health-spec-v0.md
@@ -27,3 +27,7 @@ When the selected provider is OpenAI-compatible, enabled, and `allow_network=tru
 ## Redaction and persistence
 
 `llm.health` is a global inspection API, not a task run event. It does not write to the run ledger. Health results, reasons, diagnostics, errors, status, and inspection data must not expose API keys, Authorization headers, Bearer tokens, or URL query-string secrets. Health responses contain only high-level metadata such as provider, model, redacted base URL, status code, latency, and redacted reason.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -59,3 +59,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.5 LLM health
 
 Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/docs/specifications/real-provider-task-run-smoke-spec-v0.md
+++ b/docs/specifications/real-provider-task-run-smoke-spec-v0.md
@@ -1,0 +1,18 @@
+# Real-provider task.run smoke spec v0
+
+Phase 2.6 adds a guarded `task.run` smoke path for the OpenAI-compatible provider. The runtime never contacts a real provider during `task.run` unless the selected provider is OpenAI-compatible, the provider is enabled, `strict=true`, and `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is explicitly set. The default value is false.
+
+The explicit guard exists because `task.run` can send task context and tool feedback prompts to an LLM endpoint. `llm.health` already has a per-request `allow_network` flag; `task.run` is guarded by environment opt-in so automated tests, editor commands, and local runs cannot accidentally contact a real endpoint.
+
+Without the guard, strict OpenAI-compatible `task.run` fails before the first LLM request with `real-provider task.run requires BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true`; non-strict OpenAI-compatible configurations fall back to Fake. Fake remains the default provider.
+
+Mock smoke coverage uses a local OpenAI-compatible server implementing `/v1/chat/completions` and `/v1/models`. The chat endpoint verifies an Authorization header is present without logging its value, returns a first-pass `workspace.read` intent, and returns a second-pass final response after tool feedback.
+
+Optional local endpoint smoke:
+
+1. Configure `.brownie/config.json` with an OpenAI-compatible strict profile.
+2. Export `BROWNIE_LLM_API_KEY` and `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true`.
+3. Run `llm.health` with `allow_network=true` to probe `/models`.
+4. Run `task.start`, `task.run`, and `run.inspect` to verify provider metadata.
+
+Phase 2.6 does not add streaming, workspace.write, file write, patch apply, process execution, network tools, service control, destructive operations, subtask spawning, AgentModes YAML parsing, ModePack activation, Qdrant, llama-server lifecycle control, or indexing. Ledgers, inspection, diagnostics, status, health, and errors must not expose API keys, Authorization headers, Bearer tokens, query-string secrets, full prompts, full provider responses, or full README content.

--- a/docs/specifications/runtime-config-spec-v0.md
+++ b/docs/specifications/runtime-config-spec-v0.md
@@ -69,3 +69,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.5 LLM health
 
 Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/docs/specifications/runtime-diagnostics-spec-v0.md
+++ b/docs/specifications/runtime-diagnostics-spec-v0.md
@@ -32,3 +32,7 @@ Diagnostics must never return API key values, Authorization headers, Bearer toke
 ## Phase 2.5 LLM health
 
 Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -242,3 +242,7 @@ Unknown `BROWNIE_LLM_PROVIDER` values must not silently become Fake. Status repo
 ## Phase 2.5 LLM health
 
 Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/specifications/llm-health-spec-v0.md`. `runtime.diagnostics.get` remains read-only and no-network. Endpoint readiness checks are only performed by `llm.health` when `allow_network=true`; Fake health remains no-network. OpenAI-compatible health uses `GET {base_url}/models`, does not persist response bodies, does not write run ledgers, and redacts API keys, Authorization/Bearer values, and query-string secrets.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -159,3 +159,7 @@ If OpenAI-compatible configuration is incomplete, `BROWNIE_LLM_STRICT=false` (de
 ## Phase 2.2 task LLM provider selection
 
 `task.run` resolves its LLM provider using the same priority as `llm.status`: explicit environment override, workspace `.brownie/config.json` active profile, then default Fake. Runtime permissions remain authoritative over LLM instructions, and Phase 2.2 does not add streaming or new tool execution capabilities.
+
+## Phase 2.6 real-provider task.run guard
+
+`BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -30,6 +30,7 @@ export function activate(context: vscode.ExtensionContext): void {
       output.appendLine(`base_url: ${status.base_url ?? 'null'}`);
       output.appendLine(`strict: ${String(status.strict)}`);
       output.appendLine(`will_fallback_to_fake: ${String(status.will_fallback_to_fake)}`);
+      output.appendLine(`task_run_network_allowed: ${String(status.task_run_network_allowed)}`);
       output.appendLine(`reason: ${status.reason ?? 'null'}`);
       output.show(true);
       await vscode.window.showInformationMessage(

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -31,6 +31,7 @@ export interface LlmStatusResult {
   reason?: string | null;
   strict: boolean;
   will_fallback_to_fake: boolean;
+  task_run_network_allowed: boolean;
   config_source: string;
   active_profile?: string | null;
 }
@@ -253,6 +254,7 @@ export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
     (value.reason === undefined || value.reason === null || typeof value.reason === 'string') &&
     typeof value.strict === 'boolean' &&
     typeof value.will_fallback_to_fake === 'boolean' &&
+    typeof value.task_run_network_allowed === 'boolean' &&
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -63,16 +63,16 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid llm.status results and rejects missing required fields', () => {
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, config_source: 'Env', active_profile: null })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, config_source: 'Default' })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Env', active_profile: null })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default' })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true })).toBe(false);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, active_profile: null })).toBe(false);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', api_key: 'secret' })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, active_profile: null })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', api_key: 'secret' })).toBe(false);
   });
 
   it('accepts valid runtime diagnostics results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
@@ -102,7 +102,7 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid runtime.config.get results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
     expect(isRuntimeConfigGetResult({ config_source: 'Default', config_path: null, active_profile: null, llm_status })).toBe(true);
     expect(isRuntimeConfigGetResult({ config_source: 'Default', llm_status, api_key: 'secret' })).toBe(false);
   });
@@ -186,7 +186,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates an llm.status request', async () => {
-    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
 
@@ -211,7 +211,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.diagnostics.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
     const result = { config_source: 'Default', active_profile: null, llm_status, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
@@ -220,7 +220,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.config.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
     const result = { config_source: 'Default', config_path: null, active_profile: null, llm_status };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);


### PR DESCRIPTION
### Motivation
- Enforce an explicit opt-in for real OpenAI-compatible `task.run` network calls to prevent accidental external LLM requests and to make provider selection/verifiability explicit. 
- Surface the guard state in `llm.status`/`runtime.config.get` and `runtime.diagnostics.get` so clients and CI can observe whether real-provider `task.run` is allowed.

### Description
- Added a new environment guard `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK` and helper functions `task_run_network_allowed()` and `task_run_network_guard_reason()` in the runtime to centralize guard semantics. 
- Extended `LlmStatusResult` with `task_run_network_allowed: bool` and propagated the new field through `llm.status`, `runtime.config.get`, and diagnostics generation. 
- Updated provider selection for `task.run` so OpenAI-compatible is used only when provider is enabled, `strict=true`, and the guard is true; otherwise strict+guard=false causes a pre-network failure (writes `LlmRequestFailed` + `TaskFailed`) while non-strict falls back to Fake. 
- Added diagnostics codes `TASK_RUN_NETWORK_ALLOWED` and `TASK_RUN_NETWORK_NOT_ALLOWED` and emit an Info or Warning for strict enabled OpenAI-compatible profiles depending on the guard. 
- Implemented deterministic mock OpenAI-compatible server helpers and tests that exercise first-pass tool intent + second-pass flow, provider failure (500, malformed JSON, missing choices), and the guard failure path. 
- Updated VSIX protocol types/validator (`LlmStatusResult`) and `Brownie: LLM Status` output to include and display `task_run_network_allowed`. 
- Added documentation `docs/specifications/real-provider-task-run-smoke-spec-v0.md` and updated relevant spec files to describe the Phase 2.6 guard semantics.

### Testing
- Ran Rust formatting and static checks: `cargo fmt --check` and `cargo check --workspace` which completed successfully. 
- Ran Rust unit tests: `cargo test --workspace` and all runtime unit tests passed (53 tests in runtime and full workspace tests passed). 
- Ran VSIX checks and tests: `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build` which completed successfully (extension tests: 40 tests passed). 
- Performed the documented manual smoke test for guard=false `llm.status` which returned `task_run_network_allowed:false` as expected; optional guarded local endpoint smoke was not performed because no live local OpenAI-compatible endpoint was available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40b63479e0832887bf00d3a822ac0e)