### PR TITLE
Add workspace.write dry-run patch proposals and `proposal.list` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "time",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -310,6 +310,8 @@ impl FakeLlm {
             .map(|(tool_id, reason)| {
                 if tool_id == "workspace.read" {
                     serde_json::json!({ "tool_id": tool_id, "reason": reason, "input": { "path": "README.md" } })
+                } else if tool_id == "workspace.write" {
+                    serde_json::json!({ "tool_id": tool_id, "reason": reason, "input": { "path": "README.md", "operation": "replace_file", "content": "new README content" } })
                 } else {
                     serde_json::json!({ "tool_id": tool_id, "reason": reason })
                 }

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -76,6 +76,7 @@ pub struct ToolIntentParserConfigSummary {
     pub max_tool_requests: usize,
     pub max_input_bytes: usize,
     pub max_reason_chars: usize,
+    pub max_workspace_write_content_chars: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -231,6 +232,7 @@ pub struct ToolIntentParserSummary {
     pub max_tool_requests: usize,
     pub max_input_bytes: usize,
     pub max_reason_chars: usize,
+    pub max_workspace_write_content_chars: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -324,6 +326,11 @@ pub struct RunInspectParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalListParams {
+    pub run_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskInspectParams {
     pub task_id: String,
 }
@@ -349,6 +356,22 @@ pub struct RunEventsResult {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct RunInspectResult {
     pub run: RunInspectSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchProposalSummary {
+    pub proposal_id: String,
+    pub path: String,
+    pub operation: String,
+    pub content_preview: String,
+    pub content_chars: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalListResult {
+    pub run_id: String,
+    pub proposals: Vec<WorkspacePatchProposalSummary>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -19,6 +19,7 @@ brownie-tools = { path = "../brownie-tools" }
 serde.workspace = true
 serde_json.workspace = true
 time.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -17,21 +17,22 @@ use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
     LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
     ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
-    PermissionCheckResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
-    RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic,
-    RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams,
-    TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams,
-    TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus,
-    ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
-    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
-    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
-    ToolPlanResult, ToolSummary,
+    PermissionCheckResult, ProposalListParams, ProposalListResult, RunEventsParams,
+    RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
+    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
+    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult,
+    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
+    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary,
+    ToolIntentParseParams, ToolIntentParseResult, ToolIntentParserConfigSummary,
+    ToolIntentParserSummary, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
+    ToolPlanParams, ToolPlanResult, ToolSummary, WorkspacePatchProposalSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
     BuiltinToolRegistry, RejectedToolIntent, ToolExecutionRequest, ToolExecutionStatus,
     ToolExecutor, ToolIntentDecision, ToolIntentEvaluator, ToolIntentParser, ToolPlanDecision,
-    ToolPlanEvaluator, ToolPlanner, ToolPlanningInput, WORKSPACE_READ_TOOL_ID,
+    ToolPlanEvaluator, ToolPlanner, ToolPlanningInput, WorkspacePatchOperation,
+    DEFAULT_PROPOSAL_PREVIEW_CHARS, WORKSPACE_READ_TOOL_ID, WORKSPACE_WRITE_TOOL_ID,
 };
 use serde_json::{json, Value};
 
@@ -55,6 +56,7 @@ const METHOD_TOOL_INTENT_PARSE: &str = "tool.intent.parse";
 const METHOD_TOOL_EXECUTE: &str = "tool.execute";
 const METHOD_RUN_EVENTS: &str = "run.events";
 const METHOD_RUN_INSPECT: &str = "run.inspect";
+const METHOD_PROPOSAL_LIST: &str = "proposal.list";
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -103,6 +105,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TOOL_EXECUTE => handle_tool_execute(request.id, request.params),
         METHOD_RUN_EVENTS => handle_run_events(request.id, request.params),
         METHOD_RUN_INSPECT => handle_run_inspect(request.id, request.params),
+        METHOD_PROPOSAL_LIST => handle_proposal_list(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -1385,12 +1388,9 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     {
         return error_response(id, -32603, &format!("internal error: {error}"));
     }
-    if let Err(error) = execute_approved_workspace_read_intents(
-        &store,
-        &running,
-        &policy,
-        &result.llm_response.content,
-    ) {
+    if let Err(error) =
+        handle_approved_workspace_intents(&store, &running, &policy, &result.llm_response.content)
+    {
         return error_response(id, -32603, &format!("internal error: {error}"));
     }
 
@@ -1654,6 +1654,30 @@ fn handle_run_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value
     }
 }
 
+fn handle_proposal_list(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ProposalListParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: run_id must not be empty");
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match list_proposals(&store, &params.run_id) {
+        Ok(proposals) => result_response(
+            id,
+            json!(ProposalListResult {
+                run_id: params.run_id,
+                proposals
+            }),
+        ),
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
 fn handle_task_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     let params: TaskInspectParams = match parse_params(params) {
         Ok(params) => params,
@@ -1856,6 +1880,28 @@ fn read_existing_run_events(
         .map_err(|error| format!("invalid params: {error}"))
 }
 
+fn list_proposals(
+    store: &BrownieStore,
+    run_id: &str,
+) -> Result<Vec<WorkspacePatchProposalSummary>, String> {
+    let events = read_existing_run_events(store, run_id)?;
+    Ok(events
+        .into_iter()
+        .filter(|event| event.kind == LedgerEventKind::WorkspacePatchProposed)
+        .filter_map(|event| {
+            let payload = sanitize_ledger_payload(event.payload)?;
+            Some(WorkspacePatchProposalSummary {
+                proposal_id: payload.get("proposal_id")?.as_str()?.to_string(),
+                path: payload.get("path")?.as_str()?.to_string(),
+                operation: payload.get("operation")?.as_str()?.to_string(),
+                content_preview: payload.get("content_preview")?.as_str()?.to_string(),
+                content_chars: payload.get("content_chars")?.as_u64()? as usize,
+                truncated: payload.get("truncated")?.as_bool()?,
+            })
+        })
+        .collect())
+}
+
 fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, String> {
     let events = read_existing_run_events(store, run_id)?;
     let task = store
@@ -1943,6 +1989,10 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "parser",
         "code",
         "input_summary",
+        "proposal_id",
+        "operation",
+        "path",
+        "content_chars",
     ];
     let sanitized = map
         .into_iter()
@@ -1967,6 +2017,10 @@ fn timeline_entry(event: &LedgerEvent) -> String {
             "provider",
             "model",
             "message_count",
+            "proposal_id",
+            "operation",
+            "path",
+            "content_chars",
         ] {
             if let Some(value) = payload.get(key) {
                 let value = value
@@ -2118,6 +2172,7 @@ fn tool_intent_parser_summary(
         max_tool_requests: summary.max_tool_requests,
         max_input_bytes: summary.max_input_bytes,
         max_reason_chars: summary.max_reason_chars,
+        max_workspace_write_content_chars: summary.max_workspace_write_content_chars,
     }
 }
 
@@ -2129,6 +2184,7 @@ fn tool_intent_parser_config_summary() -> ToolIntentParserConfigSummary {
         max_tool_requests: config.max_tool_requests,
         max_input_bytes: config.max_input_bytes,
         max_reason_chars: config.max_reason_chars,
+        max_workspace_write_content_chars: config.max_workspace_write_content_chars,
     }
 }
 
@@ -2205,7 +2261,7 @@ fn append_tool_intent_events(
     Ok(())
 }
 
-fn execute_approved_workspace_read_intents(
+fn handle_approved_workspace_intents(
     store: &BrownieStore,
     record: &brownie_protocol::TaskRecord,
     policy: &CompiledModePolicy,
@@ -2216,7 +2272,14 @@ fn execute_approved_workspace_read_intents(
         ToolIntentParser::parse_assistant_content(assistant_content),
     );
     for decision in evaluation.items {
-        if !decision.allowed || decision.tool_id != WORKSPACE_READ_TOOL_ID {
+        if !decision.allowed {
+            continue;
+        }
+        if decision.tool_id == WORKSPACE_WRITE_TOOL_ID {
+            append_workspace_patch_proposal(store, record, &decision)?;
+            continue;
+        }
+        if decision.tool_id != WORKSPACE_READ_TOOL_ID {
             continue;
         }
         store.tasks().append_task_event_with_payload(
@@ -2261,6 +2324,41 @@ fn execute_approved_workspace_read_intents(
             Some(tool_execution_ledger_payload(&result)),
         )?;
     }
+    Ok(())
+}
+
+fn append_workspace_patch_proposal(
+    store: &BrownieStore,
+    record: &brownie_protocol::TaskRecord,
+    decision: &ToolIntentDecision,
+) -> anyhow::Result<()> {
+    let path = decision
+        .input
+        .get("path")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let content = decision
+        .input
+        .get("content")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let content_chars = content.chars().count();
+    let content_preview = preview_with_limit(content, DEFAULT_PROPOSAL_PREVIEW_CHARS);
+    let truncated = content_chars > content_preview.chars().count();
+    let proposal_id = format!("proposal_{}", uuid::Uuid::new_v4().simple());
+    store.tasks().append_task_event_with_payload(
+        record,
+        LedgerEventKind::WorkspacePatchProposed,
+        Some(json!({
+            "proposal_id": proposal_id,
+            "tool_id": WORKSPACE_WRITE_TOOL_ID,
+            "path": path,
+            "operation": WorkspacePatchOperation::ReplaceFile.as_str(),
+            "content_preview": content_preview,
+            "content_chars": content_chars,
+            "truncated": truncated,
+        })),
+    )?;
     Ok(())
 }
 
@@ -2992,6 +3090,81 @@ mod tests {
     }
 
     #[test]
+    fn implementer_workspace_write_creates_proposal_without_modifying_file() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("README.md"), "original README").expect("write readme");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        std::env::remove_var("BROWNIE_LLM_PROVIDER");
+        std::env::remove_var("BROWNIE_LLM_STRICT");
+
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Implement README update","mode_id":"implementer"}}"#,
+        );
+        let start_result = start.result.expect("start result");
+        let task_id = start_result["task_id"]
+            .as_str()
+            .expect("task id")
+            .to_string();
+        let run_id = start_result["run_id"].as_str().expect("run id").to_string();
+
+        let run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{task_id}"}}}}"#
+        ));
+        assert!(run.error.is_none());
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "original README"
+        );
+
+        let events = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
+        ));
+        let events = events.result.expect("events result")["events"]
+            .as_array()
+            .unwrap()
+            .clone();
+        let proposal = events
+            .iter()
+            .find(|event| event["kind"] == "WorkspacePatchProposed")
+            .expect("proposal event");
+        let payload = &proposal["payload"];
+        assert_eq!(payload["tool_id"], "workspace.write");
+        assert_eq!(payload["path"], "README.md");
+        assert_eq!(payload["operation"], "replace_file");
+        assert!(payload.get("content_preview").is_some());
+        assert!(payload.get("content_chars").is_some());
+        assert!(payload.get("content").is_none());
+        assert!(payload.get("raw_content").is_none());
+        assert!(payload.get("patch").is_none());
+        assert!(payload.get("diff").is_none());
+        assert!(payload.get("raw_input").is_none());
+
+        let list = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"proposal.list","params":{{"run_id":"{run_id}"}}}}"#
+        ));
+        let proposals = list.result.expect("proposal result")["proposals"]
+            .as_array()
+            .unwrap()
+            .clone();
+        assert_eq!(proposals.len(), 1);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn proposal_list_unknown_run_returns_invalid_params() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let response = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"proposal.list","params":{"run_id":"run_missing"}}"#,
+        );
+        assert_eq!(response.error.expect("error").code, -32602);
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
     fn task_run_completed_task_returns_invalid_params() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let temp = tempfile::tempdir().expect("tempdir");
@@ -3173,7 +3346,7 @@ mod tests {
     #[test]
     fn tool_intent_parse_returns_evaluated_decisions() {
         let response = parse_line(
-            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"README.md\"}},{\"tool_id\":\"workspace.write\",\"reason\":\"Need edits.\"}]}\n```"}}"#,
+            r#"{"jsonrpc":"2.0","id":1,"method":"tool.intent.parse","params":{"mode_id":"orchestrator","assistant_content":"```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"README.md\"}},{\"tool_id\":\"workspace.write\",\"reason\":\"Need edits.\",\"input\":{\"path\":\"README.md\",\"operation\":\"replace_file\",\"content\":\"new README content\"}}]}\n```"}}"#,
         );
         assert!(response.error.is_none());
         let result = response.result.expect("result");

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -275,6 +275,7 @@ pub enum LedgerEventKind {
     ToolExecutionCompleted,
     ToolExecutionDenied,
     ToolExecutionFailed,
+    WorkspacePatchProposed,
     TaskRunning,
     PromptBuilt,
     PromptSensitiveScanCompleted,

--- a/crates/brownie-tools/src/lib.rs
+++ b/crates/brownie-tools/src/lib.rs
@@ -9,7 +9,12 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
 pub const WORKSPACE_READ_TOOL_ID: &str = "workspace.read";
+pub const WORKSPACE_WRITE_TOOL_ID: &str = "workspace.write";
 pub const MAX_WORKSPACE_READ_BYTES: usize = 65_536;
+pub const DEFAULT_MAX_WORKSPACE_WRITE_CONTENT_CHARS: usize = 20_000;
+pub const MIN_WORKSPACE_WRITE_CONTENT_CHARS: usize = 100;
+pub const MAX_WORKSPACE_WRITE_CONTENT_CHARS: usize = 200_000;
+pub const DEFAULT_PROPOSAL_PREVIEW_CHARS: usize = 2_000;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ToolSideEffectLevel {
@@ -238,6 +243,7 @@ pub struct ToolIntentParserConfig {
     pub max_tool_requests: usize,
     pub max_input_bytes: usize,
     pub max_reason_chars: usize,
+    pub max_workspace_write_content_chars: usize,
 }
 
 impl Default for ToolIntentParserConfig {
@@ -248,6 +254,7 @@ impl Default for ToolIntentParserConfig {
             max_tool_requests: 8,
             max_input_bytes: 4_096,
             max_reason_chars: 1_000,
+            max_workspace_write_content_chars: DEFAULT_MAX_WORKSPACE_WRITE_CONTENT_CHARS,
         }
     }
 }
@@ -263,6 +270,7 @@ pub struct ToolIntentParserSummary {
     pub max_tool_requests: usize,
     pub max_input_bytes: usize,
     pub max_reason_chars: usize,
+    pub max_workspace_write_content_chars: usize,
 }
 
 impl ToolIntentParserSummary {
@@ -277,6 +285,7 @@ impl ToolIntentParserSummary {
             max_tool_requests: config.max_tool_requests,
             max_input_bytes: config.max_input_bytes,
             max_reason_chars: config.max_reason_chars,
+            max_workspace_write_content_chars: config.max_workspace_write_content_chars,
         }
     }
 }
@@ -306,6 +315,97 @@ pub struct RejectedToolIntent {
     pub tool_id: Option<String>,
     pub reason: String,
     pub code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchProposal {
+    pub proposal_id: String,
+    pub task_id: String,
+    pub run_id: String,
+    pub tool_id: String,
+    pub path: String,
+    pub operation: WorkspacePatchOperation,
+    pub content_preview: String,
+    pub content_chars: usize,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum WorkspacePatchOperation {
+    ReplaceFile,
+}
+
+impl WorkspacePatchOperation {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::ReplaceFile => "replace_file",
+        }
+    }
+}
+
+pub fn preflight_workspace_write_input(input: &Value) -> Result<(), &'static str> {
+    preflight_workspace_write_input_with_limit(input, DEFAULT_MAX_WORKSPACE_WRITE_CONTENT_CHARS)
+}
+
+pub fn preflight_workspace_write_input_with_limit(
+    input: &Value,
+    max_content_chars: usize,
+) -> Result<(), &'static str> {
+    let max_content_chars = max_content_chars.clamp(
+        MIN_WORKSPACE_WRITE_CONTENT_CHARS,
+        MAX_WORKSPACE_WRITE_CONTENT_CHARS,
+    );
+    let Some(object) = input.as_object() else {
+        return Err("workspace.write input must be an object.");
+    };
+    let Some(path) = object.get("path") else {
+        return Err("workspace.write input.path is required.");
+    };
+    let Some(path) = path.as_str() else {
+        return Err("workspace.write input.path must be a string.");
+    };
+    preflight_workspace_write_path(path)?;
+    let Some(operation) = object.get("operation") else {
+        return Err("workspace.write input.operation is required.");
+    };
+    if operation.as_str() != Some("replace_file") {
+        return Err("workspace.write input.operation must be replace_file.");
+    }
+    let Some(content) = object.get("content") else {
+        return Err("workspace.write input.content is required.");
+    };
+    let Some(content) = content.as_str() else {
+        return Err("workspace.write input.content must be a string.");
+    };
+    if content.chars().count() > max_content_chars {
+        return Err("workspace.write input.content exceeds parser length limit.");
+    }
+    Ok(())
+}
+
+pub fn preflight_workspace_write_path(relative_path: &str) -> Result<(), &'static str> {
+    if relative_path.trim().is_empty() {
+        return Err("workspace.write input.path must not be empty.");
+    }
+    let requested_path = Path::new(relative_path);
+    if requested_path.is_absolute() {
+        return Err("workspace.write input.path must be workspace-relative.");
+    }
+    for component in requested_path.components() {
+        match component {
+            Component::ParentDir => {
+                return Err("workspace.write input.path must not contain path traversal.")
+            }
+            Component::Normal(name) if is_blocked_component(name.to_string_lossy().as_ref()) => {
+                return Err("workspace.write input.path targets a protected workspace path.")
+            }
+            Component::Prefix(_) | Component::RootDir => {
+                return Err("workspace.write input.path must be workspace-relative.")
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 pub struct ToolIntentParser;
@@ -521,6 +621,15 @@ impl ToolIntentParser {
             }
             if tool_id_value == WORKSPACE_READ_TOOL_ID {
                 if let Err(reason) = preflight_workspace_read_input(&input) {
+                    rejected.push(rejection(Some(tool_id_value), reason, "invalid_input"));
+                    continue;
+                }
+            }
+            if tool_id_value == WORKSPACE_WRITE_TOOL_ID {
+                if let Err(reason) = preflight_workspace_write_input_with_limit(
+                    &input,
+                    config.max_workspace_write_content_chars,
+                ) {
                     rejected.push(rejection(Some(tool_id_value), reason, "invalid_input"));
                     continue;
                 }
@@ -858,10 +967,11 @@ mod tests {
     }
 
     #[test]
-    fn parser_parses_input_object_and_defaults_missing_input() {
+    fn parser_parses_input_object_and_rejects_missing_write_input() {
         let parsed = ToolIntentParser::parse_assistant_content("```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.read\",\"reason\":\"Need context.\",\"input\":{\"path\":\"README.md\"}},{\"tool_id\":\"workspace.write\",\"reason\":\"Need edit.\"}]}\n```");
         assert_eq!(parsed.requests[0].input["path"], "README.md");
-        assert_eq!(parsed.requests[1].input, serde_json::json!({}));
+        assert_eq!(parsed.requests.len(), 1);
+        assert_eq!(parsed.rejected[0].code, "invalid_input");
     }
 
     #[test]
@@ -905,6 +1015,49 @@ mod tests {
             .find(|item| item.tool_id == "workspace.read")
             .expect("read decision");
         assert_eq!(read.input["path"], "README.md");
+    }
+
+    #[test]
+    fn parser_accepts_valid_workspace_write_replace_file_intent() {
+        let parsed = ToolIntentParser::parse_assistant_content("```brownie-tool-intent\n{\"tool_requests\":[{\"tool_id\":\"workspace.write\",\"reason\":\"Propose README update\",\"input\":{\"path\":\"README.md\",\"operation\":\"replace_file\",\"content\":\"new content\"}}]}\n```");
+        assert_eq!(parsed.requests.len(), 1);
+        assert!(parsed.rejected.is_empty());
+    }
+
+    #[test]
+    fn parser_rejects_invalid_workspace_write_inputs() {
+        for (input, reason) in [
+            (
+                serde_json::json!({"operation":"replace_file","content":"x"}),
+                "missing path",
+            ),
+            (
+                serde_json::json!({"path":"/tmp/x","operation":"replace_file","content":"x"}),
+                "absolute path",
+            ),
+            (
+                serde_json::json!({"path":"../README.md","operation":"replace_file","content":"x"}),
+                "parent traversal",
+            ),
+            (
+                serde_json::json!({"path":".git/config","operation":"replace_file","content":"x"}),
+                "protected component",
+            ),
+            (
+                serde_json::json!({"path":"README.md","operation":"append","content":"x"}),
+                "unsupported operation",
+            ),
+        ] {
+            assert!(preflight_workspace_write_input(&input).is_err(), "{reason}");
+        }
+    }
+
+    #[test]
+    fn parser_rejects_workspace_write_content_too_large() {
+        let content = "x".repeat(101);
+        let input =
+            serde_json::json!({"path":"README.md","operation":"replace_file","content":content});
+        assert!(preflight_workspace_write_input_with_limit(&input, 100).is_err());
     }
 
     #[test]

--- a/docs/specifications/patch-proposal-spec-v0.md
+++ b/docs/specifications/patch-proposal-spec-v0.md
@@ -1,0 +1,36 @@
+# Patch Proposal Spec v0
+
+Brownie Phase 3.0 treats `workspace.write` as a dry-run proposal source only.
+The runtime must not modify workspace files, apply patches, invoke git, or execute shell commands for a write intent.
+
+## Accepted intent shape
+
+Only `workspace.write` requests with `operation: "replace_file"` are accepted. The input must include a workspace-relative `path` and string `content`.
+
+Rejected paths include empty paths, absolute paths, parent traversal, and protected components: `.git`, `.brownie`, `node_modules`, and `target`.
+
+## Permission gate
+
+Proposal generation is gated by `WriteWorkspace`. If the active runtime policy denies `WriteWorkspace`, the runtime records the normal denied tool-intent event and does not create a proposal.
+
+## Ledger event
+
+Approved write intents append `WorkspacePatchProposed` with metadata only:
+
+```json
+{
+  "proposal_id": "proposal_...",
+  "tool_id": "workspace.write",
+  "path": "README.md",
+  "operation": "replace_file",
+  "content_preview": "bounded preview",
+  "content_chars": 123,
+  "truncated": false
+}
+```
+
+The ledger event must not include `content`, `raw_content`, `full_content`, `patch`, `diff`, or `raw_input`.
+
+## Inspection
+
+`proposal.list` returns summaries reconstructed from sanitized ledger events for a run. It returns `-32602` when the run does not exist. Responses contain preview/count/truncation metadata only and never full proposed content.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -268,3 +268,7 @@ Provider responses are untrusted input. The `tool.intent.parse` method parses fe
 It must not contain a raw `input` field. Raw provider responses and raw `brownie-tool-intent` JSON are never returned by this RPC. Rejected requests include stable rejection codes such as `malformed_json`, `invalid_schema`, `unknown_tool`, and `invalid_input` without echoing raw input JSON.
 
 Ledger and inspection surfaces follow the same trust boundary: parser metadata, rejection codes, and input summaries may be stored or displayed; raw provider responses and raw intent JSON must not be stored or displayed.
+
+## `proposal.list`
+
+Phase 3.0 adds `proposal.list` with params `{ "run_id": string }`. The result is `{ "run_id": string, "proposals": [...] }`, where each proposal summary contains `proposal_id`, `path`, `operation`, `content_preview`, `content_chars`, and `truncated`. Unknown runs return `-32602`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -171,3 +171,7 @@ See [LLM Request Budget Spec v0](llm-request-budget-spec-v0.md). Runtime provide
 ## Phase 2.8 prompt sensitive guard
 
 Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) with `BROWNIE_LLM_SENSITIVE_GUARD` as the highest-priority override. Fake defaults to `warn`; OpenAI-compatible defaults to `fail`. Provider calls are preceded by budget validation and prompt sensitive-content scanning. In fail mode, findings block the provider call and task failure metadata records only categories, counts, message indexes, and guard mode. Matched secret text, full prompt text, and full provider responses must not be persisted or exposed through status, diagnostics, ledger, or inspection APIs.
+
+## Phase 3.0 patch proposal dry-run path
+
+During `task.run`, approved `workspace.read` intents continue to use read-only execution. Approved `workspace.write` intents are not executed; they create `WorkspacePatchProposed` ledger events with bounded preview metadata only. Denied write intents create no proposal.

--- a/docs/specifications/tool-intent-parser-hardening-spec-v0.md
+++ b/docs/specifications/tool-intent-parser-hardening-spec-v0.md
@@ -36,3 +36,7 @@ The parser uses stable rejection codes for malformed or unsafe requests, includi
 ## Ledger and inspection
 
 Ledger and inspection views store parser metadata and input summaries only for tool-intent permission events such as `ToolIntentPermissionChecked`, `ToolIntentApproved`, and `ToolIntentDenied`. They must not persist or expose raw provider responses or raw `brownie-tool-intent` JSON. Inspection sanitization must not expose raw execution input.
+
+## Phase 3.0 workspace.write preflight
+
+The parser validates `workspace.write` input before permission evaluation. The input must be an object with a relative safe `path`, `operation: "replace_file"`, and string `content` within the configured maximum proposed content character limit. Rejection reasons are high-level and raw input/content is not returned.

--- a/docs/specifications/tool-intent-spec-v0.md
+++ b/docs/specifications/tool-intent-spec-v0.md
@@ -33,3 +33,7 @@ Provider responses are untrusted input. Tool intent parsing validates fenced blo
 `tool.intent.parse` returns the parser summary and typed `input_summary` values only. It never returns raw provider responses, raw `brownie-tool-intent` JSON, or raw request `input` JSON. Unknown tools and invalid `workspace.read` paths are rejected and are not executed.
 
 Rejected tool intent uses stable codes such as `malformed_json`, `invalid_schema`, `unknown_tool`, and `invalid_input`. Ledger and inspection records for `ToolIntentPermissionChecked`, `ToolIntentApproved`, and `ToolIntentDenied` store parser metadata and summaries only, including `input_summary`; they do not store raw provider responses or raw intent JSON.
+
+## Phase 3.0 workspace.write dry-run proposals
+
+`workspace.write` supports only `replace_file` input for Phase 3.0. The parser preflights `path`, `operation`, and `content`, and invalid input is rejected with `code = "invalid_input"` without returning raw content. Approved intents remain dry-run and produce patch proposals only; the runtime does not write files or apply patches.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -76,6 +76,10 @@
       {
         "command": "brownie.toolExecuteRead",
         "title": "Brownie: Execute Read Tool"
+      },
+      {
+        "command": "brownie.proposalList",
+        "title": "Brownie: List Patch Proposals"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -340,6 +340,28 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const proposalListCommand = vscode.commands.registerCommand('brownie.proposalList', async () => {
+    const runId = await vscode.window.showInputBox({
+      prompt: 'Run ID',
+      placeHolder: 'run_...',
+      ignoreFocusOut: true,
+    });
+
+    if (runId === undefined) {
+      return;
+    }
+
+    try {
+      const result = await runtimeClient.listProposals(runId.trim());
+      output.appendLine(`proposal.list: ${JSON.stringify(result, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(`Brownie patch proposals: ${result.proposals.length}`);
+    } catch (error) {
+      output.appendLine(`proposal.list failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie proposal list failed: ${formatError(error)}`);
+    }
+  });
+
   const toolExecuteReadCommand = vscode.commands.registerCommand('brownie.toolExecuteRead', async () => {
     const modeIdInput = await vscode.window.showInputBox({
       prompt: 'Mode ID',
@@ -375,7 +397,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -74,6 +74,7 @@ export interface ToolIntentParserConfigSummary {
   max_tool_requests: number;
   max_input_bytes: number;
   max_reason_chars: number;
+  max_workspace_write_content_chars: number;
 }
 
 export interface ToolIntentParserSummary extends ToolIntentParserConfigSummary {
@@ -245,6 +246,20 @@ export interface TaskInspectResult {
   run: RunInspectSummary;
 }
 
+export interface WorkspacePatchProposalSummary {
+  proposal_id: string;
+  path: string;
+  operation: string;
+  content_preview: string;
+  content_chars: number;
+  truncated: boolean;
+}
+
+export interface ProposalListResult {
+  run_id: string;
+  proposals: WorkspacePatchProposalSummary[];
+}
+
 export function isJsonRpcResponse(value: unknown): value is JsonRpcResponse<unknown> {
   if (!isRecord(value)) {
     return false;
@@ -412,6 +427,33 @@ export function isToolPlanResult(value: unknown): value is ToolPlanResult {
   );
 }
 
+export function isWorkspacePatchProposalSummary(value: unknown): value is WorkspacePatchProposalSummary {
+  return (
+    isRecord(value) &&
+    typeof value.proposal_id === 'string' &&
+    typeof value.path === 'string' &&
+    typeof value.operation === 'string' &&
+    typeof value.content_preview === 'string' &&
+    isNonNegativeInteger(value.content_chars) &&
+    typeof value.truncated === 'boolean' &&
+    !Object.prototype.hasOwnProperty.call(value, 'content') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_content') &&
+    !Object.prototype.hasOwnProperty.call(value, 'full_content') &&
+    !Object.prototype.hasOwnProperty.call(value, 'patch') &&
+    !Object.prototype.hasOwnProperty.call(value, 'diff') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_input')
+  );
+}
+
+export function isProposalListResult(value: unknown): value is ProposalListResult {
+  return (
+    isRecord(value) &&
+    typeof value.run_id === 'string' &&
+    Array.isArray(value.proposals) &&
+    value.proposals.every(isWorkspacePatchProposalSummary)
+  );
+}
+
 export function isToolExecuteResult(value: unknown): value is ToolExecuteResult {
   return (
     isRecord(value) &&
@@ -458,7 +500,8 @@ function isToolIntentParserConfigSummary(value: unknown): value is ToolIntentPar
     isNonNegativeInteger(value.max_block_bytes) &&
     isNonNegativeInteger(value.max_tool_requests) &&
     isNonNegativeInteger(value.max_input_bytes) &&
-    isNonNegativeInteger(value.max_reason_chars)
+    isNonNegativeInteger(value.max_reason_chars) &&
+    isNonNegativeInteger(value.max_workspace_write_content_chars)
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalListResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalListResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -137,6 +137,16 @@ export class RuntimeClient {
     }
 
     return result.run;
+  }
+
+  async listProposals(runId: string): Promise<ProposalListResult> {
+    const result = await this.call<ProposalListResult>('proposal.list', { run_id: runId });
+
+    if (!isProposalListResult(result)) {
+      throw new RuntimeProtocolError('proposal.list returned an invalid result');
+    }
+
+    return result;
   }
 
   async inspectTask(taskId: string): Promise<TaskInspectResult> {

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalListResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -76,10 +76,10 @@ describe('protocol validation', () => {
 
   it('accepts valid runtime diagnostics results', () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
-    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [], api_key: 'secret' })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, diagnostics: [{ severity: 'Info', code: 'CONFIG_NOT_FOUND', message: 'No config.', subject: '.brownie/config.json' }] })).toBe(true);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, diagnostics: [{ code: 'CONFIG_NOT_FOUND', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, diagnostics: [{ severity: 'Info', message: 'No config.' }] })).toBe(false);
+    expect(isRuntimeDiagnosticsResult({ config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, diagnostics: [], api_key: 'secret' })).toBe(false);
   });
 
   it('accepts valid llm.health results and rejects invalid health fields', () => {
@@ -122,7 +122,7 @@ describe('protocol validation', () => {
   it('accepts valid tool intent parse results and rejects invalid decision shapes', () => {
     const result = {
       mode_id: 'orchestrator',
-      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
+      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 },
       items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'need context', input_summary: { has_path: true, field_count: 1 } }],
       rejected: [{ tool_id: null, reason: 'bad json', code: 'malformed_json' }, { reason: 'missing id is ok', code: 'invalid_schema' }],
     };
@@ -166,6 +166,17 @@ describe('protocol validation', () => {
       timestamp: '2026-06-26T00:00:00Z',
       payload: { output_preview: 'safe', bytes_read: 4, truncated: false },
     })).toBe(true);
+  });
+
+
+  it('accepts proposal.list results and rejects raw content fields', () => {
+    const result = {
+      run_id: 'run_1',
+      proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false }],
+    };
+    expect(isProposalListResult(result)).toBe(true);
+    expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], content: 'full' }] })).toBe(false);
+    expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], raw_input: { content: 'full' } }] })).toBe(false);
   });
 
   it('validates tool.execute results', () => {
@@ -219,7 +230,7 @@ describe('RuntimeClient', () => {
 
   it('creates a runtime.diagnostics.get request', async () => {
     const llm_status = { provider: 'Fake', enabled: true, model: 'brownie-fake-llm', base_url: null, reason: null, strict: false, will_fallback_to_fake: false, task_run_network_allowed: false, config_source: 'Default', active_profile: null, budget: { max_prompt_chars: 120000, max_messages: 64, request_timeout_ms: 30000, response_preview_chars: 2000 }, sensitive_guard: 'warn' };
-    const result = { config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, diagnostics: [] };
+    const result = { config_source: 'Default', active_profile: null, llm_status, parser_config: { max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, diagnostics: [] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
     await expect(client.runtimeDiagnostics()).resolves.toEqual(result);
@@ -335,7 +346,7 @@ describe('RuntimeClient', () => {
   it('creates a tool.intent.parse request', async () => {
     const result = {
       mode_id: 'orchestrator',
-      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 },
+      parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 },
       items: [{ tool_id: 'workspace.read', required_action: 'ReadWorkspace', allowed: true, reason: 'ok', request_reason: 'Need context.', input_summary: { has_path: true, field_count: 1 } }],
       rejected: [],
     };
@@ -347,7 +358,7 @@ describe('RuntimeClient', () => {
   });
 
   it('rejects invalid tool.intent.parse results', async () => {
-    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000 }, items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.', input_summary: { has_path: true, field_count: 1 } }], rejected: [] } });
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { mode_id: 'orchestrator', parser: { found_blocks: 1, accepted_blocks: 1, accepted_requests: 1, rejected_requests: 0, max_blocks: 1, max_block_bytes: 16384, max_tool_requests: 8, max_input_bytes: 4096, max_reason_chars: 1000, max_workspace_write_content_chars: 20000 }, items: [{ tool_id: 'workspace.read', required_action: 'Unknown', allowed: true, reason: 'bad', request_reason: 'Need context.', input_summary: { has_path: true, field_count: 1 } }], rejected: [] } });
     const client = new RuntimeClient(transport);
 
     await expect(client.parseToolIntent('orchestrator', 'content')).rejects.toThrow('tool.intent.parse returned an invalid result');
@@ -372,6 +383,16 @@ describe('RuntimeClient', () => {
     const client = new RuntimeClient(transport);
 
     await expect(client.planTools('task_1')).rejects.toThrow('tool.plan returned an invalid result');
+  });
+
+
+  it('creates a proposal.list request', async () => {
+    const result = { run_id: 'run_1', proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false }] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.listProposals('run_1')).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.list', params: { run_id: 'run_1' } }]);
   });
 
   it('creates a tool.execute request', async () => {


### PR DESCRIPTION
### Motivation

- Implement a Phase 3.0 dry-run path for `workspace.write` so approved write intents produce safe patch proposals instead of modifying files. 
- Enforce parser-level preflight for `workspace.write` inputs to reject unsafe or oversized proposals early. 
- Provide a guarded inspection API and VSIX command to list proposals without ever persisting full proposed content. 

### Description

- Added parser config and limits: `max_workspace_write_content_chars` and constants `DEFAULT_MAX_WORKSPACE_WRITE_CONTENT_CHARS`, `MIN_WORKSPACE_WRITE_CONTENT_CHARS`, `MAX_WORKSPACE_WRITE_CONTENT_CHARS`, and `DEFAULT_PROPOSAL_PREVIEW_CHARS` in `crates/brownie-tools`, and implemented `preflight_workspace_write_input` / `preflight_workspace_write_path`. 
- Introduced `WorkspacePatchProposal` / `WorkspacePatchOperation` types and `WorkspacePatchProposed` ledger event kind, and added `append_workspace_patch_proposal` to generate sanitized proposal metadata (preview, char count, truncated) without persisting full content. 
- Integrated proposal generation into `task.run` flow by replacing the previous read-only-only helper with `handle_approved_workspace_intents` which appends proposals for allowed `workspace.write` intents and continues to execute approved `workspace.read` intents as before. 
- Added protocol and VSIX support: `ProposalListParams` / `ProposalListResult` / `WorkspacePatchProposalSummary`, new JSON-RPC method `proposal.list` and `RuntimeClient.listProposals`, protocol validators rejecting raw/full content fields, and VSIX command `brownie.proposalList` that prompts for `run_id` and prints sanitized JSON. 
- Ledger sanitization and inspection were updated to allowlist proposal metadata (`proposal_id`, `operation`, `path`, `content_preview`, `content_chars`, `truncated`) and explicitly forbid `content`, `raw_content`, `full_content`, `patch`, `diff`, and `raw_input`. 
- Added Rust unit tests and VSIX tests covering parser acceptance/rejection cases, proposal event shape, no file modifications, `proposal.list` behavior, and protocol validators; also added documentation `docs/specifications/patch-proposal-spec-v0.md` and updates to related specs. 

### Testing

- Ran Rust checks and tests with `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, and all tests passed. 
- Built and tested the VSIX with `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, and all checks/tests/build succeeded. 
- Executed manual smoke tests for `tool.intent.parse` valid `workspace.write`, invalid path rejection, and an end-to-end `task.run` (implementer mode) followed by `proposal.list`, which confirmed a proposal was recorded in the ledger summary and that workspace files were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41ad09f3e0832890642b355190977e)