### PR TITLE
Add LLM request budget enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ name = "brownie-config"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "brownie-llm",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -1,7 +1,9 @@
 //! Agent loop state-machine crate.
 
 use brownie_context::{PromptBuildInput, PromptBuilder, PromptRole, PromptView};
-use brownie_llm::{FakeLlmProvider, LlmMessage, LlmProvider, LlmRequest, LlmResponse};
+use brownie_llm::{
+    FakeLlmProvider, LlmMessage, LlmProvider, LlmRequest, LlmRequestBudget, LlmResponse,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AgentLoopState {
@@ -65,8 +67,9 @@ impl AgentLoop {
     pub fn run_with_llm(
         prompt_input: PromptBuildInput,
         provider: &dyn LlmProvider,
+        budget: &LlmRequestBudget,
     ) -> anyhow::Result<AgentLoopRunOutput> {
-        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider)?;
+        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider, budget)?;
         Ok(AgentLoopRunOutput {
             final_state: AgentLoopState::Completed,
             prompt,
@@ -79,8 +82,9 @@ impl AgentLoop {
     pub fn run_second_pass_with_llm(
         prompt_input: PromptBuildInput,
         provider: &dyn LlmProvider,
+        budget: &LlmRequestBudget,
     ) -> anyhow::Result<AgentLoopSecondPassOutput> {
-        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider)?;
+        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider, budget)?;
         Ok(AgentLoopSecondPassOutput {
             final_state: AgentLoopState::Completed,
             prompt,
@@ -91,13 +95,14 @@ impl AgentLoop {
     }
 
     pub fn run_with_fake_llm(prompt_input: PromptBuildInput) -> AgentLoopRunOutput {
-        Self::run_with_llm(prompt_input, &FakeLlmProvider).expect("fake provider should not fail")
+        Self::run_with_llm(prompt_input, &FakeLlmProvider, &LlmRequestBudget::default())
+            .expect("fake provider should not fail")
     }
 
     pub fn run_second_pass_with_fake_llm(
         prompt_input: PromptBuildInput,
     ) -> AgentLoopSecondPassOutput {
-        Self::run_second_pass_with_llm(prompt_input, &FakeLlmProvider)
+        Self::run_second_pass_with_llm(prompt_input, &FakeLlmProvider, &LlmRequestBudget::default())
             .expect("fake provider should not fail")
     }
 }
@@ -105,6 +110,7 @@ impl AgentLoop {
 fn run_llm(
     prompt_input: PromptBuildInput,
     provider: &dyn LlmProvider,
+    budget: &LlmRequestBudget,
 ) -> anyhow::Result<(String, PromptView, LlmRequest, LlmResponse)> {
     let task_id = prompt_input.task_id.clone();
     let prompt = PromptBuilder::build(prompt_input);
@@ -119,8 +125,33 @@ fn run_llm(
             })
             .collect(),
     };
-    let llm_response = provider.complete(&llm_request)?;
+    validate_request_budget(&llm_request, budget)?;
+    let llm_response = provider.complete(&llm_request, budget)?;
     Ok((task_id, prompt, llm_request, llm_response))
+}
+
+fn validate_request_budget(request: &LlmRequest, budget: &LlmRequestBudget) -> anyhow::Result<()> {
+    let message_count = request.messages.len();
+    if message_count > budget.max_messages {
+        anyhow::bail!(
+            "LLM request budget exceeded: message count {} > max_messages {}",
+            message_count,
+            budget.max_messages
+        );
+    }
+    let prompt_chars: usize = request
+        .messages
+        .iter()
+        .map(|m| m.content.chars().count())
+        .sum();
+    if prompt_chars > budget.max_prompt_chars {
+        anyhow::bail!(
+            "LLM request budget exceeded: prompt chars {} > max_prompt_chars {}",
+            prompt_chars,
+            budget.max_prompt_chars
+        );
+    }
+    Ok(())
 }
 
 fn prompt_role_to_llm_role(role: &PromptRole) -> &'static str {

--- a/crates/brownie-config/Cargo.toml
+++ b/crates/brownie-config/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]
+brownie-llm = { path = "../brownie-llm" }
 anyhow.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/brownie-config/src/lib.rs
+++ b/crates/brownie-config/src/lib.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use brownie_llm::{validate_llm_request_budget, LlmRequestBudget};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -29,6 +30,7 @@ pub struct LlmConfig {
 pub enum LlmProfile {
     Fake {
         model: Option<String>,
+        budget: Option<LlmRequestBudgetConfig>,
     },
     #[serde(rename = "openai-compatible")]
     OpenAiCompatible {
@@ -36,10 +38,36 @@ pub enum LlmProfile {
         model: String,
         api_key_env: Option<String>,
         strict: Option<bool>,
+        budget: Option<LlmRequestBudgetConfig>,
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct LlmRequestBudgetConfig {
+    pub max_prompt_chars: Option<usize>,
+    pub max_messages: Option<usize>,
+    pub request_timeout_ms: Option<u64>,
+    pub response_preview_chars: Option<usize>,
+}
+
+impl LlmRequestBudgetConfig {
+    pub fn apply_to(&self, mut budget: LlmRequestBudget) -> LlmRequestBudget {
+        if let Some(v) = self.max_prompt_chars {
+            budget.max_prompt_chars = v;
+        }
+        if let Some(v) = self.max_messages {
+            budget.max_messages = v;
+        }
+        if let Some(v) = self.request_timeout_ms {
+            budget.request_timeout_ms = v;
+        }
+        if let Some(v) = self.response_preview_chars {
+            budget.response_preview_chars = v;
+        }
+        budget
+    }
+}
+
 pub struct RuntimeConfigLoadResult {
     pub config: Option<BrownieConfig>,
     pub path: PathBuf,
@@ -75,6 +103,20 @@ pub fn validate_config(config: &BrownieConfig) -> Result<()> {
         };
         if !llm.profiles.contains_key(active) {
             bail!("active_profile references unknown profile: {active}");
+        }
+    }
+    if let Some(llm) = &config.llm {
+        for (name, profile) in &llm.profiles {
+            let budget = match profile {
+                LlmProfile::Fake { budget, .. } | LlmProfile::OpenAiCompatible { budget, .. } => {
+                    budget
+                }
+            };
+            if let Some(budget) = budget {
+                let resolved = budget.apply_to(LlmRequestBudget::default());
+                validate_llm_request_budget(&resolved)
+                    .map_err(|e| anyhow::anyhow!("invalid llm budget for profile {name}: {e}"))?;
+            }
         }
     }
     Ok(())

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -12,6 +12,41 @@ pub const OPENAI_COMPATIBLE_API_VERSION: &str = "v1";
 pub const FAKE_LLM_MODEL: &str = "brownie-fake-llm";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmRequestBudget {
+    pub max_prompt_chars: usize,
+    pub max_messages: usize,
+    pub request_timeout_ms: u64,
+    pub response_preview_chars: usize,
+}
+
+impl Default for LlmRequestBudget {
+    fn default() -> Self {
+        Self {
+            max_prompt_chars: 120_000,
+            max_messages: 64,
+            request_timeout_ms: 30_000,
+            response_preview_chars: 2_000,
+        }
+    }
+}
+
+pub fn validate_llm_request_budget(budget: &LlmRequestBudget) -> Result<(), String> {
+    if !(1_000..=1_000_000).contains(&budget.max_prompt_chars) {
+        return Err("max_prompt_chars must be between 1000 and 1000000".to_string());
+    }
+    if !(1..=256).contains(&budget.max_messages) {
+        return Err("max_messages must be between 1 and 256".to_string());
+    }
+    if !(1_000..=300_000).contains(&budget.request_timeout_ms) {
+        return Err("request_timeout_ms must be between 1000 and 300000".to_string());
+    }
+    if !(100..=20_000).contains(&budget.response_preview_chars) {
+        return Err("response_preview_chars must be between 100 and 20000".to_string());
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmRequest {
     pub model: String,
     pub messages: Vec<LlmMessage>,
@@ -46,7 +81,11 @@ pub struct LlmProviderStatus {
 
 pub trait LlmProvider {
     fn status(&self) -> LlmProviderStatus;
-    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse>;
+    fn complete(
+        &self,
+        request: &LlmRequest,
+        budget: &LlmRequestBudget,
+    ) -> anyhow::Result<LlmResponse>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -136,7 +175,11 @@ impl LlmProvider for FakeLlmProvider {
         }
     }
 
-    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse> {
+    fn complete(
+        &self,
+        request: &LlmRequest,
+        _budget: &LlmRequestBudget,
+    ) -> anyhow::Result<LlmResponse> {
         Ok(FakeLlm::complete(request))
     }
 }
@@ -145,7 +188,6 @@ impl LlmProvider for FakeLlmProvider {
 pub struct OpenAiCompatibleLlmProvider {
     config: OpenAiCompatibleConfig,
     api_key: String,
-    timeout: Duration,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -159,11 +201,7 @@ pub struct LlmHealthProbeResult {
 
 impl OpenAiCompatibleLlmProvider {
     pub fn new(config: OpenAiCompatibleConfig, api_key: String) -> Self {
-        Self {
-            config,
-            api_key,
-            timeout: Duration::from_secs(30),
-        }
+        Self { config, api_key }
     }
 
     pub fn from_env() -> OpenAiCompatibleConfigFromEnv {
@@ -265,7 +303,11 @@ impl LlmProvider for OpenAiCompatibleLlmProvider {
         }
     }
 
-    fn complete(&self, request: &LlmRequest) -> anyhow::Result<LlmResponse> {
+    fn complete(
+        &self,
+        request: &LlmRequest,
+        budget: &LlmRequestBudget,
+    ) -> anyhow::Result<LlmResponse> {
         let base_url = redact_secret(&self.config.base_url);
         let failure_prefix = || {
             format!(
@@ -279,7 +321,7 @@ impl LlmProvider for OpenAiCompatibleLlmProvider {
         );
         let client = reqwest::blocking::Client::builder()
             .no_proxy()
-            .timeout(self.timeout)
+            .timeout(Duration::from_millis(budget.request_timeout_ms))
             .build()
             .map_err(|e| {
                 anyhow!(
@@ -425,7 +467,10 @@ mod tests {
                 content: "user".into(),
             }],
         };
-        let content = provider.complete(&request).unwrap().content;
+        let content = provider
+            .complete(&request, &LlmRequestBudget::default())
+            .unwrap()
+            .content;
         assert!(content.starts_with("Fake LLM completed request with 1 messages."));
     }
 

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -29,6 +29,14 @@ pub struct JsonRpcError {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LlmRequestBudgetSummary {
+    pub max_prompt_chars: usize,
+    pub max_messages: usize,
+    pub request_timeout_ms: u64,
+    pub response_preview_chars: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmStatusResult {
     pub provider: String,
     pub enabled: bool,
@@ -40,6 +48,7 @@ pub struct LlmStatusResult {
     pub task_run_network_allowed: bool,
     pub config_source: String,
     pub active_profile: Option<String>,
+    pub budget: LlmRequestBudgetSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -4,23 +4,27 @@ use brownie_agent_loop::{AgentLoop, AgentLoopState};
 use brownie_agentmodes::{
     BuiltinModeRegistry, CompiledModePolicy, RuntimeAction, RuntimePermissionGate,
 };
-use brownie_config::{BrownieConfig, LlmProfile, RuntimeConfigLoader, CONFIG_RELATIVE_PATH};
+use brownie_config::{
+    BrownieConfig, LlmProfile, LlmRequestBudgetConfig, RuntimeConfigLoader, CONFIG_RELATIVE_PATH,
+};
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_llm::{
-    redact_secret, FakeLlmProvider, LlmProvider, LlmProviderKind, LlmProviderStatus,
-    OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv, OpenAiCompatibleLlmProvider,
+    redact_secret, validate_llm_request_budget, FakeLlmProvider, LlmProvider, LlmProviderKind,
+    LlmProviderStatus, LlmRequestBudget, OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv,
+    OpenAiCompatibleLlmProvider,
 };
 use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
-    LlmHealthParams, LlmHealthResult, LlmStatusResult, ModeGetParams, ModeListResult,
-    ModePermissionsSummary, ModeSummary, PermissionCheckParams, PermissionCheckResult,
-    RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary,
-    RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult,
-    RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult,
-    TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
-    ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary,
-    ToolIntentParseParams, ToolIntentParseResult, ToolIntentRejectedSummary, ToolListResult,
-    ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
+    LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
+    ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
+    PermissionCheckResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
+    RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic,
+    RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams,
+    TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams,
+    TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus,
+    ToolIntentDecisionSummary, ToolIntentParseParams, ToolIntentParseResult,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -110,6 +114,7 @@ pub struct RuntimeLlmProviderStatus {
     config_source: RuntimeConfigSource,
     active_profile: Option<String>,
     task_run_network_allowed: bool,
+    budget: LlmRequestBudget,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -160,7 +165,76 @@ fn llm_status_result(selection: RuntimeLlmProviderStatus) -> LlmStatusResult {
         config_source: selection.config_source.as_str().to_string(),
         active_profile: selection.active_profile,
         task_run_network_allowed: selection.task_run_network_allowed,
+        budget: budget_summary(&selection.budget),
     }
+}
+
+fn budget_summary(budget: &LlmRequestBudget) -> LlmRequestBudgetSummary {
+    LlmRequestBudgetSummary {
+        max_prompt_chars: budget.max_prompt_chars,
+        max_messages: budget.max_messages,
+        request_timeout_ms: budget.request_timeout_ms,
+        response_preview_chars: budget.response_preview_chars,
+    }
+}
+
+fn budget_from_profile(
+    profile_budget: Option<&LlmRequestBudgetConfig>,
+) -> Result<LlmRequestBudget, String> {
+    let mut budget = LlmRequestBudget::default();
+    if let Some(profile_budget) = profile_budget {
+        budget = profile_budget.apply_to(budget);
+    }
+    apply_env_budget_overrides(budget)
+}
+
+fn env_budget_override_present() -> bool {
+    [
+        "BROWNIE_LLM_MAX_PROMPT_CHARS",
+        "BROWNIE_LLM_MAX_MESSAGES",
+        "BROWNIE_LLM_REQUEST_TIMEOUT_MS",
+        "BROWNIE_LLM_RESPONSE_PREVIEW_CHARS",
+    ]
+    .iter()
+    .any(|key| {
+        std::env::var(key)
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .is_some()
+    })
+}
+
+fn apply_env_budget_overrides(mut budget: LlmRequestBudget) -> Result<LlmRequestBudget, String> {
+    if let Ok(v) = std::env::var("BROWNIE_LLM_MAX_PROMPT_CHARS") {
+        if !v.trim().is_empty() {
+            budget.max_prompt_chars = v
+                .parse()
+                .map_err(|_| "invalid BROWNIE_LLM_MAX_PROMPT_CHARS".to_string())?;
+        }
+    }
+    if let Ok(v) = std::env::var("BROWNIE_LLM_MAX_MESSAGES") {
+        if !v.trim().is_empty() {
+            budget.max_messages = v
+                .parse()
+                .map_err(|_| "invalid BROWNIE_LLM_MAX_MESSAGES".to_string())?;
+        }
+    }
+    if let Ok(v) = std::env::var("BROWNIE_LLM_REQUEST_TIMEOUT_MS") {
+        if !v.trim().is_empty() {
+            budget.request_timeout_ms = v
+                .parse()
+                .map_err(|_| "invalid BROWNIE_LLM_REQUEST_TIMEOUT_MS".to_string())?;
+        }
+    }
+    if let Ok(v) = std::env::var("BROWNIE_LLM_RESPONSE_PREVIEW_CHARS") {
+        if !v.trim().is_empty() {
+            budget.response_preview_chars = v
+                .parse()
+                .map_err(|_| "invalid BROWNIE_LLM_RESPONSE_PREVIEW_CHARS".to_string())?;
+        }
+    }
+    validate_llm_request_budget(&budget)?;
+    Ok(budget)
 }
 
 fn provider_kind_name(kind: &LlmProviderKind) -> &'static str {
@@ -174,6 +248,9 @@ fn provider_kind_name(kind: &LlmProviderKind) -> &'static str {
 pub fn llm_provider_status_from_workspace(
     workspace_root: &std::path::Path,
 ) -> Result<RuntimeLlmProviderStatus, String> {
+    if env_budget_override_present() {
+        budget_from_profile(None)?;
+    }
     if std::env::var("BROWNIE_LLM_PROVIDER")
         .ok()
         .filter(|v| !v.trim().is_empty())
@@ -209,6 +286,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 config_source: RuntimeConfigSource::Env,
                 active_profile: None,
                 task_run_network_allowed: task_run_network_allowed(),
+                budget: budget_from_profile(None).unwrap_or_default(),
             },
             OpenAiCompatibleConfigFromEnv::Disabled(status) => RuntimeLlmProviderStatus {
                 status,
@@ -217,6 +295,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 config_source: RuntimeConfigSource::Env,
                 active_profile: None,
                 task_run_network_allowed: task_run_network_allowed(),
+                budget: budget_from_profile(None).unwrap_or_default(),
             },
         },
         Some("fake") | None => RuntimeLlmProviderStatus {
@@ -236,6 +315,7 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
             config_source: RuntimeConfigSource::Env,
             active_profile: None,
             task_run_network_allowed: task_run_network_allowed(),
+            budget: budget_from_profile(None).unwrap_or_default(),
         },
     }
 }
@@ -258,6 +338,7 @@ fn fake_status_with_profile(
         config_source: RuntimeConfigSource::WorkspaceConfig,
         active_profile,
         task_run_network_allowed: task_run_network_allowed(),
+        budget: budget_from_profile(None).unwrap_or_default(),
     }
 }
 
@@ -271,8 +352,9 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
         .and_then(|l| l.profiles.get(&profile_name))
         .ok_or_else(|| "active_profile references unknown profile".to_string())?;
     Ok(match profile {
-        LlmProfile::Fake { model } => {
+        LlmProfile::Fake { model, budget } => {
             let mut s = fake_status_with_profile(Some(profile_name), false);
+            s.budget = budget_from_profile(budget.as_ref())?;
             if let Some(model) = model {
                 s.status.model = model.clone();
             }
@@ -283,6 +365,7 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
             model,
             api_key_env,
             strict,
+            budget,
         } => {
             let api_key_env = api_key_env
                 .clone()
@@ -310,6 +393,7 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
                 config_source: RuntimeConfigSource::WorkspaceConfig,
                 active_profile: Some(profile_name),
                 task_run_network_allowed: task_run_network_allowed(),
+                budget: budget_from_profile(budget.as_ref())?,
             }
         }
     })
@@ -474,8 +558,47 @@ pub fn runtime_diagnostics_from_workspace(
             config_source: RuntimeConfigSource::WorkspaceConfig,
             active_profile: None,
             task_run_network_allowed: task_run_network_allowed(),
+            budget: budget_from_profile(None).unwrap_or_default(),
         },
     };
+
+    match llm_provider_status_from_workspace(workspace_root) {
+        Ok(selection) => {
+            let code = if env_budget_override_present() {
+                "LLM_BUDGET_ENV_OVERRIDE"
+            } else if selection.config_source == RuntimeConfigSource::WorkspaceConfig {
+                "LLM_BUDGET_PROFILE"
+            } else {
+                "LLM_BUDGET_DEFAULT"
+            };
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Info,
+                code,
+                format!(
+                    "LLM request budget: max_prompt_chars={} max_messages={} request_timeout_ms={} response_preview_chars={}",
+                    selection.budget.max_prompt_chars, selection.budget.max_messages, selection.budget.request_timeout_ms, selection.budget.response_preview_chars
+                ),
+                None,
+            ));
+        }
+        Err(error)
+            if error.contains("BROWNIE_LLM_")
+                || error.contains("budget")
+                || error.contains("max_")
+                || error.contains("request_timeout_ms")
+                || error.contains("response_preview_chars") =>
+        {
+            diagnostics.push(diagnostic(
+                DiagnosticSeverity::Error,
+                "LLM_BUDGET_INVALID",
+                format!("Invalid LLM request budget: {}.", redact_secret(&error)),
+                None,
+            ));
+            status.status.enabled = false;
+            status.status.reason = Some("invalid LLM request budget".to_string());
+        }
+        Err(_) => {}
+    }
 
     let strict_env = matches!(
         std::env::var("BROWNIE_LLM_STRICT").ok().as_deref(),
@@ -869,18 +992,21 @@ fn handle_llm_health(id: Value, params: Option<Value>) -> JsonRpcResponse<Value>
         Ok(params) => params,
         Err(message) => return error_response(id, -32602, &message),
     };
-    let timeout_ms = params.timeout_ms.unwrap_or(5000);
-    if !(1000..=30000).contains(&timeout_ms) {
-        return error_response(
-            id,
-            -32602,
-            "invalid params: timeout_ms must be between 1000 and 30000",
-        );
-    }
     let store = match BrownieStore::from_env_or_cwd() {
         Ok(store) => store,
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
+    let default_timeout_ms = llm_provider_status_from_workspace(store.workspace_root())
+        .map(|selection| selection.budget.request_timeout_ms)
+        .unwrap_or(30_000);
+    let timeout_ms = params.timeout_ms.unwrap_or(default_timeout_ms);
+    if !(1000..=300000).contains(&timeout_ms) {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: timeout_ms must be between 1000 and 300000",
+        );
+    }
     match llm_health_from_workspace(
         store.workspace_root(),
         params.allow_network,
@@ -1062,7 +1188,11 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         }
     };
     let provider_strict = provider_selection.strict;
-    let result = match AgentLoop::run_with_llm(prompt_input, provider.as_ref()) {
+    let result = match AgentLoop::run_with_llm(
+        prompt_input,
+        provider.as_ref(),
+        &provider_selection.budget,
+    ) {
         Ok(result) => result,
         Err(error) => {
             return fail_llm_request(
@@ -1076,6 +1206,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                     config_source: provider_selection.config_source.clone(),
                     active_profile: provider_selection.active_profile.clone(),
                     task_run_network_allowed: provider_selection.task_run_network_allowed,
+                    budget: provider_selection.budget.clone(),
                 },
                 &error.to_string(),
                 LedgerEventKind::LlmRequestFailed,
@@ -1088,7 +1219,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         LedgerEventKind::PromptBuilt,
         Some(json!({
             "message_count": result.prompt.messages.len(),
-            "prompt_preview": preview_prompt(&result.prompt),
+            "prompt_preview": preview_prompt(&result.prompt, provider_selection.budget.response_preview_chars),
+            "max_prompt_chars": provider_selection.budget.max_prompt_chars,
         })),
     ) {
         return error_response(id, -32603, &format!("internal error: {error}"));
@@ -1125,7 +1257,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         LedgerEventKind::LlmResponseReceived,
         Some(json!({
             "provider": provider_kind_name(&provider_status.provider),
-            "content_preview": preview(&result.llm_response.content),
+            "content_preview": preview_with_limit(&result.llm_response.content, provider_selection.budget.response_preview_chars),
+            "response_preview_chars": provider_selection.budget.response_preview_chars,
         })),
     ) {
         return error_response(id, -32603, &format!("internal error: {error}"));
@@ -1146,6 +1279,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         let second_pass = match AgentLoop::run_second_pass_with_llm(
             second_pass_prompt_input,
             provider.as_ref(),
+            &provider_selection.budget,
         ) {
             Ok(result) => result,
             Err(error) => {
@@ -1160,6 +1294,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                         config_source: provider_selection.config_source.clone(),
                         active_profile: provider_selection.active_profile.clone(),
                         task_run_network_allowed: provider_selection.task_run_network_allowed,
+                        budget: provider_selection.budget.clone(),
                     },
                     &error.to_string(),
                     LedgerEventKind::SecondPassLlmRequestFailed,
@@ -1171,7 +1306,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             LedgerEventKind::SecondPassPromptBuilt,
             Some(json!({
                 "message_count": second_pass.prompt.messages.len(),
-                "prompt_preview": preview_prompt(&second_pass.prompt),
+                "prompt_preview": preview_prompt(&second_pass.prompt, provider_selection.budget.response_preview_chars),
+                    "max_prompt_chars": provider_selection.budget.max_prompt_chars,
             })),
         ) {
             return error_response(id, -32603, &format!("internal error: {error}"));
@@ -1194,7 +1330,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             LedgerEventKind::SecondPassLlmResponseReceived,
             Some(json!({
                 "provider": provider_kind_name(&provider_status.provider),
-                "content_preview": preview(&second_pass.llm_response.content),
+                "content_preview": preview_with_limit(&second_pass.llm_response.content, provider_selection.budget.response_preview_chars),
+                "response_preview_chars": provider_selection.budget.response_preview_chars,
             })),
         ) {
             return error_response(id, -32603, &format!("internal error: {error}"));
@@ -2008,19 +2145,18 @@ fn runtime_action_name(action: &RuntimeAction) -> RuntimeActionName {
     }
 }
 
-fn preview_prompt(prompt: &brownie_context::PromptView) -> String {
+fn preview_prompt(prompt: &brownie_context::PromptView, max_chars: usize) -> String {
     let joined = prompt
         .messages
         .iter()
         .map(|message| message.content.as_str())
         .collect::<Vec<_>>()
         .join("\n---\n");
-    preview(&joined)
+    preview_with_limit(&joined, max_chars)
 }
 
-fn preview(content: &str) -> String {
-    const MAX_PREVIEW_CHARS: usize = 200;
-    content.chars().take(MAX_PREVIEW_CHARS).collect()
+fn preview_with_limit(content: &str, max_chars: usize) -> String {
+    content.chars().take(max_chars).collect()
 }
 
 fn preview_tool_output(content: &str) -> String {
@@ -3121,7 +3257,7 @@ mod phase_2_5_tests {
         );
         assert_eq!(below.error.unwrap().code, -32602);
         let above = super::tests::parse_line(
-            r#"{"jsonrpc":"2.0","id":1,"method":"llm.health","params":{"allow_network":true,"timeout_ms":30001}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"llm.health","params":{"allow_network":true,"timeout_ms":300001}}"#,
         );
         assert_eq!(above.error.unwrap().code, -32602);
     }

--- a/docs/specifications/llm-health-spec-v0.md
+++ b/docs/specifications/llm-health-spec-v0.md
@@ -31,3 +31,7 @@ When the selected provider is OpenAI-compatible, enabled, and `allow_network=tru
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -63,3 +63,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/llm-request-budget-spec-v0.md
+++ b/docs/specifications/llm-request-budget-spec-v0.md
@@ -1,0 +1,33 @@
+# LLM Request Budget Spec v0
+
+Brownie enforces an LLM request budget at runtime before provider calls.
+
+## Schema
+
+Profiles may include `budget` with these optional fields:
+
+- `max_prompt_chars` (default `120000`, hard bounds `1000..=1000000`)
+- `max_messages` (default `64`, hard bounds `1..=256`)
+- `request_timeout_ms` (default `30000`, hard bounds `1000..=300000`)
+- `response_preview_chars` (default `2000`, hard bounds `100..=20000`)
+
+Unspecified profile fields use defaults.
+
+## Environment overrides
+
+Environment variables override profile and default values:
+
+- `BROWNIE_LLM_MAX_PROMPT_CHARS`
+- `BROWNIE_LLM_MAX_MESSAGES`
+- `BROWNIE_LLM_REQUEST_TIMEOUT_MS`
+- `BROWNIE_LLM_RESPONSE_PREVIEW_CHARS`
+
+Priority is env override, then active profile budget, then default budget.
+
+## Runtime behavior
+
+Before an LLM provider call, Brownie checks message count and total prompt characters. Budget failures do not call the provider. The task fails with `LlmRequestFailed` and `TaskFailed` ledger events and a high-level redacted JSON-RPC error.
+
+Prompt and response ledger payloads store previews only. Full prompt text and full provider responses are not persisted. Response preview length is controlled by `response_preview_chars`; prompt preview payloads include `max_prompt_chars`.
+
+`llm.status`, `runtime.config.get`, and diagnostics expose budget summaries. `llm.health` uses `request_timeout_ms` unless an explicit bounded `timeout_ms` is supplied.

--- a/docs/specifications/real-provider-task-run-smoke-spec-v0.md
+++ b/docs/specifications/real-provider-task-run-smoke-spec-v0.md
@@ -16,3 +16,7 @@ Optional local endpoint smoke:
 4. Run `task.start`, `task.run`, and `run.inspect` to verify provider metadata.
 
 Phase 2.6 does not add streaming, workspace.write, file write, patch apply, process execution, network tools, service control, destructive operations, subtask spawning, AgentModes YAML parsing, ModePack activation, Qdrant, llama-server lifecycle control, or indexing. Ledgers, inspection, diagnostics, status, health, and errors must not expose API keys, Authorization headers, Bearer tokens, query-string secrets, full prompts, full provider responses, or full README content.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/runtime-config-spec-v0.md
+++ b/docs/specifications/runtime-config-spec-v0.md
@@ -73,3 +73,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/runtime-diagnostics-spec-v0.md
+++ b/docs/specifications/runtime-diagnostics-spec-v0.md
@@ -36,3 +36,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -246,3 +246,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -163,3 +163,7 @@ If OpenAI-compatible configuration is incomplete, `BROWNIE_LLM_STRICT=false` (de
 ## Phase 2.6 real-provider task.run guard
 
 `BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK=true` is required before strict enabled OpenAI-compatible `task.run` may make network LLM calls. The default is false. `llm.status` and `runtime.config.get` expose `task_run_network_allowed`; `runtime.diagnostics.get` reports `TASK_RUN_NETWORK_ALLOWED` or `TASK_RUN_NETWORK_NOT_ALLOWED` for strict enabled OpenAI-compatible profiles. Missing guard is a warning in diagnostics and a pre-network `task.run` error. Non-strict OpenAI-compatible `task.run` falls back to Fake. See `docs/specifications/real-provider-task-run-smoke-spec-v0.md`.
+
+## Phase 2.7 LLM request budget note
+
+See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -31,6 +31,10 @@ export function activate(context: vscode.ExtensionContext): void {
       output.appendLine(`strict: ${String(status.strict)}`);
       output.appendLine(`will_fallback_to_fake: ${String(status.will_fallback_to_fake)}`);
       output.appendLine(`task_run_network_allowed: ${String(status.task_run_network_allowed)}`);
+      output.appendLine(`budget.max_prompt_chars: ${String(status.budget.max_prompt_chars)}`);
+      output.appendLine(`budget.max_messages: ${String(status.budget.max_messages)}`);
+      output.appendLine(`budget.request_timeout_ms: ${String(status.budget.request_timeout_ms)}`);
+      output.appendLine(`budget.response_preview_chars: ${String(status.budget.response_preview_chars)}`);
       output.appendLine(`reason: ${status.reason ?? 'null'}`);
       output.show(true);
       await vscode.window.showInformationMessage(

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -23,6 +23,13 @@ export interface RuntimeStatusResult {
   status: string;
 }
 
+export interface LlmRequestBudgetSummary {
+  max_prompt_chars: number;
+  max_messages: number;
+  request_timeout_ms: number;
+  response_preview_chars: number;
+}
+
 export interface LlmStatusResult {
   provider: string;
   enabled: boolean;
@@ -34,6 +41,7 @@ export interface LlmStatusResult {
   task_run_network_allowed: boolean;
   config_source: string;
   active_profile?: string | null;
+  budget: LlmRequestBudgetSummary;
 }
 
 export interface RuntimeConfigGetResult {
@@ -244,6 +252,20 @@ export function isRuntimeStatusResult(value: unknown): value is RuntimeStatusRes
   );
 }
 
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+export function isLlmRequestBudgetSummary(value: unknown): value is LlmRequestBudgetSummary {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.max_prompt_chars) &&
+    isNonNegativeInteger(value.max_messages) &&
+    isNonNegativeInteger(value.request_timeout_ms) &&
+    isNonNegativeInteger(value.response_preview_chars)
+  );
+}
+
 export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
   return (
     isRecord(value) &&
@@ -257,6 +279,7 @@ export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
     typeof value.task_run_network_allowed === 'boolean' &&
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
+    isLlmRequestBudgetSummary(value.budget) &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')
   );
 }

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -63,16 +63,19 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid llm.status results and rejects missing required fields', () => {
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Env', active_profile: null })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default' })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Env', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true })).toBe(false);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, active_profile: null })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', api_key: 'secret' })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: -1, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 1.5, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
   });
 
   it('accepts valid runtime diagnostics results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
@@ -102,7 +105,7 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid runtime.config.get results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
     expect(isRuntimeConfigGetResult({ config_source: 'Default', config_path: null, active_profile: null, llm_status })).toBe(true);
     expect(isRuntimeConfigGetResult({ config_source: 'Default', llm_status, api_key: 'secret' })).toBe(false);
   });
@@ -186,7 +189,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates an llm.status request', async () => {
-    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
+    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
 
@@ -211,7 +214,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.diagnostics.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
     const result = { config_source: 'Default', active_profile: null, llm_status, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
@@ -220,7 +223,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.config.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
     const result = { config_source: 'Default', config_path: null, active_profile: null, llm_status };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);


### PR DESCRIPTION
### Motivation
- Introduce a runtime-enforced LLM request budget so provider calls are safely bounded by prompt size, message count, timeout, and response-preview length.
- Allow budgets to be configured via profile, overridden by environment variables, and surfaced in status/diagnostics to aid operator visibility and safety.
- Prevent accidental network calls or very large prompts from reaching real providers by failing early and recording budget failures in the ledger.

### Description
- Added `LlmRequestBudget` and `validate_llm_request_budget` to `crates/brownie-llm` with defaults and hard bounds, and changed the `LlmProvider::complete` signature to accept a budget so providers can use `request_timeout_ms` (Fake and OpenAI-compatible providers updated). 
- Added `LlmRequestBudgetConfig` to `crates/brownie-config` and merged profile `budget` fields onto defaults during config validation; invalid profile budgets now fail validation. 
- Resolved budget in the runtime with env overrides (`BROWNIE_LLM_MAX_PROMPT_CHARS`, `BROWNIE_LLM_MAX_MESSAGES`, `BROWNIE_LLM_REQUEST_TIMEOUT_MS`, `BROWNIE_LLM_RESPONSE_PREVIEW_CHARS`) and threaded the resolved `LlmRequestBudget` into `RuntimeLlmProviderStatus` and `llm.status` (`LlmRequestBudgetSummary` in protocol). 
- Enforced prompt/message budgets in the agent loop before provider calls so violations bail out without calling the provider and create `LlmRequestFailed`/`TaskFailed` ledger events; previews are capped by `response_preview_chars` and prompt previews include `max_prompt_chars`. 
- Added diagnostics codes `LLM_BUDGET_DEFAULT`, `LLM_BUDGET_PROFILE`, `LLM_BUDGET_ENV_OVERRIDE`, and `LLM_BUDGET_INVALID` and emit an Info/Error per resolution/validation rules; `llm.health` uses budget `request_timeout_ms` by default. 
- Updated protocol/VSIX types and validators to include budget fields and updated the Brownie VSIX `LLM Status` output to show the resolved budget; added `docs/specifications/llm-request-budget-spec-v0.md` and linked notes into related specs.

### Testing
- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, which all completed successfully. 
- Ran VSIX checks and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, which all passed. 
- Performed manual smoke tests: `llm.status` returned default budget values, env overrides (`BROWNIE_LLM_MAX_PROMPT_CHARS`/`BROWNIE_LLM_MAX_MESSAGES`) were reflected in `llm.status` and `runtime.diagnostics.get` (diagnostic `LLM_BUDGET_ENV_OVERRIDE` emitted), and an invalid env budget produced a `LLM_BUDGET_INVALID` diagnostic; all produced the expected results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40d9b67b208328be108747f2b3beb7)