### PR TITLE
Add prompt sensitive-content guard and enforcement (Phase 2.8)

### DIFF
--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -2,7 +2,8 @@
 
 use brownie_context::{PromptBuildInput, PromptBuilder, PromptRole, PromptView};
 use brownie_llm::{
-    FakeLlmProvider, LlmMessage, LlmProvider, LlmRequest, LlmRequestBudget, LlmResponse,
+    enforce_prompt_sensitive_guard, FakeLlmProvider, LlmMessage, LlmProvider, LlmRequest,
+    LlmRequestBudget, LlmResponse, PromptSensitiveGuardMode, PromptSensitiveScanResult,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +43,7 @@ pub struct AgentLoopRunOutput {
     pub prompt: PromptView,
     pub llm_request: LlmRequest,
     pub llm_response: LlmResponse,
+    pub sensitive_scan: PromptSensitiveScanResult,
     pub completion_summary: String,
 }
 
@@ -51,6 +53,7 @@ pub struct AgentLoopSecondPassOutput {
     pub prompt: PromptView,
     pub llm_request: LlmRequest,
     pub llm_response: LlmResponse,
+    pub sensitive_scan: PromptSensitiveScanResult,
     pub completion_summary: String,
 }
 
@@ -68,14 +71,17 @@ impl AgentLoop {
         prompt_input: PromptBuildInput,
         provider: &dyn LlmProvider,
         budget: &LlmRequestBudget,
+        sensitive_guard_mode: PromptSensitiveGuardMode,
     ) -> anyhow::Result<AgentLoopRunOutput> {
-        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider, budget)?;
+        let (task_id, prompt, llm_request, sensitive_scan, llm_response) =
+            run_llm(prompt_input, provider, budget, sensitive_guard_mode)?;
         Ok(AgentLoopRunOutput {
             final_state: AgentLoopState::Completed,
             prompt,
             llm_request,
             completion_summary: format!("LLM agent loop completed for {task_id}"),
             llm_response,
+            sensitive_scan,
         })
     }
 
@@ -83,27 +89,40 @@ impl AgentLoop {
         prompt_input: PromptBuildInput,
         provider: &dyn LlmProvider,
         budget: &LlmRequestBudget,
+        sensitive_guard_mode: PromptSensitiveGuardMode,
     ) -> anyhow::Result<AgentLoopSecondPassOutput> {
-        let (task_id, prompt, llm_request, llm_response) = run_llm(prompt_input, provider, budget)?;
+        let (task_id, prompt, llm_request, sensitive_scan, llm_response) =
+            run_llm(prompt_input, provider, budget, sensitive_guard_mode)?;
         Ok(AgentLoopSecondPassOutput {
             final_state: AgentLoopState::Completed,
             prompt,
             llm_request,
             completion_summary: format!("Second-pass LLM agent loop completed for {task_id}"),
             llm_response,
+            sensitive_scan,
         })
     }
 
     pub fn run_with_fake_llm(prompt_input: PromptBuildInput) -> AgentLoopRunOutput {
-        Self::run_with_llm(prompt_input, &FakeLlmProvider, &LlmRequestBudget::default())
-            .expect("fake provider should not fail")
+        Self::run_with_llm(
+            prompt_input,
+            &FakeLlmProvider,
+            &LlmRequestBudget::default(),
+            PromptSensitiveGuardMode::Warn,
+        )
+        .expect("fake provider should not fail")
     }
 
     pub fn run_second_pass_with_fake_llm(
         prompt_input: PromptBuildInput,
     ) -> AgentLoopSecondPassOutput {
-        Self::run_second_pass_with_llm(prompt_input, &FakeLlmProvider, &LlmRequestBudget::default())
-            .expect("fake provider should not fail")
+        Self::run_second_pass_with_llm(
+            prompt_input,
+            &FakeLlmProvider,
+            &LlmRequestBudget::default(),
+            PromptSensitiveGuardMode::Warn,
+        )
+        .expect("fake provider should not fail")
     }
 }
 
@@ -111,7 +130,14 @@ fn run_llm(
     prompt_input: PromptBuildInput,
     provider: &dyn LlmProvider,
     budget: &LlmRequestBudget,
-) -> anyhow::Result<(String, PromptView, LlmRequest, LlmResponse)> {
+    sensitive_guard_mode: PromptSensitiveGuardMode,
+) -> anyhow::Result<(
+    String,
+    PromptView,
+    LlmRequest,
+    PromptSensitiveScanResult,
+    LlmResponse,
+)> {
     let task_id = prompt_input.task_id.clone();
     let prompt = PromptBuilder::build(prompt_input);
     let llm_request = LlmRequest {
@@ -126,8 +152,10 @@ fn run_llm(
             .collect(),
     };
     validate_request_budget(&llm_request, budget)?;
+    let sensitive_scan =
+        enforce_prompt_sensitive_guard(&llm_request.messages, sensitive_guard_mode)?;
     let llm_response = provider.complete(&llm_request, budget)?;
-    Ok((task_id, prompt, llm_request, llm_response))
+    Ok((task_id, prompt, llm_request, sensitive_scan, llm_response))
 }
 
 fn validate_request_budget(request: &LlmRequest, budget: &LlmRequestBudget) -> anyhow::Result<()> {

--- a/crates/brownie-config/src/lib.rs
+++ b/crates/brownie-config/src/lib.rs
@@ -31,6 +31,7 @@ pub enum LlmProfile {
     Fake {
         model: Option<String>,
         budget: Option<LlmRequestBudgetConfig>,
+        sensitive_guard: Option<String>,
     },
     #[serde(rename = "openai-compatible")]
     OpenAiCompatible {
@@ -39,6 +40,7 @@ pub enum LlmProfile {
         api_key_env: Option<String>,
         strict: Option<bool>,
         budget: Option<LlmRequestBudgetConfig>,
+        sensitive_guard: Option<String>,
     },
 }
 
@@ -108,7 +110,21 @@ pub fn validate_config(config: &BrownieConfig) -> Result<()> {
     if let Some(llm) = &config.llm {
         for (name, profile) in &llm.profiles {
             let budget = match profile {
-                LlmProfile::Fake { budget, .. } | LlmProfile::OpenAiCompatible { budget, .. } => {
+                LlmProfile::Fake {
+                    budget,
+                    sensitive_guard,
+                    ..
+                }
+                | LlmProfile::OpenAiCompatible {
+                    budget,
+                    sensitive_guard,
+                    ..
+                } => {
+                    if let Some(value) = sensitive_guard {
+                        if brownie_llm::PromptSensitiveGuardMode::parse(value).is_none() {
+                            anyhow::bail!("invalid sensitive_guard for profile {name}: expected off, warn, or fail");
+                        }
+                    }
                     budget
                 }
             };

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -12,6 +12,171 @@ pub const OPENAI_COMPATIBLE_API_VERSION: &str = "v1";
 pub const FAKE_LLM_MODEL: &str = "brownie-fake-llm";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum PromptSensitiveGuardMode {
+    Off,
+    Warn,
+    Fail,
+}
+
+impl PromptSensitiveGuardMode {
+    pub fn as_config_str(&self) -> &'static str {
+        match self {
+            Self::Off => "off",
+            Self::Warn => "warn",
+            Self::Fail => "fail",
+        }
+    }
+
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(Self::Off),
+            "warn" => Some(Self::Warn),
+            "fail" => Some(Self::Fail),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptSensitiveGuardConfig {
+    pub mode: PromptSensitiveGuardMode,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptSensitiveFinding {
+    pub category: String,
+    pub message_index: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PromptSensitiveScanResult {
+    pub findings: Vec<PromptSensitiveFinding>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PromptSensitiveGuardError {
+    finding_count: usize,
+    message_count: usize,
+    categories: Vec<String>,
+}
+
+impl std::fmt::Display for PromptSensitiveGuardError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Prompt sensitive-content guard failed: {} findings across {} messages.",
+            self.finding_count, self.message_count
+        )?;
+        if !self.categories.is_empty() {
+            write!(f, " categories={}", self.categories.join(","))?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for PromptSensitiveGuardError {}
+
+pub fn scan_prompt_for_sensitive_content(messages: &[LlmMessage]) -> PromptSensitiveScanResult {
+    let mut findings = Vec::new();
+    for (message_index, message) in messages.iter().enumerate() {
+        let content = message.content.as_str();
+        let lower = content.to_ascii_lowercase();
+        let checks = [
+            (
+                "authorization_header",
+                lower.contains("authorization: bearer "),
+            ),
+            (
+                "bearer_token",
+                lower.contains("bearer sk-")
+                    || lower.contains("bearer ghp_")
+                    || lower.contains("bearer github_pat_"),
+            ),
+            (
+                "api_key_assignment",
+                contains_assignment(&lower, &["api_key", "apikey", "api-key"]),
+            ),
+            (
+                "access_token_assignment",
+                contains_assignment(&lower, &["access_token", "access-token"]),
+            ),
+            (
+                "private_key_block",
+                content.contains("-----BEGIN PRIVATE KEY-----"),
+            ),
+            (
+                "ssh_private_key_block",
+                content.contains("-----BEGIN OPENSSH PRIVATE KEY-----"),
+            ),
+            (
+                "env_file_secret",
+                contains_assignment(
+                    &lower,
+                    &[
+                        "aws_secret_access_key",
+                        "secret_key",
+                        "client_secret",
+                        "password",
+                    ],
+                ),
+            ),
+            (
+                "github_token_like",
+                content.contains("ghp_") || content.contains("github_pat_"),
+            ),
+            ("openai_key_like", content.contains("sk-")),
+        ];
+        for (category, matched) in checks {
+            if matched {
+                findings.push(PromptSensitiveFinding {
+                    category: category.to_string(),
+                    message_index,
+                });
+            }
+        }
+    }
+    PromptSensitiveScanResult { findings }
+}
+
+pub fn enforce_prompt_sensitive_guard(
+    messages: &[LlmMessage],
+    mode: PromptSensitiveGuardMode,
+) -> Result<PromptSensitiveScanResult, PromptSensitiveGuardError> {
+    let result = scan_prompt_for_sensitive_content(messages);
+    if mode == PromptSensitiveGuardMode::Fail && !result.findings.is_empty() {
+        let mut categories = result
+            .findings
+            .iter()
+            .map(|f| f.category.clone())
+            .collect::<Vec<_>>();
+        categories.sort();
+        categories.dedup();
+        let mut indexes = result
+            .findings
+            .iter()
+            .map(|f| f.message_index)
+            .collect::<Vec<_>>();
+        indexes.sort_unstable();
+        indexes.dedup();
+        return Err(PromptSensitiveGuardError {
+            finding_count: result.findings.len(),
+            message_count: indexes.len(),
+            categories,
+        });
+    }
+    Ok(result)
+}
+
+fn contains_assignment(lower: &str, names: &[&str]) -> bool {
+    names.iter().any(|name| {
+        lower.contains(&format!("{name}="))
+            || lower.contains(&format!("{name}:"))
+            || lower.contains(&format!("{name} ="))
+            || lower.contains(&format!("{name}: "))
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct LlmRequestBudget {
     pub max_prompt_chars: usize,
     pub max_messages: usize,
@@ -454,6 +619,45 @@ mod tests {
         ] {
             env::remove_var(key);
         }
+    }
+
+    #[test]
+    fn sensitive_scanner_detects_secret_like_content_without_values() {
+        let messages = vec![
+            LlmMessage {
+                role: "user".into(),
+                content: "Authorization: Bearer sk-secretvalue".into(),
+            },
+            LlmMessage {
+                role: "user".into(),
+                content: "api_key=supersecret\n-----BEGIN PRIVATE KEY-----\nghp_secret".into(),
+            },
+        ];
+        let result = scan_prompt_for_sensitive_content(&messages);
+        let categories: Vec<_> = result
+            .findings
+            .iter()
+            .map(|f| f.category.as_str())
+            .collect();
+        assert!(categories.contains(&"authorization_header"));
+        assert!(categories.contains(&"api_key_assignment"));
+        assert!(categories.contains(&"private_key_block"));
+        assert!(categories.contains(&"github_token_like"));
+        let serialized = serde_json::to_string(&result).unwrap();
+        assert!(!serialized.contains("supersecret"));
+        assert!(!serialized.contains("sk-secretvalue"));
+        assert!(!serialized.contains("ghp_secret"));
+    }
+
+    #[test]
+    fn sensitive_guard_fail_blocks_and_warn_allows() {
+        let messages = vec![LlmMessage {
+            role: "user".into(),
+            content: "access_token=secret".into(),
+        }];
+        assert!(enforce_prompt_sensitive_guard(&messages, PromptSensitiveGuardMode::Fail).is_err());
+        assert!(enforce_prompt_sensitive_guard(&messages, PromptSensitiveGuardMode::Warn).is_ok());
+        assert!(enforce_prompt_sensitive_guard(&messages, PromptSensitiveGuardMode::Off).is_ok());
     }
 
     #[test]

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -49,6 +49,7 @@ pub struct LlmStatusResult {
     pub config_source: String,
     pub active_profile: Option<String>,
     pub budget: LlmRequestBudgetSummary,
+    pub sensitive_guard: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1355,11 +1355,13 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     if let Err(error) = store.tasks().append_task_event_with_payload(
         &running,
         LedgerEventKind::PromptBuilt,
-        Some(json!({
-            "message_count": result.prompt.messages.len(),
-            "prompt_preview": preview_prompt(&result.prompt, provider_selection.budget.response_preview_chars),
-            "max_prompt_chars": provider_selection.budget.max_prompt_chars,
-        })),
+        Some(prompt_built_payload(
+            result.prompt.messages.len(),
+            &result.prompt,
+            provider_selection.budget.response_preview_chars,
+            provider_selection.budget.max_prompt_chars,
+            &result.sensitive_scan,
+        )),
     ) {
         return error_response(id, -32603, &format!("internal error: {error}"));
     }
@@ -1455,11 +1457,13 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         if let Err(error) = store.tasks().append_task_event_with_payload(
             &running,
             LedgerEventKind::SecondPassPromptBuilt,
-            Some(json!({
-                "message_count": second_pass.prompt.messages.len(),
-                "prompt_preview": preview_prompt(&second_pass.prompt, provider_selection.budget.response_preview_chars),
-                    "max_prompt_chars": provider_selection.budget.max_prompt_chars,
-            })),
+            Some(prompt_built_payload(
+                second_pass.prompt.messages.len(),
+                &second_pass.prompt,
+                provider_selection.budget.response_preview_chars,
+                provider_selection.budget.max_prompt_chars,
+                &second_pass.sensitive_scan,
+            )),
         ) {
             return error_response(id, -32603, &format!("internal error: {error}"));
         }
@@ -2353,6 +2357,25 @@ fn runtime_action_name(action: &RuntimeAction) -> RuntimeActionName {
         RuntimeAction::DestructiveOperation => RuntimeActionName::DestructiveOperation,
         RuntimeAction::SpawnSubtask => RuntimeActionName::SpawnSubtask,
     }
+}
+
+fn prompt_built_payload(
+    message_count: usize,
+    prompt: &brownie_context::PromptView,
+    response_preview_chars: usize,
+    max_prompt_chars: usize,
+    sensitive_scan: &PromptSensitiveScanResult,
+) -> Value {
+    let mut payload = serde_json::Map::new();
+    payload.insert("message_count".to_string(), json!(message_count));
+    payload.insert("max_prompt_chars".to_string(), json!(max_prompt_chars));
+    if sensitive_scan.findings.is_empty() {
+        payload.insert(
+            "prompt_preview".to_string(),
+            json!(preview_prompt(prompt, response_preview_chars)),
+        );
+    }
+    Value::Object(payload)
 }
 
 fn preview_prompt(prompt: &brownie_context::PromptView, max_chars: usize) -> String {
@@ -3674,6 +3697,67 @@ content-length: {}
             observed
         });
         (format!("http://{addr}/v1"), handle)
+    }
+
+    #[test]
+    fn sensitive_prompt_findings_suppress_prompt_previews() {
+        let _lock = super::tests::ENV_LOCK.lock().expect("env lock");
+        let _guard = EnvGuard::clear();
+        let temp = tempfile::tempdir().unwrap();
+        let (base_url, handle) = spawn_mock_two(
+            r#"{"choices":[{"message":{"content":"Mock LLM first pass.\n\n```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Read README\",\"input\":{\"path\":\"README.md\"}}]}\n```"}}]}"#,
+            r#"{"choices":[{"message":{"content":"Mock LLM final response after tool feedback."}}]}"#,
+        );
+        write_mock_config(temp.path(), &base_url);
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        std::env::set_var("BROWNIE_TEST_LLM_API_KEY", "test-key");
+        std::env::set_var("BROWNIE_LLM_ALLOW_TASK_RUN_NETWORK", "true");
+        std::env::set_var("BROWNIE_LLM_SENSITIVE_GUARD", "warn");
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Read README with api_key=sk-test-sensitive-preview","mode_id":"orchestrator"}}"#,
+        )
+        .result
+        .unwrap();
+        let task_id = start["task_id"].as_str().unwrap();
+        let run_id = start["run_id"].as_str().unwrap();
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        if run.error.is_some() {
+            panic!("run error: {:?}", run.error);
+        }
+        assert_eq!(handle.join().unwrap().len(), 2);
+
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/runs")
+                .join(run_id)
+                .join("ledger.jsonl"),
+        )
+        .expect("ledger");
+        let events = ledger
+            .lines()
+            .map(|line| serde_json::from_str::<brownie_store::LedgerEvent>(line).expect("event"))
+            .collect::<Vec<_>>();
+        assert!(events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::PromptSensitiveScanCompleted));
+        for kind in [
+            LedgerEventKind::PromptBuilt,
+            LedgerEventKind::SecondPassPromptBuilt,
+        ] {
+            let event = events
+                .iter()
+                .find(|event| event.kind == kind)
+                .unwrap_or_else(|| panic!("missing {kind:?}"));
+            let payload = event.payload.as_ref().expect("prompt payload");
+            assert_eq!(payload["message_count"].as_u64().is_some(), true);
+            assert_eq!(payload.get("prompt_preview"), None);
+            assert!(!serde_json::to_string(payload)
+                .unwrap()
+                .contains("sk-test-sensitive-preview"));
+        }
     }
 
     #[test]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1935,6 +1935,7 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "categories",
         "message_indexes",
         "sensitive_guard",
+        "prompt_preview_redacted",
     ];
     let sanitized = map
         .into_iter()
@@ -2374,6 +2375,8 @@ fn prompt_built_payload(
             "prompt_preview".to_string(),
             json!(preview_prompt(prompt, response_preview_chars)),
         );
+    } else {
+        payload.insert("prompt_preview_redacted".to_string(), json!(true));
     }
     Value::Object(payload)
 }
@@ -3754,6 +3757,7 @@ content-length: {}
             let payload = event.payload.as_ref().expect("prompt payload");
             assert_eq!(payload["message_count"].as_u64().is_some(), true);
             assert_eq!(payload.get("prompt_preview"), None);
+            assert_eq!(payload["prompt_preview_redacted"], true);
             assert!(!serde_json::to_string(payload)
                 .unwrap()
                 .contains("sk-test-sensitive-preview"));

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -11,7 +11,7 @@ use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_llm::{
     redact_secret, validate_llm_request_budget, FakeLlmProvider, LlmProvider, LlmProviderKind,
     LlmProviderStatus, LlmRequestBudget, OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv,
-    OpenAiCompatibleLlmProvider,
+    OpenAiCompatibleLlmProvider, PromptSensitiveGuardMode, PromptSensitiveScanResult,
 };
 use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
@@ -115,6 +115,8 @@ pub struct RuntimeLlmProviderStatus {
     active_profile: Option<String>,
     task_run_network_allowed: bool,
     budget: LlmRequestBudget,
+    sensitive_guard_mode: PromptSensitiveGuardMode,
+    sensitive_guard_invalid: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -166,6 +168,7 @@ fn llm_status_result(selection: RuntimeLlmProviderStatus) -> LlmStatusResult {
         active_profile: selection.active_profile,
         task_run_network_allowed: selection.task_run_network_allowed,
         budget: budget_summary(&selection.budget),
+        sensitive_guard: selection.sensitive_guard_mode.as_config_str().to_string(),
     }
 }
 
@@ -186,6 +189,49 @@ fn budget_from_profile(
         budget = profile_budget.apply_to(budget);
     }
     apply_env_budget_overrides(budget)
+}
+
+fn provider_default_sensitive_guard(kind: &LlmProviderKind) -> PromptSensitiveGuardMode {
+    match kind {
+        LlmProviderKind::OpenAiCompatible => PromptSensitiveGuardMode::Fail,
+        _ => PromptSensitiveGuardMode::Warn,
+    }
+}
+
+fn resolve_sensitive_guard(
+    provider: &LlmProviderKind,
+    profile_value: Option<&String>,
+) -> (PromptSensitiveGuardMode, Option<String>) {
+    if let Ok(value) = std::env::var("BROWNIE_LLM_SENSITIVE_GUARD") {
+        if !value.trim().is_empty() {
+            return PromptSensitiveGuardMode::parse(&value)
+                .map(|mode| (mode, None))
+                .unwrap_or_else(|| {
+                    (
+                        provider_default_sensitive_guard(provider),
+                        Some("BROWNIE_LLM_SENSITIVE_GUARD".to_string()),
+                    )
+                });
+        }
+    }
+    if let Some(value) = profile_value {
+        return PromptSensitiveGuardMode::parse(value)
+            .map(|mode| (mode, None))
+            .unwrap_or_else(|| {
+                (
+                    provider_default_sensitive_guard(provider),
+                    Some("sensitive_guard".to_string()),
+                )
+            });
+    }
+    (provider_default_sensitive_guard(provider), None)
+}
+
+fn env_sensitive_guard_override_present() -> bool {
+    std::env::var("BROWNIE_LLM_SENSITIVE_GUARD")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .is_some()
 }
 
 fn env_budget_override_present() -> bool {
@@ -287,6 +333,16 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 active_profile: None,
                 task_run_network_allowed: task_run_network_allowed(),
                 budget: budget_from_profile(None).unwrap_or_default(),
+                sensitive_guard_mode: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    None,
+                )
+                .0,
+                sensitive_guard_invalid: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    None,
+                )
+                .1,
             },
             OpenAiCompatibleConfigFromEnv::Disabled(status) => RuntimeLlmProviderStatus {
                 status,
@@ -296,6 +352,16 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
                 active_profile: None,
                 task_run_network_allowed: task_run_network_allowed(),
                 budget: budget_from_profile(None).unwrap_or_default(),
+                sensitive_guard_mode: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    None,
+                )
+                .0,
+                sensitive_guard_invalid: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    None,
+                )
+                .1,
             },
         },
         Some("fake") | None => RuntimeLlmProviderStatus {
@@ -316,6 +382,8 @@ pub fn llm_provider_status_from_env() -> RuntimeLlmProviderStatus {
             active_profile: None,
             task_run_network_allowed: task_run_network_allowed(),
             budget: budget_from_profile(None).unwrap_or_default(),
+            sensitive_guard_mode: resolve_sensitive_guard(&LlmProviderKind::Unknown, None).0,
+            sensitive_guard_invalid: resolve_sensitive_guard(&LlmProviderKind::Unknown, None).1,
         },
     }
 }
@@ -339,6 +407,8 @@ fn fake_status_with_profile(
         active_profile,
         task_run_network_allowed: task_run_network_allowed(),
         budget: budget_from_profile(None).unwrap_or_default(),
+        sensitive_guard_mode: resolve_sensitive_guard(&LlmProviderKind::Fake, None).0,
+        sensitive_guard_invalid: resolve_sensitive_guard(&LlmProviderKind::Fake, None).1,
     }
 }
 
@@ -352,9 +422,17 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
         .and_then(|l| l.profiles.get(&profile_name))
         .ok_or_else(|| "active_profile references unknown profile".to_string())?;
     Ok(match profile {
-        LlmProfile::Fake { model, budget } => {
+        LlmProfile::Fake {
+            model,
+            budget,
+            sensitive_guard,
+        } => {
             let mut s = fake_status_with_profile(Some(profile_name), false);
             s.budget = budget_from_profile(budget.as_ref())?;
+            let (mode, invalid) =
+                resolve_sensitive_guard(&LlmProviderKind::Fake, sensitive_guard.as_ref());
+            s.sensitive_guard_mode = mode;
+            s.sensitive_guard_invalid = invalid;
             if let Some(model) = model {
                 s.status.model = model.clone();
             }
@@ -366,6 +444,7 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
             api_key_env,
             strict,
             budget,
+            sensitive_guard,
         } => {
             let api_key_env = api_key_env
                 .clone()
@@ -394,6 +473,16 @@ fn status_from_config(config: &BrownieConfig) -> Result<RuntimeLlmProviderStatus
                 active_profile: Some(profile_name),
                 task_run_network_allowed: task_run_network_allowed(),
                 budget: budget_from_profile(budget.as_ref())?,
+                sensitive_guard_mode: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    sensitive_guard.as_ref(),
+                )
+                .0,
+                sensitive_guard_invalid: resolve_sensitive_guard(
+                    &LlmProviderKind::OpenAiCompatible,
+                    sensitive_guard.as_ref(),
+                )
+                .1,
             }
         }
     })
@@ -559,6 +648,8 @@ pub fn runtime_diagnostics_from_workspace(
             active_profile: None,
             task_run_network_allowed: task_run_network_allowed(),
             budget: budget_from_profile(None).unwrap_or_default(),
+            sensitive_guard_mode: resolve_sensitive_guard(&LlmProviderKind::Unknown, None).0,
+            sensitive_guard_invalid: resolve_sensitive_guard(&LlmProviderKind::Unknown, None).1,
         },
     };
 
@@ -598,6 +689,40 @@ pub fn runtime_diagnostics_from_workspace(
             status.status.reason = Some("invalid LLM request budget".to_string());
         }
         Err(_) => {}
+    }
+
+    if let Some(subject) = status.sensitive_guard_invalid.clone() {
+        diagnostics.push(diagnostic(
+            DiagnosticSeverity::Error,
+            "PROMPT_SENSITIVE_GUARD_INVALID",
+            "Invalid prompt sensitive guard value; expected off, warn, or fail.",
+            Some(&subject),
+        ));
+        status.status.enabled = false;
+        status.status.reason = Some("invalid prompt sensitive guard".to_string());
+    } else {
+        let (code, subject) = if env_sensitive_guard_override_present() {
+            (
+                "PROMPT_SENSITIVE_GUARD_ENV_OVERRIDE",
+                Some("BROWNIE_LLM_SENSITIVE_GUARD"),
+            )
+        } else if status.config_source == RuntimeConfigSource::WorkspaceConfig {
+            (
+                "PROMPT_SENSITIVE_GUARD_PROFILE",
+                status.active_profile.as_deref(),
+            )
+        } else {
+            ("PROMPT_SENSITIVE_GUARD_DEFAULT", None)
+        };
+        diagnostics.push(diagnostic(
+            DiagnosticSeverity::Info,
+            code,
+            format!(
+                "Prompt sensitive guard mode: {}.",
+                status.sensitive_guard_mode.as_config_str()
+            ),
+            subject,
+        ));
     }
 
     let strict_env = matches!(
@@ -1192,6 +1317,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         prompt_input,
         provider.as_ref(),
         &provider_selection.budget,
+        provider_selection.sensitive_guard_mode.clone(),
     ) {
         Ok(result) => result,
         Err(error) => {
@@ -1207,12 +1333,24 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                     active_profile: provider_selection.active_profile.clone(),
                     task_run_network_allowed: provider_selection.task_run_network_allowed,
                     budget: provider_selection.budget.clone(),
+                    sensitive_guard_mode: provider_selection.sensitive_guard_mode.clone(),
+                    sensitive_guard_invalid: provider_selection.sensitive_guard_invalid.clone(),
                 },
                 &error.to_string(),
                 LedgerEventKind::LlmRequestFailed,
             );
         }
     };
+
+    if let Err(error) = append_sensitive_scan_event(
+        &store,
+        &running,
+        &result.sensitive_scan,
+        &provider_selection.sensitive_guard_mode,
+        false,
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
 
     if let Err(error) = store.tasks().append_task_event_with_payload(
         &running,
@@ -1280,6 +1418,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             second_pass_prompt_input,
             provider.as_ref(),
             &provider_selection.budget,
+            provider_selection.sensitive_guard_mode.clone(),
         ) {
             Ok(result) => result,
             Err(error) => {
@@ -1295,12 +1434,24 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                         active_profile: provider_selection.active_profile.clone(),
                         task_run_network_allowed: provider_selection.task_run_network_allowed,
                         budget: provider_selection.budget.clone(),
+                        sensitive_guard_mode: provider_selection.sensitive_guard_mode.clone(),
+                        sensitive_guard_invalid: provider_selection.sensitive_guard_invalid.clone(),
                     },
                     &error.to_string(),
                     LedgerEventKind::SecondPassLlmRequestFailed,
                 );
             }
         };
+        if let Err(error) = append_sensitive_scan_event(
+            &store,
+            &running,
+            &second_pass.sensitive_scan,
+            &provider_selection.sensitive_guard_mode,
+            false,
+        ) {
+            return error_response(id, -32603, &format!("internal error: {error}"));
+        }
+
         if let Err(error) = store.tasks().append_task_event_with_payload(
             &running,
             LedgerEventKind::SecondPassPromptBuilt,
@@ -1367,6 +1518,47 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     }
 }
 
+fn append_sensitive_scan_event(
+    store: &BrownieStore,
+    running: &brownie_protocol::TaskRecord,
+    scan: &PromptSensitiveScanResult,
+    mode: &PromptSensitiveGuardMode,
+    failed: bool,
+) -> anyhow::Result<()> {
+    if !failed && scan.findings.is_empty() {
+        return Ok(());
+    }
+    let mut categories = scan
+        .findings
+        .iter()
+        .map(|f| f.category.clone())
+        .collect::<Vec<_>>();
+    categories.sort();
+    categories.dedup();
+    let mut message_indexes = scan
+        .findings
+        .iter()
+        .map(|f| f.message_index)
+        .collect::<Vec<_>>();
+    message_indexes.sort_unstable();
+    message_indexes.dedup();
+    store.tasks().append_task_event_with_payload(
+        running,
+        if failed {
+            LedgerEventKind::PromptSensitiveScanFailed
+        } else {
+            LedgerEventKind::PromptSensitiveScanCompleted
+        },
+        Some(json!({
+            "mode": mode.as_config_str(),
+            "sensitive_guard": mode.as_config_str(),
+            "finding_count": scan.findings.len(),
+            "categories": categories,
+            "message_indexes": message_indexes,
+        })),
+    )
+}
+
 fn fail_llm_request(
     store: &BrownieStore,
     running: &brownie_protocol::TaskRecord,
@@ -1376,6 +1568,19 @@ fn fail_llm_request(
     kind: LedgerEventKind,
 ) -> JsonRpcResponse<Value> {
     let reason = redact_secret(reason);
+    if reason.contains("Prompt sensitive-content guard failed") {
+        let _ = store.tasks().append_task_event_with_payload(
+            running,
+            LedgerEventKind::PromptSensitiveScanFailed,
+            Some(json!({
+                "mode": selection.sensitive_guard_mode.as_config_str(),
+                "sensitive_guard": selection.sensitive_guard_mode.as_config_str(),
+                "finding_count": 1,
+                "categories": [],
+                "message_indexes": [],
+            })),
+        );
+    }
     let _ = store.tasks().append_task_event_with_payload(
         running,
         kind,
@@ -1385,6 +1590,7 @@ fn fail_llm_request(
             "reason": reason,
             "base_url": selection.status.base_url.as_deref().map(redact_secret),
             "strict": selection.strict,
+            "sensitive_guard": selection.sensitive_guard_mode.as_config_str(),
         })),
     );
     let _ = store.tasks().update_task_status(
@@ -1721,6 +1927,10 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "allowed",
         "request_reason",
         "tool_ids",
+        "finding_count",
+        "categories",
+        "message_indexes",
+        "sensitive_guard",
     ];
     let sanitized = map
         .into_iter()

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -277,6 +277,8 @@ pub enum LedgerEventKind {
     ToolExecutionFailed,
     TaskRunning,
     PromptBuilt,
+    PromptSensitiveScanCompleted,
+    PromptSensitiveScanFailed,
     LlmRequestCreated,
     LlmRequestFailed,
     LlmResponseReceived,

--- a/docs/specifications/llm-provider-spec-v0.md
+++ b/docs/specifications/llm-provider-spec-v0.md
@@ -67,3 +67,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/llm-request-budget-spec-v0.md
+++ b/docs/specifications/llm-request-budget-spec-v0.md
@@ -31,3 +31,7 @@ Before an LLM provider call, Brownie checks message count and total prompt chara
 Prompt and response ledger payloads store previews only. Full prompt text and full provider responses are not persisted. Response preview length is controlled by `response_preview_chars`; prompt preview payloads include `max_prompt_chars`.
 
 `llm.status`, `runtime.config.get`, and diagnostics expose budget summaries. `llm.health` uses `request_timeout_ms` unless an explicit bounded `timeout_ms` is supplied.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/prompt-sensitive-guard-spec-v0.md
+++ b/docs/specifications/prompt-sensitive-guard-spec-v0.md
@@ -1,0 +1,17 @@
+# Prompt Sensitive Guard Spec v0
+
+Brownie scans LLM prompt messages immediately before provider calls to reduce accidental transmission of secret-like content.
+
+## Configuration
+
+Profiles may set `sensitive_guard` to `off`, `warn`, or `fail`. `BROWNIE_LLM_SENSITIVE_GUARD` overrides the active profile. If neither is set, Fake defaults to `warn` and OpenAI-compatible defaults to `fail`.
+
+## Categories
+
+The scanner reports categories only: `authorization_header`, `bearer_token`, `api_key_assignment`, `access_token_assignment`, `private_key_block`, `ssh_private_key_block`, `env_file_secret`, `github_token_like`, and `openai_key_like`.
+
+## Behavior
+
+`off` scans without blocking. `warn` allows the provider call and records warning metadata when findings exist. `fail` blocks before provider calls and fails the task.
+
+Ledger and inspection surfaces persist only category, count, message index, and mode metadata. Matched secret text, full prompts, and full provider responses are never persisted.

--- a/docs/specifications/real-provider-task-run-smoke-spec-v0.md
+++ b/docs/specifications/real-provider-task-run-smoke-spec-v0.md
@@ -20,3 +20,7 @@ Phase 2.6 does not add streaming, workspace.write, file write, patch apply, proc
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/runtime-config-spec-v0.md
+++ b/docs/specifications/runtime-config-spec-v0.md
@@ -77,3 +77,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/runtime-diagnostics-spec-v0.md
+++ b/docs/specifications/runtime-diagnostics-spec-v0.md
@@ -40,3 +40,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -250,3 +250,7 @@ Phase 2.5 adds the explicit `llm.health` JSON-RPC method, specified in `docs/spe
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -167,3 +167,7 @@ If OpenAI-compatible configuration is incomplete, `BROWNIE_LLM_STRICT=false` (de
 ## Phase 2.7 LLM request budget note
 
 See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provider requests are bounded by the resolved budget, status/config responses include the budget summary, diagnostics report default/profile/env/invalid budget sources, and ledger/inspection payloads keep prompt and response previews only.
+
+## Phase 2.8 prompt sensitive guard
+
+Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -31,6 +31,7 @@ export function activate(context: vscode.ExtensionContext): void {
       output.appendLine(`strict: ${String(status.strict)}`);
       output.appendLine(`will_fallback_to_fake: ${String(status.will_fallback_to_fake)}`);
       output.appendLine(`task_run_network_allowed: ${String(status.task_run_network_allowed)}`);
+      output.appendLine(`sensitive_guard: ${status.sensitive_guard}`);
       output.appendLine(`budget.max_prompt_chars: ${String(status.budget.max_prompt_chars)}`);
       output.appendLine(`budget.max_messages: ${String(status.budget.max_messages)}`);
       output.appendLine(`budget.request_timeout_ms: ${String(status.budget.request_timeout_ms)}`);

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -42,6 +42,7 @@ export interface LlmStatusResult {
   config_source: string;
   active_profile?: string | null;
   budget: LlmRequestBudgetSummary;
+  sensitive_guard: string;
 }
 
 export interface RuntimeConfigGetResult {
@@ -280,6 +281,7 @@ export function isLlmStatusResult(value: unknown): value is LlmStatusResult {
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
     isLlmRequestBudgetSummary(value.budget) &&
+    typeof value.sensitive_guard === 'string' &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')
   );
 }

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -63,11 +63,11 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid llm.status results and rejects missing required fields', () => {
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Env', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(true);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Unknown', enabled: false, model: '', base_url: null, reason: 'unknown provider: mystery', strict: true, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Env', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' })).toBe(true);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true })).toBe(false);
-    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
+    expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', api_key: 'secret' })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null })).toBe(false);
     expect(isLlmStatusResult({ provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: -1, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } })).toBe(false);
@@ -75,7 +75,7 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid runtime diagnostics results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
     expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
@@ -105,7 +105,7 @@ describe('protocol validation', () => {
   });
 
   it('accepts valid runtime.config.get results', () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
     expect(isRuntimeConfigGetResult({ config_source: 'Default', config_path: null, active_profile: null, llm_status })).toBe(true);
     expect(isRuntimeConfigGetResult({ config_source: 'Default', llm_status, api_key: 'secret' })).toBe(false);
   });
@@ -189,7 +189,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates an llm.status request', async () => {
-    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
+    const result = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
 
@@ -214,7 +214,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.diagnostics.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
     const result = { config_source: 'Default', active_profile: null, llm_status, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
@@ -223,7 +223,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a runtime.config.get request', async () => {
-    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 } };
+    const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
     const result = { config_source: 'Default', config_path: null, active_profile: null, llm_status };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of secret-like content to real LLM providers by scanning prompts just before provider calls and enforcing configurable guard policies. 
- Surface sanitized, non-secret guard metadata (mode, categories, counts, message indexes) in diagnostics and ledger while ensuring matched secret text, full prompts, and full provider responses are never persisted. 

### Description

- Added guard model, scanner and enforcement API in `crates/brownie-llm` including `PromptSensitiveGuardMode`, `PromptSensitiveScanResult`, `scan_prompt_for_sensitive_content`, and `enforce_prompt_sensitive_guard`. 
- Added `sensitive_guard` profile field in `crates/brownie-config` and env override resolution `BROWNIE_LLM_SENSITIVE_GUARD` with provider defaults (Fake=`warn`, OpenAI-compatible=`fail`) and invalid-value handling. 
- Integrated pre-provider enforcement into the agent path by running the scanner/enforcer before `provider.complete` via `AgentLoop::run_with_llm`, and threaded `sensitive_scan` through run outputs. 
- Added ledger event kinds `PromptSensitiveScanCompleted` and `PromptSensitiveScanFailed`, an `append_sensitive_scan_event` helper that persists only mode, finding_count, categories and message_indexes, and updated `sanitize_ledger_payload` to allowlist these metadata keys. 
- Extended runtime protocol and VSIX types to include `sensitive_guard` in `LlmStatusResult` and updated validators and the extension UI to display it. 
- Added unit tests for detection and enforcement behavior and test coverage updates, and created `docs/specifications/prompt-sensitive-guard-spec-v0.md` plus Phase 2.8 notes in related specs. 

### Testing

- Ran formatting and compile checks with `cargo fmt --check` and `cargo check --workspace` which succeeded. 
- Ran the full Rust test suite with `cargo test --workspace` which passed (all tests green). 
- Ran VSIX checks and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build` which all passed. 
- Performed manual smoke checks by invoking `llm.status` (no env override), `runtime.diagnostics.get` with `BROWNIE_LLM_SENSITIVE_GUARD=fail`, and `runtime.diagnostics.get` with `BROWNIE_LLM_SENSITIVE_GUARD=invalid`, and observed expected `sensitive_guard` presence, `PROMPT_SENSITIVE_GUARD_ENV_OVERRIDE`, and `PROMPT_SENSITIVE_GUARD_INVALID` diagnostics respectively.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4122f409208328aa4fa4c945dfdb16)