### PR TITLE
Harden brownie-tool-intent parsing boundary

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -65,7 +65,17 @@ pub struct RuntimeDiagnosticsResult {
     pub config_source: String,
     pub active_profile: Option<String>,
     pub llm_status: LlmStatusResult,
+    pub parser_config: ToolIntentParserConfigSummary,
     pub diagnostics: Vec<RuntimeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolIntentParserConfigSummary {
+    pub max_blocks: usize,
+    pub max_block_bytes: usize,
+    pub max_tool_requests: usize,
+    pub max_input_bytes: usize,
+    pub max_reason_chars: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -205,8 +215,22 @@ pub struct ToolIntentParseParams {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolIntentParseResult {
     pub mode_id: String,
+    pub parser: ToolIntentParserSummary,
     pub items: Vec<ToolIntentDecisionSummary>,
     pub rejected: Vec<ToolIntentRejectedSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolIntentParserSummary {
+    pub found_blocks: usize,
+    pub accepted_blocks: usize,
+    pub accepted_requests: usize,
+    pub rejected_requests: usize,
+    pub max_blocks: usize,
+    pub max_block_bytes: usize,
+    pub max_tool_requests: usize,
+    pub max_input_bytes: usize,
+    pub max_reason_chars: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -223,6 +247,7 @@ pub struct ToolIntentDecisionSummary {
 pub struct ToolIntentRejectedSummary {
     pub tool_id: Option<String>,
     pub reason: String,
+    pub code: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -23,8 +23,8 @@ use brownie_protocol::{
     TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams,
     TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus,
     ToolIntentDecisionSummary, ToolIntentParseParams, ToolIntentParseResult,
-    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
-    ToolPlanResult, ToolSummary,
+    ToolIntentParserConfigSummary, ToolIntentParserSummary, ToolIntentRejectedSummary,
+    ToolListResult, ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -917,6 +917,7 @@ pub fn runtime_diagnostics_from_workspace(
         config_source: status.config_source.as_str().to_string(),
         active_profile: status.active_profile.clone(),
         llm_status: llm_status_result(status),
+        parser_config: tool_intent_parser_config_summary(),
         diagnostics,
     }
 }
@@ -1727,11 +1728,13 @@ fn handle_tool_intent_parse(id: Value, params: Option<Value>) -> JsonRpcResponse
         None => return error_response(id, -32602, "invalid params: unknown mode_id"),
     };
     let parsed = ToolIntentParser::parse_assistant_content(&params.assistant_content);
+    let parser_summary = parsed.summary.clone();
     let evaluation = ToolIntentEvaluator::evaluate(&policy, parsed);
     result_response(
         id,
         json!(ToolIntentParseResult {
             mode_id: policy.mode_id,
+            parser: tool_intent_parser_summary(parser_summary),
             items: evaluation
                 .items
                 .into_iter()
@@ -1936,6 +1939,9 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "message_indexes",
         "sensitive_guard",
         "prompt_preview_redacted",
+        "parser",
+        "code",
+        "input_summary",
     ];
     let sanitized = map
         .into_iter()
@@ -2094,7 +2100,42 @@ fn tool_intent_rejected_summary(rejected: RejectedToolIntent) -> ToolIntentRejec
     ToolIntentRejectedSummary {
         tool_id: rejected.tool_id,
         reason: rejected.reason,
+        code: rejected.code,
     }
+}
+
+fn tool_intent_parser_summary(
+    summary: brownie_tools::ToolIntentParserSummary,
+) -> ToolIntentParserSummary {
+    ToolIntentParserSummary {
+        found_blocks: summary.found_blocks,
+        accepted_blocks: summary.accepted_blocks,
+        accepted_requests: summary.accepted_requests,
+        rejected_requests: summary.rejected_requests,
+        max_blocks: summary.max_blocks,
+        max_block_bytes: summary.max_block_bytes,
+        max_tool_requests: summary.max_tool_requests,
+        max_input_bytes: summary.max_input_bytes,
+        max_reason_chars: summary.max_reason_chars,
+    }
+}
+
+fn tool_intent_parser_config_summary() -> ToolIntentParserConfigSummary {
+    let config = ToolIntentParser::config();
+    ToolIntentParserConfigSummary {
+        max_blocks: config.max_blocks,
+        max_block_bytes: config.max_block_bytes,
+        max_tool_requests: config.max_tool_requests,
+        max_input_bytes: config.max_input_bytes,
+        max_reason_chars: config.max_reason_chars,
+    }
+}
+
+fn summarize_intent_input(input: &Value) -> Value {
+    json!({
+        "has_path": input.get("path").and_then(Value::as_str).is_some(),
+        "field_count": input.as_object().map(|object| object.len()).unwrap_or(0),
+    })
 }
 
 fn tool_execute_result(result: brownie_tools::ToolExecutionResult) -> ToolExecuteResult {
@@ -2121,6 +2162,7 @@ fn append_tool_intent_events(
         LedgerEventKind::ToolIntentParsed,
         Some(json!({
             "tool_ids": parsed.requests.iter().map(|request| request.tool_id.as_str()).collect::<Vec<_>>(),
+            "parser": parsed.summary,
         })),
     )?;
     let evaluation = ToolIntentEvaluator::evaluate(policy, parsed);
@@ -2128,7 +2170,7 @@ fn append_tool_intent_events(
         store.tasks().append_task_event_with_payload(
             record,
             LedgerEventKind::ToolIntentRejected,
-            Some(json!({ "tool_id": rejected.tool_id, "reason": rejected.reason })),
+            Some(json!({ "tool_id": rejected.tool_id, "reason": rejected.reason, "code": rejected.code })),
         )?;
     }
     for decision in evaluation.items {
@@ -2138,7 +2180,7 @@ fn append_tool_intent_events(
             "allowed": decision.allowed,
             "reason": decision.reason,
             "request_reason": decision.request_reason,
-            "input": decision.input,
+            "input_summary": summarize_intent_input(&decision.input),
         });
         store.tasks().append_task_event_with_payload(
             record,
@@ -3126,7 +3168,7 @@ mod tests {
     #[test]
     fn tool_intent_parse_returns_evaluated_decisions() {
         let response = parse_line(
-            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\"},{\"tool_id\":\"workspace.write\",\"reason\":\"Need edits.\"}]}\n```"}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"README.md\"}},{\"tool_id\":\"workspace.write\",\"reason\":\"Need edits.\"}]}\n```"}}"#,
         );
         assert!(response.error.is_none());
         let result = response.result.expect("result");

--- a/crates/brownie-tools/src/lib.rs
+++ b/crates/brownie-tools/src/lib.rs
@@ -232,6 +232,56 @@ fn tool(
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolIntentParserConfig {
+    pub max_blocks: usize,
+    pub max_block_bytes: usize,
+    pub max_tool_requests: usize,
+    pub max_input_bytes: usize,
+    pub max_reason_chars: usize,
+}
+
+impl Default for ToolIntentParserConfig {
+    fn default() -> Self {
+        Self {
+            max_blocks: 1,
+            max_block_bytes: 16_384,
+            max_tool_requests: 8,
+            max_input_bytes: 4_096,
+            max_reason_chars: 1_000,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolIntentParserSummary {
+    pub found_blocks: usize,
+    pub accepted_blocks: usize,
+    pub accepted_requests: usize,
+    pub rejected_requests: usize,
+    pub max_blocks: usize,
+    pub max_block_bytes: usize,
+    pub max_tool_requests: usize,
+    pub max_input_bytes: usize,
+    pub max_reason_chars: usize,
+}
+
+impl ToolIntentParserSummary {
+    fn new(config: &ToolIntentParserConfig) -> Self {
+        Self {
+            found_blocks: 0,
+            accepted_blocks: 0,
+            accepted_requests: 0,
+            rejected_requests: 0,
+            max_blocks: config.max_blocks,
+            max_block_bytes: config.max_block_bytes,
+            max_tool_requests: config.max_tool_requests,
+            max_input_bytes: config.max_input_bytes,
+            max_reason_chars: config.max_reason_chars,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AssistantToolIntent {
     pub tool_requests: Vec<AssistantToolRequest>,
 }
@@ -248,104 +298,311 @@ pub struct AssistantToolRequest {
 pub struct ParsedToolIntent {
     pub requests: Vec<AssistantToolRequest>,
     pub rejected: Vec<RejectedToolIntent>,
+    pub summary: ToolIntentParserSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RejectedToolIntent {
     pub tool_id: Option<String>,
     pub reason: String,
+    pub code: String,
 }
 
 pub struct ToolIntentParser;
 
 impl ToolIntentParser {
+    pub fn config() -> ToolIntentParserConfig {
+        ToolIntentParserConfig::default()
+    }
+
     pub fn parse_assistant_content(content: &str) -> ParsedToolIntent {
-        let Some(json_block) = extract_fenced_block(content) else {
+        Self::parse_assistant_content_with_config(content, &Self::config())
+    }
+
+    pub fn parse_assistant_content_with_config(
+        content: &str,
+        config: &ToolIntentParserConfig,
+    ) -> ParsedToolIntent {
+        let mut summary = ToolIntentParserSummary::new(config);
+        let blocks = extract_fenced_blocks(content);
+        summary.found_blocks = blocks.len();
+        let mut rejected = Vec::new();
+        if blocks.is_empty() {
+            if content.contains("```brownie-tool-intent") {
+                rejected.push(rejection(
+                    None,
+                    "Missing closing brownie-tool-intent fence.",
+                    "missing_closing_fence",
+                ));
+            }
+            summary.rejected_requests = rejected.len();
             return ParsedToolIntent {
                 requests: Vec::new(),
-                rejected: Vec::new(),
+                rejected,
+                summary,
             };
-        };
+        }
+        if blocks.len() > config.max_blocks {
+            rejected.push(rejection(
+                None,
+                "Too many brownie-tool-intent blocks.",
+                "too_many_blocks",
+            ));
+            summary.rejected_requests = rejected.len();
+            return ParsedToolIntent {
+                requests: Vec::new(),
+                rejected,
+                summary,
+            };
+        }
+        let json_block = blocks[0];
+        if json_block.len() > config.max_block_bytes {
+            rejected.push(rejection(
+                None,
+                "brownie-tool-intent block exceeds parser size limit.",
+                "block_too_large",
+            ));
+            summary.rejected_requests = rejected.len();
+            return ParsedToolIntent {
+                requests: Vec::new(),
+                rejected,
+                summary,
+            };
+        }
+        summary.accepted_blocks = 1;
         let value: Value = match serde_json::from_str(json_block.trim()) {
             Ok(value) => value,
-            Err(error) => {
+            Err(_) => {
+                rejected.push(rejection(
+                    None,
+                    "Invalid brownie-tool-intent JSON.",
+                    "malformed_json",
+                ));
+                summary.rejected_requests = rejected.len();
                 return ParsedToolIntent {
                     requests: Vec::new(),
-                    rejected: vec![RejectedToolIntent {
-                        tool_id: None,
-                        reason: format!("Invalid brownie-tool-intent JSON: {error}"),
-                    }],
-                }
+                    rejected,
+                    summary,
+                };
             }
         };
-        let Some(items) = value.get("tool_requests").and_then(Value::as_array) else {
+        let Some(object) = value.as_object() else {
+            rejected.push(rejection(
+                None,
+                "brownie-tool-intent JSON must be an object.",
+                "invalid_schema",
+            ));
+            summary.rejected_requests = rejected.len();
             return ParsedToolIntent {
                 requests: Vec::new(),
-                rejected: vec![RejectedToolIntent {
-                    tool_id: None,
-                    reason: "tool_requests must be an array.".to_string(),
-                }],
+                rejected,
+                summary,
             };
         };
+        if object.keys().any(|key| key != "tool_requests") {
+            rejected.push(rejection(
+                None,
+                "Unknown top-level field in brownie-tool-intent JSON.",
+                "unknown_field",
+            ));
+            summary.rejected_requests = rejected.len();
+            return ParsedToolIntent {
+                requests: Vec::new(),
+                rejected,
+                summary,
+            };
+        }
+        let Some(items) = object.get("tool_requests").and_then(Value::as_array) else {
+            rejected.push(rejection(
+                None,
+                "tool_requests must be an array.",
+                "invalid_schema",
+            ));
+            summary.rejected_requests = rejected.len();
+            return ParsedToolIntent {
+                requests: Vec::new(),
+                rejected,
+                summary,
+            };
+        };
+        if items.len() > config.max_tool_requests {
+            rejected.push(rejection(
+                None,
+                "tool_requests exceeds parser count limit.",
+                "too_many_requests",
+            ));
+            summary.rejected_requests = rejected.len();
+            return ParsedToolIntent {
+                requests: Vec::new(),
+                rejected,
+                summary,
+            };
+        }
         let mut requests = Vec::new();
-        let mut rejected = Vec::new();
         for item in items {
-            let tool_id = item
+            let Some(obj) = item.as_object() else {
+                rejected.push(rejection(
+                    None,
+                    "tool request must be an object.",
+                    "invalid_schema",
+                ));
+                continue;
+            };
+            if obj
+                .keys()
+                .any(|key| !matches!(key.as_str(), "tool_id" | "reason" | "input"))
+            {
+                rejected.push(rejection(
+                    None,
+                    "Unknown field in tool request.",
+                    "unknown_field",
+                ));
+                continue;
+            }
+            let tool_id = obj
                 .get("tool_id")
                 .and_then(Value::as_str)
                 .map(str::to_string);
-            let reason = item
+            let reason = obj
                 .get("reason")
                 .and_then(Value::as_str)
                 .map(str::to_string);
-            let input = match item.get("input") {
+            let Some(tool_id_value) = tool_id.clone() else {
+                rejected.push(rejection(
+                    None,
+                    "tool_id must be a string.",
+                    "invalid_schema",
+                ));
+                continue;
+            };
+            let Some(reason_value) = reason else {
+                rejected.push(rejection(
+                    Some(tool_id_value),
+                    "reason must be a string.",
+                    "invalid_schema",
+                ));
+                continue;
+            };
+            if reason_value.chars().count() > config.max_reason_chars {
+                rejected.push(rejection(
+                    Some(tool_id_value),
+                    "reason exceeds parser length limit.",
+                    "input_too_large",
+                ));
+                continue;
+            }
+            if BuiltinToolRegistry::get(&tool_id_value).is_none() {
+                rejected.push(rejection(
+                    Some(tool_id_value),
+                    "Unknown tool id.",
+                    "unknown_tool",
+                ));
+                continue;
+            }
+            let input = match obj.get("input") {
                 Some(value) if value.is_object() => value.clone(),
                 Some(_) => {
-                    rejected.push(RejectedToolIntent {
-                        tool_id,
-                        reason: "input must be an object when provided.".to_string(),
-                    });
+                    rejected.push(rejection(
+                        Some(tool_id_value),
+                        "input must be an object when provided.",
+                        "invalid_input",
+                    ));
                     continue;
                 }
                 None => empty_input_object(),
             };
-            match (tool_id, reason) {
-                (Some(tool_id), Some(reason)) if BuiltinToolRegistry::get(&tool_id).is_some() => {
-                    requests.push(AssistantToolRequest {
-                        tool_id,
-                        reason,
-                        input,
-                    })
-                }
-                (Some(tool_id), Some(_)) => rejected.push(RejectedToolIntent {
-                    tool_id: Some(tool_id),
-                    reason: "Unknown tool id.".to_string(),
-                }),
-                (tool_id, _) => rejected.push(RejectedToolIntent {
-                    tool_id,
-                    reason: "tool_id and reason must be strings.".to_string(),
-                }),
+            if input.to_string().len() > config.max_input_bytes {
+                rejected.push(rejection(
+                    Some(tool_id_value),
+                    "input exceeds parser size limit.",
+                    "input_too_large",
+                ));
+                continue;
             }
+            if tool_id_value == WORKSPACE_READ_TOOL_ID {
+                if let Err(reason) = preflight_workspace_read_input(&input) {
+                    rejected.push(rejection(Some(tool_id_value), reason, "invalid_input"));
+                    continue;
+                }
+            }
+            requests.push(AssistantToolRequest {
+                tool_id: tool_id_value,
+                reason: reason_value,
+                input,
+            });
         }
-        ParsedToolIntent { requests, rejected }
+        summary.accepted_requests = requests.len();
+        summary.rejected_requests = rejected.len();
+        ParsedToolIntent {
+            requests,
+            rejected,
+            summary,
+        }
     }
+}
+
+fn rejection(tool_id: Option<String>, reason: impl Into<String>, code: &str) -> RejectedToolIntent {
+    RejectedToolIntent {
+        tool_id,
+        reason: reason.into(),
+        code: code.to_string(),
+    }
+}
+
+pub fn preflight_workspace_read_path(relative_path: &str) -> Result<(), &'static str> {
+    if relative_path.trim().is_empty() {
+        return Err("workspace.read input.path must not be empty.");
+    }
+    let requested_path = Path::new(relative_path);
+    if requested_path.is_absolute() {
+        return Err("workspace.read input.path must be workspace-relative.");
+    }
+    for component in requested_path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err("workspace.read input.path must not contain path traversal.")
+            }
+            Component::Normal(name) if is_blocked_component(name.to_string_lossy().as_ref()) => {
+                return Err("workspace.read input.path targets a protected workspace path.")
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err("workspace.read input.path must be workspace-relative.")
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn preflight_workspace_read_input(input: &Value) -> Result<(), &'static str> {
+    let Some(path) = input.get("path").and_then(Value::as_str) else {
+        return Err("workspace.read input.path must be a string.");
+    };
+    preflight_workspace_read_path(path)
+}
+
+fn extract_fenced_blocks(content: &str) -> Vec<&str> {
+    let marker = "```brownie-tool-intent";
+    let mut blocks = Vec::new();
+    let mut rest = content;
+    while let Some(pos) = rest.find(marker) {
+        let after = &rest[pos + marker.len()..];
+        let after = after
+            .strip_prefix('\r')
+            .unwrap_or(after)
+            .strip_prefix('\n')
+            .unwrap_or(after);
+        let Some(end) = after.find("```") else {
+            break;
+        };
+        blocks.push(&after[..end]);
+        rest = &after[end + 3..];
+    }
+    blocks
 }
 
 fn empty_input_object() -> serde_json::Value {
     serde_json::json!({})
-}
-
-fn extract_fenced_block(content: &str) -> Option<&str> {
-    let marker = "```brownie-tool-intent";
-    let start = content.find(marker)? + marker.len();
-    let rest = &content[start..];
-    let rest = rest
-        .strip_prefix('\r')
-        .unwrap_or(rest)
-        .strip_prefix('\n')
-        .unwrap_or(rest);
-    let end = rest.find("```")?;
-    Some(&rest[..end])
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -375,6 +632,7 @@ impl ToolIntentEvaluator {
                 rejected.push(RejectedToolIntent {
                     tool_id: Some(request.tool_id),
                     reason: "Unknown tool id.".to_string(),
+                    code: "unknown_tool".to_string(),
                 });
                 continue;
             };
@@ -546,7 +804,7 @@ mod tests {
     }
     #[test]
     fn parser_parses_valid_fenced_json() {
-        let parsed = ToolIntentParser::parse_assistant_content("x\n```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\"}]}\n```");
+        let parsed = ToolIntentParser::parse_assistant_content("x\n```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"README.md\"}}]}\n```");
         assert_eq!(parsed.requests.len(), 1);
         assert!(parsed.rejected.is_empty());
     }
@@ -563,6 +821,35 @@ mod tests {
         assert!(parsed.requests.is_empty());
         assert_eq!(parsed.rejected.len(), 1);
     }
+
+    #[test]
+    fn parser_rejects_missing_closing_fence_and_path_traversal() {
+        let missing = ToolIntentParser::parse_assistant_content("```brownie-tool-intent\n{}");
+        assert_eq!(missing.rejected[0].code, "missing_closing_fence");
+
+        let traversal = ToolIntentParser::parse_assistant_content("```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"../secret.txt\"}}]}\n```");
+        assert!(traversal.requests.is_empty());
+        assert_eq!(traversal.rejected[0].code, "invalid_input");
+    }
+
+    #[test]
+    fn parser_rejects_unknown_fields_and_oversized_blocks() {
+        let unknown = ToolIntentParser::parse_assistant_content(
+            "```brownie-tool-intent\n{\"tool_requests\":[],\"raw\":\"do not keep\"}\n```",
+        );
+        assert_eq!(unknown.rejected[0].code, "unknown_field");
+
+        let config = ToolIntentParserConfig {
+            max_block_bytes: 2,
+            ..ToolIntentParserConfig::default()
+        };
+        let oversized = ToolIntentParser::parse_assistant_content_with_config(
+            "```brownie-tool-intent\n{}\n```",
+            &config,
+        );
+        assert_eq!(oversized.rejected[0].code, "block_too_large");
+    }
+
     #[test]
     fn parser_rejects_unknown_tool_id() {
         let parsed = ToolIntentParser::parse_assistant_content("```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"unknown.tool\",\"reason\":\"Need it.\"}]}\n```");
@@ -601,6 +888,7 @@ mod tests {
                 },
             ],
             rejected: vec![],
+            summary: ToolIntentParserSummary::new(&ToolIntentParserConfig::default()),
         };
         let evaluation = ToolIntentEvaluator::evaluate(&policy, parsed);
         assert!(evaluation

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -65,8 +65,21 @@ export interface RuntimeDiagnosticsResult {
   config_source: string;
   active_profile?: string | null;
   llm_status: LlmStatusResult;
+  parser_config: ToolIntentParserSummary;
   diagnostics: RuntimeDiagnostic[];
 }
+export interface ToolIntentParserSummary {
+  found_blocks: number;
+  accepted_blocks: number;
+  accepted_requests: number;
+  rejected_requests: number;
+  max_blocks: number;
+  max_block_bytes: number;
+  max_tool_requests: number;
+  max_input_bytes: number;
+  max_reason_chars: number;
+}
+
 
 export interface LlmHealthResult {
   provider: string;
@@ -145,10 +158,12 @@ export interface ToolIntentDecisionSummary {
 export interface ToolIntentRejectedSummary {
   tool_id?: string | null;
   reason: string;
+  code: string;
 }
 
 export interface ToolIntentParseResult {
   mode_id: string;
+  parser: ToolIntentParserSummary;
   items: ToolIntentDecisionSummary[];
   rejected: ToolIntentRejectedSummary[];
 }
@@ -303,6 +318,7 @@ export function isRuntimeDiagnosticsResult(value: unknown): value is RuntimeDiag
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
     isLlmStatusResult(value.llm_status) &&
+    isToolIntentParserSummary(value.parser_config) &&
     Array.isArray(value.diagnostics) &&
     value.diagnostics.every(isRuntimeDiagnostic) &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')
@@ -369,6 +385,7 @@ export function isToolIntentParseResult(value: unknown): value is ToolIntentPars
   return (
     isRecord(value) &&
     typeof value.mode_id === 'string' &&
+    isToolIntentParserSummary(value.parser) &&
     Array.isArray(value.items) &&
     value.items.every(isToolIntentDecisionSummary) &&
     Array.isArray(value.rejected) &&
@@ -411,7 +428,23 @@ function isToolIntentRejectedSummary(value: unknown): value is ToolIntentRejecte
   return (
     isRecord(value) &&
     (value.tool_id === undefined || value.tool_id === null || typeof value.tool_id === 'string') &&
-    typeof value.reason === 'string'
+    typeof value.reason === 'string' &&
+    typeof value.code === 'string'
+  );
+}
+
+function isToolIntentParserSummary(value: unknown): value is ToolIntentParserSummary {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.found_blocks) &&
+    isNonNegativeInteger(value.accepted_blocks) &&
+    isNonNegativeInteger(value.accepted_requests) &&
+    isNonNegativeInteger(value.rejected_requests) &&
+    isNonNegativeInteger(value.max_blocks) &&
+    isNonNegativeInteger(value.max_block_bytes) &&
+    isNonNegativeInteger(value.max_tool_requests) &&
+    isNonNegativeInteger(value.max_input_bytes) &&
+    isNonNegativeInteger(value.max_reason_chars)
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -65,14 +65,10 @@ export interface RuntimeDiagnosticsResult {
   config_source: string;
   active_profile?: string | null;
   llm_status: LlmStatusResult;
-  parser_config: ToolIntentParserSummary;
+  parser_config: ToolIntentParserConfigSummary;
   diagnostics: RuntimeDiagnostic[];
 }
-export interface ToolIntentParserSummary {
-  found_blocks: number;
-  accepted_blocks: number;
-  accepted_requests: number;
-  rejected_requests: number;
+export interface ToolIntentParserConfigSummary {
   max_blocks: number;
   max_block_bytes: number;
   max_tool_requests: number;
@@ -80,6 +76,12 @@ export interface ToolIntentParserSummary {
   max_reason_chars: number;
 }
 
+export interface ToolIntentParserSummary extends ToolIntentParserConfigSummary {
+  found_blocks: number;
+  accepted_blocks: number;
+  accepted_requests: number;
+  rejected_requests: number;
+}
 
 export interface LlmHealthResult {
   provider: string;
@@ -318,7 +320,7 @@ export function isRuntimeDiagnosticsResult(value: unknown): value is RuntimeDiag
     typeof value.config_source === 'string' &&
     (value.active_profile === undefined || value.active_profile === null || typeof value.active_profile === 'string') &&
     isLlmStatusResult(value.llm_status) &&
-    isToolIntentParserSummary(value.parser_config) &&
+    isToolIntentParserConfigSummary(value.parser_config) &&
     Array.isArray(value.diagnostics) &&
     value.diagnostics.every(isRuntimeDiagnostic) &&
     !Object.prototype.hasOwnProperty.call(value, 'api_key')
@@ -433,18 +435,25 @@ function isToolIntentRejectedSummary(value: unknown): value is ToolIntentRejecte
   );
 }
 
-function isToolIntentParserSummary(value: unknown): value is ToolIntentParserSummary {
+function isToolIntentParserConfigSummary(value: unknown): value is ToolIntentParserConfigSummary {
   return (
     isRecord(value) &&
-    isNonNegativeInteger(value.found_blocks) &&
-    isNonNegativeInteger(value.accepted_blocks) &&
-    isNonNegativeInteger(value.accepted_requests) &&
-    isNonNegativeInteger(value.rejected_requests) &&
     isNonNegativeInteger(value.max_blocks) &&
     isNonNegativeInteger(value.max_block_bytes) &&
     isNonNegativeInteger(value.max_tool_requests) &&
     isNonNegativeInteger(value.max_input_bytes) &&
     isNonNegativeInteger(value.max_reason_chars)
+  );
+}
+
+function isToolIntentParserSummary(value: unknown): value is ToolIntentParserSummary {
+  return (
+    isToolIntentParserConfigSummary(value) &&
+    isRecord(value) &&
+    isNonNegativeInteger(value.found_blocks) &&
+    isNonNegativeInteger(value.accepted_blocks) &&
+    isNonNegativeInteger(value.accepted_requests) &&
+    isNonNegativeInteger(value.rejected_requests)
   );
 }
 

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -76,10 +76,10 @@ describe('protocol validation', () => {
 
   it('accepts valid runtime diagnostics results', () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, diagnostics: [], api_key: 'secret' })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [], api_key: 'secret' })).toBe(false);
   });
 
   it('accepts valid llm.health results and rejects invalid health fields', () => {
@@ -122,8 +122,9 @@ describe('protocol validation', () => {
   it('accepts valid tool intent parse results and rejects invalid decision shapes', () => {
     const result = {
       mode_id: 'orchestrator',
+      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
       items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context' }],
-      rejected: [{ tool_id: null, reason: 'bad json' }, { reason: 'missing id is ok' }],
+      rejected: [{ tool_id: null, reason: 'bad json', code: 'malformed_json' }, { reason: 'missing id is ok', code: 'invalid_schema' }],
     };
     expect(isToolIntentParseResult(result)).toBe(true);
     expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'Nope', allowed: true, reason: 'ok', request_reason: 'need context' }] })).toBe(false);
@@ -215,7 +216,7 @@ describe('RuntimeClient', () => {
 
   it('creates a runtime.diagnostics.get request', async () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    const result = { config_source: 'Default', active_profile: null, llm_status, diagnostics: [] };
+    const result = { config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
     await expect(client.runtimeDiagnostics()).resolves.toEqual(result);
@@ -331,6 +332,7 @@ describe('RuntimeClient', () => {
   it('creates a tool.intent.parse request', async () => {
     const result = {
       mode_id: 'orchestrator',
+      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
       items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'Need context.' }],
       rejected: [],
     };
@@ -342,7 +344,7 @@ describe('RuntimeClient', () => {
   });
 
   it('rejects invalid tool.intent.parse results', async () => {
-    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.' }], rejected: [] } });
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.' }], rejected: [] } });
     const client = new RuntimeClient(transport);
 
     await expect(client.parseToolIntent('orchestrator', 'content')).rejects.toThrow('tool.intent.parse returned an invalid result');

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -76,10 +76,10 @@ describe('protocol validation', () => {
 
   it('accepts valid runtime diagnostics results', () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [], api_key: 'secret' })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [], api_key: 'secret' })).toBe(false);
   });
 
   it('accepts valid llm.health results and rejects invalid health fields', () => {
@@ -216,7 +216,7 @@ describe('RuntimeClient', () => {
 
   it('creates a runtime.diagnostics.get request', async () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    const result = { config_source: 'Default', active_profile: null, llm_status, parser_config: { found_blocks: 0, accepted_blocks: 0, accepted_requests: 0, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [] };
+    const result = { config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
     await expect(client.runtimeDiagnostics()).resolves.toEqual(result);


### PR DESCRIPTION
### Motivation

- Treat assistant/provider `brownie-tool-intent` output as untrusted and enforce parser-level limits and validation to prevent oversized, malformed, or malicious intent payloads.
- Prevent raw provider responses and raw intent JSON or secret-like values from being persisted to ledger/inspection paths by storing only bounded summaries and rejection codes.
- Add early parser-level preflight checks for `workspace.read` `input.path` to reject invalid paths before permission evaluation or execution.

### Description

- Added `ToolIntentParserConfig` with defaults and limits (`max_blocks=1`, `max_block_bytes=16384`, `max_tool_requests=8`, `max_input_bytes=4096`, `max_reason_chars=1000`) and a `ToolIntentParserSummary` returned by `tool.intent.parse` and stored in parser metadata. (`crates/brownie-tools`, `crates/brownie-protocol`, `crates/brownie-runtime`).
- Replaced single-block extraction with `extract_fenced_blocks` and hardened fenced-block handling to reject missing closing fences, multiple blocks, oversized blocks, and malformed JSON with stable rejection codes (e.g. `missing_closing_fence`, `too_many_blocks`, `block_too_large`, `malformed_json`, `invalid_schema`, `unknown_field`, `too_many_requests`, `input_too_large`, `unknown_tool`, `invalid_input`).
- Tightened JSON schema validation: top-level must be an object with exactly `tool_requests` array, each request must be an object with only `tool_id`, `reason`, and optional object `input`, and `reason`/`input` sizes are bounded; unknown tool IDs are rejected early. Added `preflight_workspace_read_input` to validate `input.path` (no empty, no absolute, no `..`, no protected components). (`crates/brownie-tools`).
- Sanitized ledger/inspection payloads to avoid storing raw provider responses or raw intent JSON by recording parser metadata, rejection codes, and a bounded `input_summary` instead of full input; updated `append_tool_intent_events` to persist these summaries. (`crates/brownie-runtime`).
- Added `ToolIntentParserConfigSummary` to runtime diagnostics and exported parser summary types in the protocol, and updated VSIX runtime protocol validators/types and tests to accept the new `parser`/`parser_config` shapes and `code` field on rejections. (`crates/brownie-protocol`, `extensions/brownie-vsix`).
- Added unit tests covering fence/malformed/oversize/unknown-field/unknown-tool/path-preflight behaviors and updated VSIX tests for protocol changes. (`crates/brownie-tools` tests, `extensions/brownie-vsix` tests).

### Testing

- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all Rust checks and unit tests passed successfully.
- Ran VSIX checks and tests with `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and TypeScript validation, vitest suite, and build completed successfully.
- Performed full manual smoke flow: `pnpm install` (lockfile unchanged), Rust build/test, VSIX validation/tests/build; all steps completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41967759f083288072fdaa24d1f92c)