### PR TITLE
Add proposal validation, diff previews, and `proposal.inspect`

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -331,6 +331,12 @@ pub struct ProposalListParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalInspectParams {
+    pub run_id: String,
+    pub proposal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskInspectParams {
     pub task_id: String,
 }
@@ -366,12 +372,22 @@ pub struct WorkspacePatchProposalSummary {
     pub content_preview: String,
     pub content_chars: usize,
     pub truncated: bool,
+    pub validation_status: String,
+    pub validation_reason: Option<String>,
+    pub diff_preview: Option<String>,
+    pub diff_truncated: bool,
+    pub diff_redacted: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalListResult {
     pub run_id: String,
     pub proposals: Vec<WorkspacePatchProposalSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalInspectResult {
+    pub proposal: WorkspacePatchProposalSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -9,23 +9,25 @@ use brownie_config::{
 };
 use brownie_context::{ContextMaterializer, ContextMaterializerInput};
 use brownie_llm::{
-    redact_secret, validate_llm_request_budget, FakeLlmProvider, LlmProvider, LlmProviderKind,
-    LlmProviderStatus, LlmRequestBudget, OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv,
-    OpenAiCompatibleLlmProvider, PromptSensitiveGuardMode, PromptSensitiveScanResult,
+    redact_secret, scan_prompt_for_sensitive_content, validate_llm_request_budget, FakeLlmProvider,
+    LlmMessage, LlmProvider, LlmProviderKind, LlmProviderStatus, LlmRequestBudget,
+    OpenAiCompatibleConfig, OpenAiCompatibleConfigFromEnv, OpenAiCompatibleLlmProvider,
+    PromptSensitiveGuardMode, PromptSensitiveScanResult,
 };
 use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
     LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
     ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
-    PermissionCheckResult, ProposalListParams, ProposalListResult, RunEventsParams,
-    RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
-    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
-    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult,
-    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
-    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary,
-    ToolIntentParseParams, ToolIntentParseResult, ToolIntentParserConfigSummary,
-    ToolIntentParserSummary, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
-    ToolPlanParams, ToolPlanResult, ToolSummary, WorkspacePatchProposalSummary,
+    PermissionCheckResult, ProposalInspectParams, ProposalInspectResult, ProposalListParams,
+    ProposalListResult, RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult,
+    RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic,
+    RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams,
+    TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams,
+    TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus,
+    ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
+    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary, WorkspacePatchProposalSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -57,6 +59,9 @@ const METHOD_TOOL_EXECUTE: &str = "tool.execute";
 const METHOD_RUN_EVENTS: &str = "run.events";
 const METHOD_RUN_INSPECT: &str = "run.inspect";
 const METHOD_PROPOSAL_LIST: &str = "proposal.list";
+const METHOD_PROPOSAL_INSPECT: &str = "proposal.inspect";
+const DEFAULT_DIFF_PREVIEW_CHARS: usize = 4000;
+const MAX_DIFF_PREVIEW_CHARS: usize = 20000;
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -106,6 +111,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_RUN_EVENTS => handle_run_events(request.id, request.params),
         METHOD_RUN_INSPECT => handle_run_inspect(request.id, request.params),
         METHOD_PROPOSAL_LIST => handle_proposal_list(request.id, request.params),
+        METHOD_PROPOSAL_INSPECT => handle_proposal_inspect(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -1678,6 +1684,27 @@ fn handle_proposal_list(id: Value, params: Option<Value>) -> JsonRpcResponse<Val
     }
 }
 
+fn handle_proposal_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ProposalInspectParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: run_id must not be empty");
+    }
+    if params.proposal_id.trim().is_empty() {
+        return error_response(id, -32602, "invalid params: proposal_id must not be empty");
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    match inspect_proposal(&store, &params.run_id, &params.proposal_id) {
+        Ok(proposal) => result_response(id, json!(ProposalInspectResult { proposal })),
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
 fn handle_task_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     let params: TaskInspectParams = match parse_params(params) {
         Ok(params) => params,
@@ -1897,9 +1924,31 @@ fn list_proposals(
                 content_preview: payload.get("content_preview")?.as_str()?.to_string(),
                 content_chars: payload.get("content_chars")?.as_u64()? as usize,
                 truncated: payload.get("truncated")?.as_bool()?,
+                validation_status: payload.get("validation_status")?.as_str()?.to_string(),
+                validation_reason: payload
+                    .get("validation_reason")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+                diff_preview: payload
+                    .get("diff_preview")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+                diff_truncated: payload.get("diff_truncated")?.as_bool()?,
+                diff_redacted: payload.get("diff_redacted")?.as_bool()?,
             })
         })
         .collect())
+}
+
+fn inspect_proposal(
+    store: &BrownieStore,
+    run_id: &str,
+    proposal_id: &str,
+) -> Result<WorkspacePatchProposalSummary, String> {
+    list_proposals(store, run_id)?
+        .into_iter()
+        .find(|proposal| proposal.proposal_id == proposal_id)
+        .ok_or_else(|| "invalid params: proposal not found".to_string())
 }
 
 fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, String> {
@@ -1993,6 +2042,11 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "operation",
         "path",
         "content_chars",
+        "validation_status",
+        "validation_reason",
+        "diff_preview",
+        "diff_truncated",
+        "diff_redacted",
     ];
     let sanitized = map
         .into_iter()
@@ -2342,24 +2396,131 @@ fn append_workspace_patch_proposal(
         .get("content")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let content_chars = content.chars().count();
-    let content_preview = preview_with_limit(content, DEFAULT_PROPOSAL_PREVIEW_CHARS);
-    let truncated = content_chars > content_preview.chars().count();
-    let proposal_id = format!("proposal_{}", uuid::Uuid::new_v4().simple());
+    let proposal = build_workspace_patch_proposal(store, path, content);
     store.tasks().append_task_event_with_payload(
         record,
         LedgerEventKind::WorkspacePatchProposed,
         Some(json!({
-            "proposal_id": proposal_id,
+            "proposal_id": format!("proposal_{}", uuid::Uuid::new_v4().simple()),
             "tool_id": WORKSPACE_WRITE_TOOL_ID,
             "path": path,
             "operation": WorkspacePatchOperation::ReplaceFile.as_str(),
-            "content_preview": content_preview,
-            "content_chars": content_chars,
-            "truncated": truncated,
+            "content_preview": proposal.content_preview,
+            "content_chars": proposal.content_chars,
+            "truncated": proposal.truncated,
+            "validation_status": proposal.validation_status,
+            "validation_reason": proposal.validation_reason,
+            "diff_preview": proposal.diff_preview,
+            "diff_truncated": proposal.diff_truncated,
+            "diff_redacted": proposal.diff_redacted,
         })),
     )?;
     Ok(())
+}
+
+struct ProposalBuildResult {
+    content_preview: String,
+    content_chars: usize,
+    truncated: bool,
+    validation_status: &'static str,
+    validation_reason: Option<&'static str>,
+    diff_preview: Option<String>,
+    diff_truncated: bool,
+    diff_redacted: bool,
+}
+
+fn build_workspace_patch_proposal(
+    store: &BrownieStore,
+    path: &str,
+    content: &str,
+) -> ProposalBuildResult {
+    let content_chars = content.chars().count();
+    let mut result = ProposalBuildResult {
+        content_preview: preview_with_limit(content, DEFAULT_PROPOSAL_PREVIEW_CHARS),
+        content_chars,
+        truncated: content_chars
+            > preview_with_limit(content, DEFAULT_PROPOSAL_PREVIEW_CHARS)
+                .chars()
+                .count(),
+        validation_status: "Valid",
+        validation_reason: None,
+        diff_preview: None,
+        diff_truncated: false,
+        diff_redacted: false,
+    };
+    if scan_text_for_sensitive_content(content) {
+        result.content_preview = "[redacted]".to_string();
+        result.validation_status = "Blocked";
+        result.validation_reason = Some("proposal content contains sensitive-like data");
+        result.diff_preview = None;
+        result.diff_redacted = true;
+        return result;
+    }
+    if brownie_tools::preflight_workspace_write_path(path).is_err() {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("path is not a safe workspace-relative path");
+        return result;
+    }
+    let target = store.workspace_root().join(path);
+    let Ok(metadata) = std::fs::metadata(&target) else {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("target file does not exist");
+        return result;
+    };
+    if !metadata.is_file() {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("target path is not a file");
+        return result;
+    }
+    let Ok(existing) = std::fs::read_to_string(&target) else {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("target file is not UTF-8");
+        return result;
+    };
+    if scan_text_for_sensitive_content(&existing) {
+        result.validation_status = "Blocked";
+        result.validation_reason = Some("target file contains sensitive-like data");
+        result.diff_redacted = true;
+        return result;
+    }
+    let diff = synthetic_unified_diff(path, &existing, content);
+    result.diff_truncated =
+        diff.chars().count() > DEFAULT_DIFF_PREVIEW_CHARS.min(MAX_DIFF_PREVIEW_CHARS);
+    result.diff_preview = Some(preview_with_limit(
+        &diff,
+        DEFAULT_DIFF_PREVIEW_CHARS.min(MAX_DIFF_PREVIEW_CHARS),
+    ));
+    result
+}
+
+fn scan_text_for_sensitive_content(content: &str) -> bool {
+    !scan_prompt_for_sensitive_content(&[LlmMessage {
+        role: "user".to_string(),
+        content: content.to_string(),
+    }])
+    .findings
+    .is_empty()
+}
+
+fn synthetic_unified_diff(path: &str, old: &str, new: &str) -> String {
+    let old_lines: Vec<&str> = old.lines().collect();
+    let new_lines: Vec<&str> = new.lines().collect();
+    let mut diff = format!(
+        "--- a/{path}\n+++ b/{path}\n@@ -1,{} +1,{} @@\n",
+        old_lines.len(),
+        new_lines.len()
+    );
+    for line in old_lines {
+        diff.push('-');
+        diff.push_str(line);
+        diff.push('\n');
+    }
+    for line in new_lines {
+        diff.push('+');
+        diff.push_str(line);
+        diff.push('\n');
+    }
+    diff
 }
 
 fn tool_execution_ledger_payload(result: &brownie_tools::ToolExecutionResult) -> Value {
@@ -3134,6 +3295,13 @@ mod tests {
         assert_eq!(payload["operation"], "replace_file");
         assert!(payload.get("content_preview").is_some());
         assert!(payload.get("content_chars").is_some());
+        assert_eq!(payload["validation_status"], "Valid");
+        assert!(payload["diff_preview"]
+            .as_str()
+            .unwrap()
+            .contains("--- a/README.md"));
+        assert_eq!(payload["diff_truncated"], false);
+        assert_eq!(payload["diff_redacted"], false);
         assert!(payload.get("content").is_none());
         assert!(payload.get("raw_content").is_none());
         assert!(payload.get("patch").is_none());
@@ -3148,8 +3316,98 @@ mod tests {
             .unwrap()
             .clone();
         assert_eq!(proposals.len(), 1);
+        let proposal_id = proposals[0]["proposal_id"].as_str().unwrap();
+        let inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"proposal.inspect","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
+        ));
+        assert_eq!(
+            inspect.result.expect("inspect result")["proposal"]["proposal_id"],
+            proposal_id
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn patch_proposal_validation_blocks_invalid_and_sensitive_cases() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(
+            temp.path().join("README.md"),
+            "old
+",
+        )
+        .expect("write readme");
+        std::fs::create_dir(temp.path().join("docs")).expect("mkdir");
+        std::fs::write(
+            temp.path().join("secret.txt"),
+            "api_key=sk-existing
+",
+        )
+        .expect("secret");
+        let store = BrownieStore::new(temp.path());
+
+        let missing = build_workspace_patch_proposal(
+            &store,
+            "missing.md",
+            "new
+",
+        );
+        assert_eq!(missing.validation_status, "Invalid");
+        assert_eq!(
+            missing.validation_reason,
+            Some("target file does not exist")
+        );
+
+        let directory = build_workspace_patch_proposal(
+            &store, "docs", "new
+",
+        );
+        assert_eq!(directory.validation_status, "Invalid");
+        assert_eq!(
+            directory.validation_reason,
+            Some("target path is not a file")
+        );
+
+        let proposed_secret = build_workspace_patch_proposal(
+            &store,
+            "README.md",
+            "sk-proposed
+",
+        );
+        assert_eq!(proposed_secret.validation_status, "Blocked");
+        assert_eq!(proposed_secret.content_preview, "[redacted]");
+        assert!(proposed_secret.diff_preview.is_none());
+        assert!(proposed_secret.diff_redacted);
+
+        let existing_secret = build_workspace_patch_proposal(
+            &store,
+            "secret.txt",
+            "safe
+",
+        );
+        assert_eq!(existing_secret.validation_status, "Blocked");
+        assert_eq!(
+            existing_secret.validation_reason,
+            Some("target file contains sensitive-like data")
+        );
+        assert!(existing_secret.diff_preview.is_none());
+        assert!(existing_secret.diff_redacted);
+
+        let large = build_workspace_patch_proposal(
+            &store,
+            "README.md",
+            &"new line
+"
+            .repeat(1000),
+        );
+        assert_eq!(large.validation_status, "Valid");
+        assert!(large.diff_truncated);
+        assert!(large.diff_preview.unwrap().chars().count() <= DEFAULT_DIFF_PREVIEW_CHARS);
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "old
+"
+        );
     }
 
     #[test]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -2461,8 +2461,23 @@ fn build_workspace_patch_proposal(
         result.validation_reason = Some("path is not a safe workspace-relative path");
         return result;
     }
-    let target = store.workspace_root().join(path);
-    let Ok(metadata) = std::fs::metadata(&target) else {
+    let Ok(root) = store.workspace_root().canonicalize() else {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("workspace root is not accessible");
+        return result;
+    };
+    let target = root.join(path);
+    let Ok(canonical_target) = target.canonicalize() else {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("target file does not exist");
+        return result;
+    };
+    if !canonical_target.starts_with(&root) {
+        result.validation_status = "Invalid";
+        result.validation_reason = Some("target path escapes workspace root");
+        return result;
+    }
+    let Ok(metadata) = std::fs::metadata(&canonical_target) else {
         result.validation_status = "Invalid";
         result.validation_reason = Some("target file does not exist");
         return result;
@@ -2472,7 +2487,7 @@ fn build_workspace_patch_proposal(
         result.validation_reason = Some("target path is not a file");
         return result;
     }
-    let Ok(existing) = std::fs::read_to_string(&target) else {
+    let Ok(existing) = std::fs::read_to_string(&canonical_target) else {
         result.validation_status = "Invalid";
         result.validation_reason = Some("target file is not UTF-8");
         return result;
@@ -3344,6 +3359,19 @@ mod tests {
 ",
         )
         .expect("secret");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        std::fs::write(
+            outside.path().join("outside.txt"),
+            "outside workspace
+",
+        )
+        .expect("outside file");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            outside.path().join("outside.txt"),
+            temp.path().join("link.txt"),
+        )
+        .expect("symlink");
         let store = BrownieStore::new(temp.path());
 
         let missing = build_workspace_patch_proposal(
@@ -3392,6 +3420,20 @@ mod tests {
         );
         assert!(existing_secret.diff_preview.is_none());
         assert!(existing_secret.diff_redacted);
+
+        #[cfg(unix)]
+        {
+            let symlink_escape = build_workspace_patch_proposal(
+                &store, "link.txt", "safe
+",
+            );
+            assert_eq!(symlink_escape.validation_status, "Invalid");
+            assert_eq!(
+                symlink_escape.validation_reason,
+                Some("target path escapes workspace root")
+            );
+            assert!(symlink_escape.diff_preview.is_none());
+        }
 
         let large = build_workspace_patch_proposal(
             &store,

--- a/docs/specifications/patch-proposal-spec-v0.md
+++ b/docs/specifications/patch-proposal-spec-v0.md
@@ -34,3 +34,15 @@ The ledger event must not include `content`, `raw_content`, `full_content`, `pat
 ## Inspection
 
 `proposal.list` returns summaries reconstructed from sanitized ledger events for a run. It returns `-32602` when the run does not exist. Responses contain preview/count/truncation metadata only and never full proposed content.
+
+## Phase 3.1 validation and diff preview
+
+Phase 3.1 keeps the Phase 3.0 dry-run contract: `workspace.write` proposals never write workspace files and never apply patches. A proposal is inspected against the current workspace and receives `validation_status` (`Valid`, `Invalid`, or `Blocked`) plus optional `validation_reason`.
+
+For `replace_file`, validation requires a safe workspace-relative path, no protected path components, an existing target file, a regular file target, UTF-8 target content, UTF-8 proposed content, configured content size compliance, and no sensitive-like findings in proposed or existing content. Missing targets are `Invalid` with `target file does not exist`. Sensitive-like proposed content is `Blocked`, stores `content_preview` as `[redacted]`, suppresses diff preview, and records no matched secret values. Sensitive-like existing file content also blocks diff preview.
+
+Valid replacements get a deterministic synthetic unified diff preview generated from existing file text and proposed text. The preview is capped by the runtime diff preview cap; only the capped preview may be stored in the ledger or returned by inspection. `diff_truncated` reports cap truncation and `diff_redacted` reports sensitive-content suppression. Full proposed content and raw full diffs are never persisted.
+
+`WorkspacePatchProposed` payloads include validation and diff-preview metadata: `validation_status`, `validation_reason`, `diff_preview`, `diff_truncated`, and `diff_redacted`. Forbidden fields remain `content`, `raw_content`, `full_content`, `patch`, and `raw_input`.
+
+`proposal.list` returns the extended proposal summary. `proposal.inspect` accepts `{ "run_id": string, "proposal_id": string }` and returns `{ "proposal": WorkspacePatchProposalSummary }`; unknown runs or proposals return `-32602`.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -272,3 +272,11 @@ Ledger and inspection surfaces follow the same trust boundary: parser metadata, 
 ## `proposal.list`
 
 Phase 3.0 adds `proposal.list` with params `{ "run_id": string }`. The result is `{ "run_id": string, "proposals": [...] }`, where each proposal summary contains `proposal_id`, `path`, `operation`, `content_preview`, `content_chars`, and `truncated`. Unknown runs return `-32602`.
+
+## Phase 3.1 proposal validation and inspection
+
+`proposal.list` summaries now include `validation_status`, `validation_reason`, `diff_preview`, `diff_truncated`, and `diff_redacted` in addition to the Phase 3.0 fields. Allowed validation statuses are `Valid`, `Invalid`, and `Blocked`.
+
+`proposal.inspect` accepts `{ "run_id": string, "proposal_id": string }` and returns `{ "proposal": WorkspacePatchProposalSummary }`. Empty IDs, unknown runs, and unknown proposals return JSON-RPC `-32602`.
+
+Diff previews are synthetic unified diff previews only. They are capped before ledger storage and RPC exposure. Sensitive-like proposed content redacts `content_preview` and suppresses diff preview; sensitive-like existing target content also suppresses diff preview. The runtime still does not apply patches or write files for `workspace.write`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -175,3 +175,9 @@ Runtime LLM configuration includes `sensitive_guard` (`off`, `warn`, `fail`) wit
 ## Phase 3.0 patch proposal dry-run path
 
 During `task.run`, approved `workspace.read` intents continue to use read-only execution. Approved `workspace.write` intents are not executed; they create `WorkspacePatchProposed` ledger events with bounded preview metadata only. Denied write intents create no proposal.
+
+## Phase 3.1 patch proposal validation
+
+Approved `workspace.write` intents remain dry-run proposals only: task execution does not write files and does not apply patches. For `replace_file` proposals, the runtime validates the target path and current target file, scans proposed and existing content for sensitive-like data, and stores only bounded previews.
+
+Valid proposals may include a capped synthetic unified diff preview. Blocked proposals suppress or redact previews when proposed or existing content looks sensitive. Proposal inspection is available through `proposal.list` and `proposal.inspect`; neither RPC returns full proposed content, raw provider responses, raw intent JSON, raw input, or full diffs.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -80,6 +80,10 @@
       {
         "command": "brownie.proposalList",
         "title": "Brownie: List Patch Proposals"
+      },
+      {
+        "command": "brownie.proposalInspect",
+        "title": "Brownie: Inspect Patch Proposal"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -362,6 +362,22 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const proposalInspectCommand = vscode.commands.registerCommand('brownie.proposalInspect', async () => {
+    const runId = await vscode.window.showInputBox({ prompt: 'Run ID', placeHolder: 'run_...', ignoreFocusOut: true });
+    if (runId === undefined) { return; }
+    const proposalId = await vscode.window.showInputBox({ prompt: 'Proposal ID', placeHolder: 'proposal_...', ignoreFocusOut: true });
+    if (proposalId === undefined) { return; }
+    try {
+      const result = await runtimeClient.inspectProposal(runId.trim(), proposalId.trim());
+      output.appendLine(`proposal.inspect: ${JSON.stringify(result, null, 2)}`);
+      output.show(true);
+      await vscode.window.showInformationMessage(`Brownie patch proposal: ${result.proposal.proposal_id}`);
+    } catch (error) {
+      output.appendLine(`proposal.inspect failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie proposal inspect failed: ${formatError(error)}`);
+    }
+  });
+
   const toolExecuteReadCommand = vscode.commands.registerCommand('brownie.toolExecuteRead', async () => {
     const modeIdInput = await vscode.window.showInputBox({
       prompt: 'Mode ID',

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -253,11 +253,20 @@ export interface WorkspacePatchProposalSummary {
   content_preview: string;
   content_chars: number;
   truncated: boolean;
+  validation_status: string;
+  validation_reason: string | null;
+  diff_preview: string | null;
+  diff_truncated: boolean;
+  diff_redacted: boolean;
 }
 
 export interface ProposalListResult {
   run_id: string;
   proposals: WorkspacePatchProposalSummary[];
+}
+
+export interface ProposalInspectResult {
+  proposal: WorkspacePatchProposalSummary;
 }
 
 export function isJsonRpcResponse(value: unknown): value is JsonRpcResponse<unknown> {
@@ -436,6 +445,11 @@ export function isWorkspacePatchProposalSummary(value: unknown): value is Worksp
     typeof value.content_preview === 'string' &&
     isNonNegativeInteger(value.content_chars) &&
     typeof value.truncated === 'boolean' &&
+    (value.validation_status === 'Valid' || value.validation_status === 'Invalid' || value.validation_status === 'Blocked') &&
+    (typeof value.validation_reason === 'string' || value.validation_reason === null) &&
+    (typeof value.diff_preview === 'string' || value.diff_preview === null) &&
+    typeof value.diff_truncated === 'boolean' &&
+    typeof value.diff_redacted === 'boolean' &&
     !Object.prototype.hasOwnProperty.call(value, 'content') &&
     !Object.prototype.hasOwnProperty.call(value, 'raw_content') &&
     !Object.prototype.hasOwnProperty.call(value, 'full_content') &&
@@ -451,6 +465,13 @@ export function isProposalListResult(value: unknown): value is ProposalListResul
     typeof value.run_id === 'string' &&
     Array.isArray(value.proposals) &&
     value.proposals.every(isWorkspacePatchProposalSummary)
+  );
+}
+
+export function isProposalInspectResult(value: unknown): value is ProposalInspectResult {
+  return (
+    isRecord(value) &&
+    isWorkspacePatchProposalSummary(value.proposal)
   );
 }
 

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalListResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalListResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalInspectResult, ProposalListResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalInspectResult, isProposalListResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -144,6 +144,16 @@ export class RuntimeClient {
 
     if (!isProposalListResult(result)) {
       throw new RuntimeProtocolError('proposal.list returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async inspectProposal(runId: string, proposalId: string): Promise<ProposalInspectResult> {
+    const result = await this.call<ProposalInspectResult>('proposal.inspect', { run_id: runId, proposal_id: proposalId });
+
+    if (!isProposalInspectResult(result)) {
+      throw new RuntimeProtocolError('proposal.inspect returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalListResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalInspectResult, isProposalListResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -172,11 +172,12 @@ describe('protocol validation', () => {
   it('accepts proposal.list results and rejects raw content fields', () => {
     const result = {
       run_id: 'run_1',
-      proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false }],
+      proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false, validation_status: 'Valid', validation_reason: null, diff_preview: '--- a/README.md', diff_truncated: false, diff_redacted: false }],
     };
     expect(isProposalListResult(result)).toBe(true);
     expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], content: 'full' }] })).toBe(false);
     expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], raw_input: { content: 'full' } }] })).toBe(false);
+    expect(isProposalInspectResult({ proposal: result.proposals[0] })).toBe(true);
   });
 
   it('validates tool.execute results', () => {
@@ -387,12 +388,21 @@ describe('RuntimeClient', () => {
 
 
   it('creates a proposal.list request', async () => {
-    const result = { run_id: 'run_1', proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false }] };
+    const result = { run_id: 'run_1', proposals: [{ proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false, validation_status: 'Valid', validation_reason: null, diff_preview: '--- a/README.md', diff_truncated: false, diff_redacted: false }] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
 
     await expect(client.listProposals('run_1')).resolves.toEqual(result);
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.list', params: { run_id: 'run_1' } }]);
+  });
+
+  it('creates a proposal.inspect request', async () => {
+    const result = { proposal: { proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false, validation_status: 'Valid', validation_reason: null, diff_preview: '--- a/README.md', diff_truncated: false, diff_redacted: false } };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.inspectProposal('run_1', 'proposal_1')).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.inspect', params: { run_id: 'run_1', proposal_id: 'proposal_1' } }]);
   });
 
   it('creates a tool.execute request', async () => {


### PR DESCRIPTION
### Motivation

- Provide safer, richer inspection of `workspace.write` dry-run proposals without applying patches or writing files. 
- Detect and block sensitive-like content in proposed or existing files and avoid exposing secrets in previews. 
- Offer a deterministic, capped synthetic unified diff preview to help reviewers assess replace-file proposals.

### Description

- Extended the protocol types with `ProposalInspectParams`, `ProposalInspectResult`, and new fields on `WorkspacePatchProposalSummary` (`validation_status`, `validation_reason`, `diff_preview`, `diff_truncated`, `diff_redacted`) and added `DEFAULT_DIFF_PREVIEW_CHARS` / `MAX_DIFF_PREVIEW_CHARS` constants in the runtime. 
- Implemented proposal validation and inspection in the runtime: `build_workspace_patch_proposal`, `scan_text_for_sensitive_content`, `synthetic_unified_diff`, enhanced `append_workspace_patch_proposal`, `list_proposals`, and new `proposal.inspect` handler that returns a sanitized proposal summary without storing full content or raw diffs. 
- Added sensitive-content redaction rules so proposals with sensitive-like proposed content redact `content_preview` and block diff previews, and existing files containing sensitive-like content also block diffs; validation statuses are `Valid`, `Invalid`, or `Blocked`. 
- Updated the VSIX client and validators: added `ProposalInspectResult`/validators, `RuntimeClient.inspectProposal`, and the `brownie.proposalInspect` command to prompt for `run_id` and `proposal_id` and print sanitized JSON; also updated tests and package manifest. 
- Updated documentation in `docs/specifications/*` to describe Phase 3.1 behavior, validation rules, sensitive redaction, capped diff previews, and `proposal.inspect` semantics.

### Testing

- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, with all Rust tests passing. 
- Ran VSIX validation and tests via `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, with TypeScript checks and Vitest tests passing. 
- Performed a manual smoke run that starts a task in a temporary workspace, produced a `WorkspacePatchProposed` event, verified `proposal.list` shows `validation_status: "Valid"` and a capped `diff_preview`, used `proposal.inspect` to retrieve the proposal, and confirmed the workspace file remained unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a41c55185848328a1a16f57823832a6)