### PR TITLE
Register proposal.inspect VSIX command

### DIFF
--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -413,7 +413,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand, proposalInspectCommand);
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
### Motivation
- Activate the VSIX `brownie.proposalInspect` command so users can prompt for `run_id`/`proposal_id`, call `proposal.inspect`, and see sanitized JSON output without applying patches.

### Description
- Add `proposalInspectCommand` to the extension `context.subscriptions` in `extensions/brownie-vsix/src/extension.ts` so the command declared in `package.json` is actually registered and activated.

### Testing
- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, all of which passed; ran `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test` (43 tests passed) and `pnpm --filter brownie-vsix build`, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43bdce10ec832885df0e03de45afdb)