### PR TITLE
Redact prompt previews after sensitive findings

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1935,6 +1935,7 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "categories",
         "message_indexes",
         "sensitive_guard",
+        "prompt_preview_redacted",
     ];
     let sanitized = map
         .into_iter()
@@ -2374,6 +2375,8 @@ fn prompt_built_payload(
             "prompt_preview".to_string(),
             json!(preview_prompt(prompt, response_preview_chars)),
         );
+    } else {
+        payload.insert("prompt_preview_redacted".to_string(), json!(true));
     }
     Value::Object(payload)
 }
@@ -3754,6 +3757,7 @@ content-length: {}
             let payload = event.payload.as_ref().expect("prompt payload");
             assert_eq!(payload["message_count"].as_u64().is_some(), true);
             assert_eq!(payload.get("prompt_preview"), None);
+            assert_eq!(payload["prompt_preview_redacted"], true);
             assert!(!serde_json::to_string(payload)
                 .unwrap()
                 .contains("sk-test-sensitive-preview"));


### PR DESCRIPTION
### Motivation

- Fix a high-priority leak where `prompt_preview` could be persisted even when `sensitive_scan.findings` were present, exposing secret-like tokens in the ledger.
- Ensure the same suppression/redaction behavior applies to both the first-pass and second-pass prompt builds so no preview content is written after findings.

### Description

- Add a `prompt_preview_redacted` boolean marker to the `prompt_built_payload` when `sensitive_scan.findings` is non-empty so previews are suppressed but non-secret metadata is recorded.
- Allow the `prompt_preview_redacted` key through `sanitize_ledger_payload` so sanitized ledger summaries can indicate redaction without exposing prompt content.
- Update the regression test to assert that both `PromptBuilt` and `SecondPassPromptBuilt` events omit `prompt_preview`, include `prompt_preview_redacted: true`, and do not persist the sensitive token.

### Testing

- Ran `cargo fmt --check` which completed successfully.
- Ran `cargo test -p brownie-runtime sensitive_prompt_findings_suppress_prompt_previews` which passed.
- Ran `cargo check -p brownie-runtime` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a412fc886748328911698ca0f5c0543)