### PR TITLE
Remove raw tool intent input from parse response and add typed input_summary

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -234,13 +234,19 @@ pub struct ToolIntentParserSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ToolIntentInputSummary {
+    pub has_path: bool,
+    pub field_count: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ToolIntentDecisionSummary {
     pub tool_id: String,
     pub required_action: RuntimeActionName,
     pub allowed: bool,
     pub reason: String,
     pub request_reason: String,
-    pub input: serde_json::Value,
+    pub input_summary: ToolIntentInputSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -22,9 +22,10 @@ use brownie_protocol::{
     RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams,
     TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams,
     TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus,
-    ToolIntentDecisionSummary, ToolIntentParseParams, ToolIntentParseResult,
-    ToolIntentParserConfigSummary, ToolIntentParserSummary, ToolIntentRejectedSummary,
-    ToolListResult, ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
+    ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
+    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -2092,7 +2093,7 @@ fn tool_intent_decision_summary(decision: ToolIntentDecision) -> ToolIntentDecis
         allowed: decision.allowed,
         reason: decision.reason,
         request_reason: decision.request_reason,
-        input: decision.input,
+        input_summary: tool_intent_input_summary(&decision.input),
     }
 }
 
@@ -2131,11 +2132,15 @@ fn tool_intent_parser_config_summary() -> ToolIntentParserConfigSummary {
     }
 }
 
+fn tool_intent_input_summary(input: &Value) -> ToolIntentInputSummary {
+    ToolIntentInputSummary {
+        has_path: input.get("path").and_then(Value::as_str).is_some(),
+        field_count: input.as_object().map(|object| object.len()).unwrap_or(0),
+    }
+}
+
 fn summarize_intent_input(input: &Value) -> Value {
-    json!({
-        "has_path": input.get("path").and_then(Value::as_str).is_some(),
-        "field_count": input.as_object().map(|object| object.len()).unwrap_or(0),
-    })
+    json!(tool_intent_input_summary(input))
 }
 
 fn tool_execute_result(result: brownie_tools::ToolExecutionResult) -> ToolExecuteResult {
@@ -3175,8 +3180,50 @@ mod tests {
         assert_eq!(result["mode_id"], "orchestrator");
         assert_eq!(result["items"][0]["tool_id"], "workspace.read");
         assert_eq!(result["items"][0]["allowed"], true);
+        assert_eq!(result["items"][0]["input_summary"]["has_path"], true);
+        assert_eq!(result["items"][0]["input_summary"]["field_count"], 1);
+        assert!(result["items"][0].get("input").is_none());
         assert_eq!(result["items"][1]["tool_id"], "workspace.write");
         assert_eq!(result["items"][1]["allowed"], false);
+    }
+
+    #[test]
+    fn tool_intent_parse_does_not_return_raw_input_or_suspicious_path() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"../secret.txt\",\"extra\":\"do-not-return\"}}]}\n```"}}"#,
+        );
+        assert!(response.error.is_none());
+        let result = response.result.expect("result");
+        assert!(result.to_string().contains("invalid_input"));
+        assert!(!result.to_string().contains("../secret.txt"));
+        assert!(!result.to_string().contains("do-not-return"));
+        assert!(result["items"].as_array().expect("items").is_empty());
+        assert_eq!(result["rejected"][0]["code"], "invalid_input");
+    }
+
+    #[test]
+    fn tool_intent_parse_rejected_response_omits_raw_input_json() {
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.unknown\",\"reason\":\"Try unknown.\",\"input\":{\"path\":\"README.md\",\"secret\":\"Bearer abc123\"}}]}\n```"}}"#,
+        );
+        assert!(response.error.is_none());
+        let result = response.result.expect("result");
+        assert!(result["items"].as_array().expect("items").is_empty());
+        assert_eq!(result["rejected"][0]["code"], "unknown_tool");
+        let result_text = result.to_string();
+        assert!(!result_text.contains("README.md"));
+        assert!(!result_text.contains("Bearer abc123"));
+        assert!(!result_text.contains("secret"));
+        assert!(result["items"]
+            .as_array()
+            .expect("items")
+            .iter()
+            .all(|item| item.get("input").is_none()));
+        assert!(result["rejected"]
+            .as_array()
+            .expect("rejected")
+            .iter()
+            .all(|item| item.get("input").is_none()));
     }
 
     #[test]

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -254,3 +254,17 @@ See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provide
 ## Phase 2.8 prompt sensitive guard
 
 Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.
+
+## `tool.intent.parse` trust boundary
+
+Provider responses are untrusted input. The `tool.intent.parse` method parses fenced `brownie-tool-intent` blocks, validates parser limits and schemas, runs `workspace.read` path preflight, and returns only parser metadata plus summaries.
+
+`ToolIntentDecisionSummary` contains `input_summary`:
+
+```json
+{"has_path":true,"field_count":1}
+```
+
+It must not contain a raw `input` field. Raw provider responses and raw `brownie-tool-intent` JSON are never returned by this RPC. Rejected requests include stable rejection codes such as `malformed_json`, `invalid_schema`, `unknown_tool`, and `invalid_input` without echoing raw input JSON.
+
+Ledger and inspection surfaces follow the same trust boundary: parser metadata, rejection codes, and input summaries may be stored or displayed; raw provider responses and raw intent JSON must not be stored or displayed.

--- a/docs/specifications/tool-intent-parser-hardening-spec-v0.md
+++ b/docs/specifications/tool-intent-parser-hardening-spec-v0.md
@@ -1,0 +1,38 @@
+# Tool Intent Parser Hardening Spec v0
+
+## Trust boundary
+
+Provider responses are untrusted input. The runtime must parse `brownie-tool-intent` fenced blocks defensively, validate schema and size limits before policy evaluation, and never treat assistant-provided JSON as authoritative instructions.
+
+## RPC response shape
+
+`tool.intent.parse` returns parser metadata plus evaluated or rejected summaries only:
+
+- `parser`: block/request counts and configured parser limits.
+- `items[].input_summary`: typed summary metadata with `has_path` and `field_count`.
+- `rejected[]`: rejected request summaries with stable rejection `code` values.
+
+Raw provider responses and raw `brownie-tool-intent` JSON are never returned by `tool.intent.parse`. Raw request `input` JSON is also never returned by `tool.intent.parse`; callers only receive `input_summary`.
+
+## Rejection codes
+
+The parser uses stable rejection codes for malformed or unsafe requests, including:
+
+- `missing_block`
+- `too_many_blocks`
+- `block_too_large`
+- `malformed_json`
+- `invalid_schema`
+- `too_many_requests`
+- `input_too_large`
+- `reason_too_long`
+- `unknown_tool`
+- `invalid_input`
+
+## `workspace.read` path preflight
+
+`workspace.read` requests must include `input.path` as a workspace-relative string. The parser rejects empty paths, absolute paths, path traversal, and protected workspace components before the request can be evaluated or executed. Invalid `workspace.read` paths are rejected with `invalid_input` and are not echoed in RPC responses, ledger inspection, diagnostics, or parser summaries.
+
+## Ledger and inspection
+
+Ledger and inspection views store parser metadata and input summaries only for tool-intent permission events such as `ToolIntentPermissionChecked`, `ToolIntentApproved`, and `ToolIntentDenied`. They must not persist or expose raw provider responses or raw `brownie-tool-intent` JSON. Inspection sanitization must not expose raw execution input.

--- a/docs/specifications/tool-intent-spec-v0.md
+++ b/docs/specifications/tool-intent-spec-v0.md
@@ -25,3 +25,11 @@ For approved `workspace.read` intents with explicit `input.path`, the runtime re
 Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` after an approved `workspace.read` execution completes. The runtime re-reads the task ledger, materializes the tool execution summary into the next prompt, builds a second-pass prompt, and records `SecondPassPromptBuilt`, `SecondPassLlmRequestCreated`, and `SecondPassLlmResponseReceived` ledger events.
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
+
+## Parser hardening and protocol summaries
+
+Provider responses are untrusted input. Tool intent parsing validates fenced block count, block size, request count, request schema, input size, reason length, tool IDs, and `workspace.read` path preflight before any permission evaluation or execution path.
+
+`tool.intent.parse` returns the parser summary and typed `input_summary` values only. It never returns raw provider responses, raw `brownie-tool-intent` JSON, or raw request `input` JSON. Unknown tools and invalid `workspace.read` paths are rejected and are not executed.
+
+Rejected tool intent uses stable codes such as `malformed_json`, `invalid_schema`, `unknown_tool`, and `invalid_input`. Ledger and inspection records for `ToolIntentPermissionChecked`, `ToolIntentApproved`, and `ToolIntentDenied` store parser metadata and summaries only, including `input_summary`; they do not store raw provider responses or raw intent JSON.

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -149,12 +149,18 @@ export interface ToolPlanResult {
   items: ToolPlanDecisionSummary[];
 }
 
+export interface ToolIntentInputSummary {
+  has_path: boolean;
+  field_count: number;
+}
+
 export interface ToolIntentDecisionSummary {
   tool_id: string;
   required_action: RuntimeActionName;
   allowed: boolean;
   reason: string;
   request_reason: string;
+  input_summary: ToolIntentInputSummary;
 }
 
 export interface ToolIntentRejectedSummary {
@@ -415,14 +421,24 @@ export function isToolExecuteResult(value: unknown): value is ToolExecuteResult 
   );
 }
 
+function isToolIntentInputSummary(value: unknown): value is ToolIntentInputSummary {
+  if (!isRecord(value) || typeof value.has_path !== 'boolean') {
+    return false;
+  }
+  const fieldCount = value.field_count;
+  return Number.isInteger(fieldCount) && typeof fieldCount === 'number' && fieldCount >= 0;
+}
+
 function isToolIntentDecisionSummary(value: unknown): value is ToolIntentDecisionSummary {
   return (
     isRecord(value) &&
+    !Object.prototype.hasOwnProperty.call(value, 'input') &&
     typeof value.tool_id === 'string' &&
     isRuntimeActionName(value.required_action) &&
     typeof value.allowed === 'boolean' &&
     typeof value.reason === 'string' &&
-    typeof value.request_reason === 'string'
+    typeof value.request_reason === 'string' &&
+    isToolIntentInputSummary(value.input_summary)
   );
 }
 

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -123,11 +123,14 @@ describe('protocol validation', () => {
     const result = {
       mode_id: 'orchestrator',
       parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
-      items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context' }],
+      items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context', input_summary: { has_path: true, field_count: 1 } }],
       rejected: [{ tool_id: null, reason: 'bad json', code: 'malformed_json' }, { reason: 'missing id is ok', code: 'invalid_schema' }],
     };
     expect(isToolIntentParseResult(result)).toBe(true);
-    expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'Nope', allowed: true, reason: 'ok', request_reason: 'need context' }] })).toBe(false);
+    expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'Nope', allowed: true, reason: 'ok', request_reason: 'need context', input_summary: { has_path: true, field_count: 1 } }] })).toBe(false);
+    expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context', input_summary: { has_path: true, field_count: 1 }, input: { path: 'README.md' } }] })).toBe(false);
+    expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context' }] })).toBe(false);
+    expect(isToolIntentParseResult({ ...result, items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context', input_summary: { has_path: true, field_count: -1 } }] })).toBe(false);
   });
 
   it('accepts valid tool.plan results and rejects invalid item shapes', () => {
@@ -333,7 +336,7 @@ describe('RuntimeClient', () => {
     const result = {
       mode_id: 'orchestrator',
       parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
-      items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'Need context.' }],
+      items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'Need context.', input_summary: { has_path: true, field_count: 1 } }],
       rejected: [],
     };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
@@ -344,7 +347,7 @@ describe('RuntimeClient', () => {
   });
 
   it('rejects invalid tool.intent.parse results', async () => {
-    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.' }], rejected: [] } });
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.', input_summary: { has_path: true, field_count: 1 } }], rejected: [] } });
     const client = new RuntimeClient(transport);
 
     await expect(client.parseToolIntent('orchestrator', 'content')).rejects.toThrow('tool.intent.parse returned an invalid result');


### PR DESCRIPTION
### Motivation

- Prevent returning untrusted raw provider input (including potential secrets) in `tool.intent.parse` RPC responses and ledger/inspection surfaces.
- Standardize the protocol to provide a small typed summary of intent inputs rather than echoing raw `input` JSON across the Rust runtime and VSIX boundary.
- Harden parsing behavior to reject suspicious `workspace.read` paths and ensure unknown or invalid requests are safely rejected without echoing raw content.

### Description

- Added a typed `ToolIntentInputSummary` struct and replaced raw `input: serde_json::Value` with `input_summary: ToolIntentInputSummary` in `ToolIntentDecisionSummary` in `crates/brownie-protocol/src/lib.rs`.
- Updated runtime mapping in `crates/brownie-runtime/src/lib.rs` to emit `input_summary` via a new `tool_intent_input_summary()` helper and to serialize summaries for ledger events instead of raw input.
- Modified VSIX protocol in `extensions/brownie-vsix/src/runtime/protocol.ts` to declare `ToolIntentInputSummary`, require `input_summary` on decisions, validate `field_count` as a non-negative integer, and explicitly reject results containing raw `input`.
- Added and adjusted tests: Rust unit tests in `crates/brownie-runtime` now assert presence of `input_summary` and absence of `input` (including rejected-response checks), and VSIX tests in `extensions/brownie-vsix` validate the new shapes and reject raw `input`.
- Documented the trust boundary and parser hardening in `docs/specifications/tool-intent-parser-hardening-spec-v0.md` and updated `runtime-protocol-spec-v0.md` and `tool-intent-spec-v0.md` to reflect the summary-only policy.

### Testing

- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, all of which passed.
- Ran `pnpm install` followed by `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and all succeeded.
- Performed a manual smoke test invoking `tool.intent.parse` against the runtime (via a JSON-RPC request) and observed `items[].input_summary` present while `items[].input` was not returned, matching the expected behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41a8703d808328821f91fbdbd3f561)