### PR TITLE
Harden VSIX protocol validators to reject canonical/absolute path fields

### DIFF
--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -487,7 +487,7 @@ export function isToolPlanResult(value: unknown): value is ToolPlanResult {
 }
 
 export function hasNoForbiddenRawFields(value: object): boolean {
-  return !Object.prototype.hasOwnProperty.call(value, 'content') && !Object.prototype.hasOwnProperty.call(value, 'raw_content') && !Object.prototype.hasOwnProperty.call(value, 'full_content') && !Object.prototype.hasOwnProperty.call(value, 'patch') && !Object.prototype.hasOwnProperty.call(value, 'diff') && !Object.prototype.hasOwnProperty.call(value, 'raw_input');
+  return !Object.prototype.hasOwnProperty.call(value, 'content') && !Object.prototype.hasOwnProperty.call(value, 'raw_content') && !Object.prototype.hasOwnProperty.call(value, 'full_content') && !Object.prototype.hasOwnProperty.call(value, 'patch') && !Object.prototype.hasOwnProperty.call(value, 'diff') && !Object.prototype.hasOwnProperty.call(value, 'raw_input') && !Object.prototype.hasOwnProperty.call(value, 'canonical_path') && !Object.prototype.hasOwnProperty.call(value, 'absolute_path');
 }
 
 export function isWorkspacePatchPreflightSnapshotSummary(value: unknown): value is WorkspacePatchPreflightSnapshotSummary {
@@ -505,8 +505,6 @@ export function isWorkspacePatchPreflightSnapshotSummary(value: unknown): value 
     typeof value.captured_at === 'string' &&
     typeof value.stale === 'boolean' &&
     (typeof value.stale_reason === 'string' || value.stale_reason === null) &&
-    !Object.prototype.hasOwnProperty.call(value, 'canonical_path') &&
-    !Object.prototype.hasOwnProperty.call(value, 'absolute_path') &&
     hasNoForbiddenRawFields(value)
   );
 }
@@ -516,7 +514,7 @@ export function isWorkspacePatchApplyCheckSummary(value: unknown): value is Work
 }
 
 export function isWorkspacePatchApplyPlanSummary(value: unknown): value is WorkspacePatchApplyPlanSummary {
-  return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.plan_id === 'string' && typeof value.status === 'string' && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchApplyCheckSummary) && !Object.prototype.hasOwnProperty.call(value, 'content') && !Object.prototype.hasOwnProperty.call(value, 'raw_content') && !Object.prototype.hasOwnProperty.call(value, 'full_content') && !Object.prototype.hasOwnProperty.call(value, 'patch') && !Object.prototype.hasOwnProperty.call(value, 'diff') && !Object.prototype.hasOwnProperty.call(value, 'raw_input');
+  return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.plan_id === 'string' && typeof value.status === 'string' && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchApplyCheckSummary) && hasNoForbiddenRawFields(value);
 }
 
 export function isWorkspacePatchProposalSummary(value: unknown): value is WorkspacePatchProposalSummary {
@@ -540,12 +538,7 @@ export function isWorkspacePatchProposalSummary(value: unknown): value is Worksp
     (typeof value.rejected_at === 'string' || value.rejected_at === null) &&
     (value.latest_apply_plan === undefined || value.latest_apply_plan === null || isWorkspacePatchApplyPlanSummary(value.latest_apply_plan)) &&
     (value.latest_snapshot === undefined || value.latest_snapshot === null || isWorkspacePatchPreflightSnapshotSummary(value.latest_snapshot)) &&
-    !Object.prototype.hasOwnProperty.call(value, 'content') &&
-    !Object.prototype.hasOwnProperty.call(value, 'raw_content') &&
-    !Object.prototype.hasOwnProperty.call(value, 'full_content') &&
-    !Object.prototype.hasOwnProperty.call(value, 'patch') &&
-    !Object.prototype.hasOwnProperty.call(value, 'diff') &&
-    !Object.prototype.hasOwnProperty.call(value, 'raw_input')
+    hasNoForbiddenRawFields(value)
   );
 }
 

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -177,6 +177,7 @@ describe('protocol validation', () => {
     expect(isProposalListResult(result)).toBe(true);
     expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], content: 'full' }] })).toBe(false);
     expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], raw_input: { content: 'full' } }] })).toBe(false);
+    expect(isProposalListResult({ ...result, proposals: [{ ...result.proposals[0], absolute_path: '/tmp/README.md' }] })).toBe(false);
     expect(isProposalInspectResult({ proposal: result.proposals[0] })).toBe(true);
     const applyPlan = { proposal_id: 'proposal_1', plan_id: 'plan_1', status: 'Blocked', checklist: [{ name: 'apply_not_enabled', status: 'Fail', reason: 'Patch apply is not implemented in Phase 3.2.' }] };
     expect(isProposalApproveResult({ proposal: { ...result.proposals[0], approval_status: 'Approved', approved_at: '2026-06-30T00:00:00Z', latest_apply_plan: applyPlan }, apply_plan: applyPlan })).toBe(true);
@@ -186,6 +187,7 @@ describe('protocol validation', () => {
     expect(isProposalPreflightResult({ proposal: result.proposals[0], snapshot: { ...snapshot, raw_input: {} }, apply_plan: applyPlan })).toBe(false);
     expect(isProposalRejectResult({ proposal: { ...result.proposals[0], approval_status: 'Rejected', rejected_at: '2026-06-30T00:00:00Z' } })).toBe(true);
     expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, raw_content: 'secret' } })).toBe(false);
+    expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, canonical_path: '/tmp/README.md' } })).toBe(false);
   });
 
   it('validates tool.execute results', () => {


### PR DESCRIPTION
### Motivation
- Prevent leaking sensitive filesystem identifiers by ensuring VSIX runtime/validator types forbid `canonical_path` and `absolute_path` alongside existing raw fields like `content`, `raw_content`, `patch`, `diff`, and `raw_input`.

### Description
- Extended `hasNoForbiddenRawFields` to also reject `canonical_path` and `absolute_path` in `extensions/brownie-vsix/src/runtime/protocol.ts`.
- Simplified proposal/apply-plan/snapshot validators to rely on `hasNoForbiddenRawFields` instead of repeating ad-hoc forbidden-field checks in `extensions/brownie-vsix/src/runtime/protocol.ts`.
- Added regression assertions to `extensions/brownie-vsix/src/test/runtimeClient.test.ts` to ensure proposal summaries reject `absolute_path` and apply-plan snapshots reject `canonical_path`.
- Changes are limited to the VSIX TypeScript validator and test code and do not alter runtime behavior or file I/O.

### Testing
- Ran Rust workspace checks and tests with `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, all succeeding.
- Ran VSIX CI steps `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, all succeeding.
- Unit test updates in `extensions/brownie-vsix/src/test/runtimeClient.test.ts` passed (45 tests in that suite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44ff4b1f148328a4a3a9a0b8bf4f43)