### PR TITLE
Add proposal.readiness and Phase 3.4 readiness reports

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -357,6 +357,12 @@ pub struct ProposalPreflightParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalReadinessParams {
+    pub run_id: String,
+    pub proposal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskInspectParams {
     pub task_id: String,
 }
@@ -438,6 +444,24 @@ pub struct WorkspacePatchApplyCheckSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchReadinessReportSummary {
+    pub proposal_id: String,
+    pub report_id: String,
+    pub readiness_status: String,
+    pub readiness_reason: Option<String>,
+    pub generated_at: String,
+    pub checklist: Vec<WorkspacePatchReadinessCheckSummary>,
+    pub summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchReadinessCheckSummary {
+    pub name: String,
+    pub status: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalListResult {
     pub run_id: String,
     pub proposals: Vec<WorkspacePatchProposalSummary>,
@@ -464,6 +488,12 @@ pub struct ProposalPreflightResult {
     pub proposal: WorkspacePatchProposalSummary,
     pub snapshot: WorkspacePatchPreflightSnapshotSummary,
     pub apply_plan: WorkspacePatchApplyPlanSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalReadinessResult {
+    pub proposal: WorkspacePatchProposalSummary,
+    pub report: WorkspacePatchReadinessReportSummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -20,17 +20,18 @@ use brownie_protocol::{
     ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
     PermissionCheckResult, ProposalApproveParams, ProposalApproveResult, ProposalInspectParams,
     ProposalInspectResult, ProposalListParams, ProposalListResult, ProposalPreflightParams,
-    ProposalPreflightResult, ProposalRejectParams, ProposalRejectResult, RunEventsParams,
-    RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
-    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
-    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult,
-    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
-    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary,
-    ToolIntentParseParams, ToolIntentParseResult, ToolIntentParserConfigSummary,
-    ToolIntentParserSummary, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
-    ToolPlanParams, ToolPlanResult, ToolSummary, WorkspacePatchApplyCheckSummary,
-    WorkspacePatchApplyPlanSummary, WorkspacePatchPreflightSnapshotSummary,
-    WorkspacePatchProposalSummary,
+    ProposalPreflightResult, ProposalReadinessParams, ProposalReadinessResult,
+    ProposalRejectParams, ProposalRejectResult, RunEventsParams, RunEventsResult, RunInspectParams,
+    RunInspectResult, RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult,
+    RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams,
+    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult,
+    TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult,
+    ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
+    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary, WorkspacePatchApplyCheckSummary, WorkspacePatchApplyPlanSummary,
+    WorkspacePatchPreflightSnapshotSummary, WorkspacePatchProposalSummary,
+    WorkspacePatchReadinessCheckSummary, WorkspacePatchReadinessReportSummary,
 };
 use brownie_store::{BrownieStore, LedgerEvent, LedgerEventKind};
 use brownie_tools::{
@@ -68,6 +69,7 @@ const METHOD_PROPOSAL_INSPECT: &str = "proposal.inspect";
 const METHOD_PROPOSAL_APPROVE: &str = "proposal.approve";
 const METHOD_PROPOSAL_REJECT: &str = "proposal.reject";
 const METHOD_PROPOSAL_PREFLIGHT: &str = "proposal.preflight";
+const METHOD_PROPOSAL_READINESS: &str = "proposal.readiness";
 const DEFAULT_DIFF_PREVIEW_CHARS: usize = 4000;
 const MAX_DIFF_PREVIEW_CHARS: usize = 20000;
 
@@ -123,6 +125,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_PROPOSAL_APPROVE => handle_proposal_approve(request.id, request.params),
         METHOD_PROPOSAL_REJECT => handle_proposal_reject(request.id, request.params),
         METHOD_PROPOSAL_PREFLIGHT => handle_proposal_preflight(request.id, request.params),
+        METHOD_PROPOSAL_READINESS => handle_proposal_readiness(request.id, request.params),
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -1795,6 +1798,30 @@ fn handle_proposal_preflight(id: Value, params: Option<Value>) -> JsonRpcRespons
     }
 }
 
+fn handle_proposal_readiness(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ProposalReadinessParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() || params.proposal_id.trim().is_empty() {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: run_id and proposal_id are required",
+        );
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32602, &format!("invalid params: {error}")),
+    };
+    match readiness_proposal(&store, &params.run_id, &params.proposal_id) {
+        Ok((proposal, report)) => {
+            result_response(id, json!(ProposalReadinessResult { proposal, report }))
+        }
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
 fn handle_task_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     let params: TaskInspectParams = match parse_params(params) {
         Ok(params) => params,
@@ -2299,6 +2326,242 @@ fn reject_proposal(
         )
         .map_err(|e| format!("invalid params: {e}"))?;
     inspect_proposal(store, run_id, proposal_id)
+}
+
+fn readiness_check(
+    name: &str,
+    status: &str,
+    reason: Option<&str>,
+) -> WorkspacePatchReadinessCheckSummary {
+    WorkspacePatchReadinessCheckSummary {
+        name: name.to_string(),
+        status: status.to_string(),
+        reason: reason.map(ToString::to_string),
+    }
+}
+
+fn readiness_proposal(
+    store: &BrownieStore,
+    run_id: &str,
+    proposal_id: &str,
+) -> Result<
+    (
+        WorkspacePatchProposalSummary,
+        WorkspacePatchReadinessReportSummary,
+    ),
+    String,
+> {
+    let task = store
+        .tasks()
+        .get_task_by_run_id(run_id)
+        .map_err(|e| format!("invalid params: {e}"))?
+        .ok_or_else(|| "invalid params: run not found".to_string())?;
+    let proposal = inspect_proposal(store, run_id, proposal_id)?;
+    let snapshot = proposal.latest_snapshot.as_ref();
+    let mut checklist = vec![readiness_check("proposal_exists", "Pass", None)];
+
+    if proposal.validation_status == "Blocked" {
+        checklist.push(readiness_check(
+            "proposal_is_valid",
+            "Blocked",
+            proposal.validation_reason.as_deref(),
+        ));
+    } else if proposal.validation_status == "Valid" {
+        checklist.push(readiness_check("proposal_is_valid", "Pass", None));
+    } else {
+        checklist.push(readiness_check(
+            "proposal_is_valid",
+            "Fail",
+            proposal
+                .validation_reason
+                .as_deref()
+                .or(Some("Proposal validation status is not Valid.")),
+        ));
+    }
+
+    checklist.push(if proposal.approval_status == "Approved" {
+        readiness_check("proposal_is_approved", "Pass", None)
+    } else {
+        readiness_check(
+            "proposal_is_approved",
+            "Fail",
+            Some("Proposal is not approved."),
+        )
+    });
+    checklist.push(if snapshot.is_some() {
+        readiness_check("proposal_has_preflight_snapshot", "Pass", None)
+    } else {
+        readiness_check(
+            "proposal_has_preflight_snapshot",
+            "Fail",
+            Some("Run proposal.preflight before final review."),
+        )
+    });
+    checklist.push(match snapshot {
+        Some(snapshot) if !snapshot.stale => readiness_check("proposal_not_stale", "Pass", None),
+        Some(snapshot) => readiness_check(
+            "proposal_not_stale",
+            "Fail",
+            snapshot
+                .stale_reason
+                .as_deref()
+                .or(Some("Latest preflight snapshot is stale.")),
+        ),
+        None => readiness_check(
+            "proposal_not_stale",
+            "Skipped",
+            Some("No preflight snapshot is available."),
+        ),
+    });
+    checklist.push(match snapshot {
+        Some(snapshot) if snapshot.file_exists => {
+            readiness_check("target_file_exists", "Pass", None)
+        }
+        Some(_) => readiness_check(
+            "target_file_exists",
+            "Fail",
+            Some("Target file was missing at preflight."),
+        ),
+        None => readiness_check(
+            "target_file_exists",
+            "Skipped",
+            Some("No preflight snapshot is available."),
+        ),
+    });
+    checklist.push(match snapshot {
+        Some(snapshot) if snapshot.file_kind == "File" => {
+            readiness_check("target_file_regular", "Pass", None)
+        }
+        Some(snapshot) if snapshot.file_kind == "Unreadable" => readiness_check(
+            "target_file_regular",
+            "Blocked",
+            Some("Target file was unreadable at preflight."),
+        ),
+        Some(_) => readiness_check(
+            "target_file_regular",
+            "Fail",
+            Some("Target path is not a regular file."),
+        ),
+        None => readiness_check(
+            "target_file_regular",
+            "Skipped",
+            Some("No preflight snapshot is available."),
+        ),
+    });
+    checklist.push(match snapshot {
+        Some(snapshot) if snapshot.file_sha256.is_some() => {
+            readiness_check("target_file_hash_available", "Pass", None)
+        }
+        Some(_) => readiness_check(
+            "target_file_hash_available",
+            "Fail",
+            Some("Target file hash is unavailable."),
+        ),
+        None => readiness_check(
+            "target_file_hash_available",
+            "Skipped",
+            Some("No preflight snapshot is available."),
+        ),
+    });
+    checklist.push(if proposal.diff_preview.is_some() {
+        readiness_check("diff_preview_available", "Pass", None)
+    } else {
+        readiness_check(
+            "diff_preview_available",
+            "Fail",
+            Some("Sanitized diff preview is unavailable."),
+        )
+    });
+    checklist.push(if proposal.diff_redacted {
+        readiness_check(
+            "diff_not_redacted",
+            "Blocked",
+            Some("Diff preview was redacted."),
+        )
+    } else {
+        readiness_check("diff_not_redacted", "Pass", None)
+    });
+    let sensitive = proposal.validation_status == "Blocked"
+        || proposal.diff_redacted
+        || proposal.content_preview == "[redacted]";
+    checklist.push(if sensitive {
+        readiness_check(
+            "no_sensitive_content_detected",
+            "Blocked",
+            Some("Sensitive-like content was detected or redacted."),
+        )
+    } else {
+        readiness_check("no_sensitive_content_detected", "Pass", None)
+    });
+    checklist.push(readiness_check("no_raw_content_exposed", "Pass", None));
+    checklist.push(readiness_check(
+        "apply_not_implemented",
+        "Skipped",
+        Some("Patch apply is not implemented in Phase 3.4."),
+    ));
+
+    let blocked_checks: Vec<String> = checklist
+        .iter()
+        .filter(|c| c.status == "Blocked")
+        .map(|c| c.name.clone())
+        .collect();
+    let failed_checks: Vec<String> = checklist
+        .iter()
+        .filter(|c| c.status == "Fail")
+        .map(|c| c.name.clone())
+        .collect();
+    let (readiness_status, readiness_reason, summary) = if !blocked_checks.is_empty() {
+        ("Blocked", Some("Proposal or target file contains sensitive-like content; sanitized preview is unavailable."), "Blocked. Proposal or target file contains sensitive-like content; sanitized preview is unavailable.")
+    } else if !failed_checks.is_empty() {
+        let stale = failed_checks
+            .iter()
+            .any(|name| name == "proposal_not_stale");
+        let reason = if stale {
+            "Latest preflight snapshot is stale; rerun proposal.preflight before review."
+        } else {
+            "Proposal is missing required approval, validation, preflight, target hash, or sanitized diff preview."
+        };
+        (
+            "NotReady",
+            Some(reason),
+            if stale {
+                "Not ready for final human review. Latest preflight snapshot is stale; rerun proposal.preflight before review."
+            } else {
+                "Not ready for final human review. Proposal is missing required approval, validation, preflight, target hash, or sanitized diff preview."
+            },
+        )
+    } else {
+        ("Ready", None, "Ready for final human review. Proposal is approved, latest preflight is fresh, target file hash is captured, and a sanitized diff preview is available. Patch apply is not implemented in Phase 3.4.")
+    };
+    let generated_at = now_rfc3339();
+    let report_id = format!("report_{}", uuid::Uuid::new_v4().simple());
+    let report = WorkspacePatchReadinessReportSummary {
+        proposal_id: proposal_id.to_string(),
+        report_id: report_id.clone(),
+        readiness_status: readiness_status.to_string(),
+        readiness_reason: readiness_reason.map(ToString::to_string),
+        generated_at: generated_at.clone(),
+        checklist,
+        summary: summary.to_string(),
+    };
+    store
+        .tasks()
+        .append_task_event_with_payload(
+            &task,
+            LedgerEventKind::WorkspacePatchReadinessReportCreated,
+            Some(json!({
+                "proposal_id": proposal_id,
+                "report_id": report_id,
+                "readiness_status": readiness_status,
+                "readiness_reason": report.readiness_reason,
+                "generated_at": generated_at,
+                "check_count": report.checklist.len(),
+                "failed_checks": failed_checks,
+                "blocked_checks": blocked_checks,
+            })),
+        )
+        .map_err(|e| format!("invalid params: {e}"))?;
+    Ok((inspect_proposal(store, run_id, proposal_id)?, report))
 }
 
 fn preflight_proposal(
@@ -3914,6 +4177,24 @@ mod tests {
             preflight_result["proposal"]["latest_snapshot"]["snapshot_id"],
             preflight_result["snapshot"]["snapshot_id"]
         );
+        let ready = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":71,"method":"proposal.readiness","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
+        ));
+        let ready_result = ready.result.expect("ready result");
+        assert_eq!(ready_result["report"]["readiness_status"], "Ready");
+        assert_eq!(
+            ready_result["report"]["checklist"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|check| check["name"] == "apply_not_implemented")
+                .unwrap()["status"],
+            "Skipped"
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "original README"
+        );
         std::fs::write(temp.path().join("README.md"), "changed manually").expect("manual change");
         let second_preflight = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":8,"method":"proposal.preflight","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
@@ -3924,8 +4205,38 @@ mod tests {
             std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
             "changed manually"
         );
+        let readiness = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":9,"method":"proposal.readiness","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
+        ));
+        let readiness_result = readiness.result.expect("readiness result");
+        assert_eq!(readiness_result["report"]["readiness_status"], "NotReady");
+        assert!(readiness_result["report"]["summary"]
+            .as_str()
+            .unwrap()
+            .contains("Latest preflight snapshot is stale"));
+        let serialized_readiness = serde_json::to_string(&readiness_result["report"]).unwrap();
+        for forbidden in [
+            "content",
+            "raw_content",
+            "full_content",
+            "patch",
+            "diff",
+            "raw_input",
+            "canonical_path",
+            "absolute_path",
+            "file_content",
+            "original README",
+            "changed manually",
+        ] {
+            assert!(!serialized_readiness.contains(&format!(r#"\"{forbidden}\""#)));
+        }
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "changed manually"
+        );
+
         let events_after_approval = parse_line(&format!(
-            r#"{{"jsonrpc":"2.0","id":9,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
+            r#"{{"jsonrpc":"2.0","id":10,"method":"run.events","params":{{"run_id":"{run_id}"}}}}"#
         ));
         let events_after_approval = events_after_approval.result.expect("events result")["events"]
             .as_array()
@@ -3940,6 +4251,9 @@ mod tests {
         assert!(events_after_approval
             .iter()
             .any(|event| event["kind"] == "WorkspacePatchPreflightSnapshotCreated"));
+        assert!(events_after_approval
+            .iter()
+            .any(|event| event["kind"] == "WorkspacePatchReadinessReportCreated"));
         for event in events_after_approval.iter().filter(|event| {
             event["kind"] == "WorkspacePatchApproved"
                 || event["kind"] == "WorkspacePatchApplyPlanCreated"

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -281,6 +281,7 @@ pub enum LedgerEventKind {
     WorkspacePatchRejected,
     WorkspacePatchPreflightSnapshotCreated,
     WorkspacePatchApplyPlanCreated,
+    WorkspacePatchReadinessReportCreated,
     TaskRunning,
     PromptBuilt,
     PromptSensitiveScanCompleted,

--- a/docs/specifications/patch-proposal-spec-v0.md
+++ b/docs/specifications/patch-proposal-spec-v0.md
@@ -66,3 +66,13 @@ A preflight snapshot includes `proposal_id`, `snapshot_id`, workspace-relative `
 Repeated preflight creates a new snapshot each time. The first snapshot is not stale. Later snapshots are stale when `file_sha256`, `file_size_bytes`, or `file_modified_unix_ms` differs from the previous latest snapshot. `proposal.list` and `proposal.inspect` return the latest snapshot in `latest_snapshot`.
 
 Approval and rejection reasons are bounded to 1000 characters. Secret-like reasons are stored and returned as `[redacted]` with `approval_reason_redacted = true`; matched secret values are not stored in the ledger.
+
+## Phase 3.4 readiness reports
+
+`proposal.readiness` accepts `{ "run_id": string, "proposal_id": string }` and generates a user-visible final human-review readiness report for an existing patch proposal. The report is not an apply trigger: Phase 3.4 still never writes workspace files and never applies patches.
+
+Readiness relies on the latest `proposal.preflight` snapshot already recorded in the ledger. The runtime checks approval, validation, snapshot freshness, target file kind, target file hash availability, sanitized diff-preview availability, redaction state, sensitive-content state, and the explicit `apply_not_implemented` marker.
+
+`readiness_status` is `Ready`, `NotReady`, or `Blocked`. `Ready` means ready for final human review only. `NotReady` covers missing approval, missing preflight, stale snapshots, missing target hashes, and missing sanitized diff previews. `Blocked` covers blocked validation, redacted previews, unsafe state, or sensitive-like findings.
+
+The runtime appends `WorkspacePatchReadinessReportCreated` with summary-only metadata: proposal ID, report ID, status, reason, generated timestamp, check count, failed check names, and blocked check names. Ledger payloads and RPC responses must not include forbidden raw fields: `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, or `file_content`.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -296,3 +296,13 @@ Diff previews are synthetic unified diff previews only. They are capped before l
 `WorkspacePatchPreflightSnapshotSummary` contains metadata only: `proposal_id`, `snapshot_id`, workspace-relative `path`, `canonical_path_hash`, `file_exists`, `file_kind` (`File`, `Directory`, `Missing`, `Other`, or `Unreadable`), `file_size_bytes`, `file_modified_unix_ms`, `file_sha256`, `captured_at`, `stale`, and `stale_reason`. The runtime hashes canonical paths instead of returning absolute paths, and it never returns file content, raw content, full content, patches, diffs, or raw input JSON.
 
 `WorkspacePatchProposalSummary` includes `latest_snapshot` and `approval_reason_redacted`. Secret-like approval or rejection reasons are represented as `[redacted]` and are not stored raw. Preflight appends ledger metadata only and never writes files or applies patches.
+
+## Phase 3.4 `proposal.readiness`
+
+`proposal.readiness` accepts `{ "run_id": string, "proposal_id": string }` and returns `{ "proposal": WorkspacePatchProposalSummary, "report": WorkspacePatchReadinessReportSummary }`. Empty IDs, unknown runs, and unknown proposals return JSON-RPC `-32602`.
+
+`WorkspacePatchReadinessReportSummary` contains `proposal_id`, `report_id`, `readiness_status`, `readiness_reason`, `generated_at`, a bounded checklist of `WorkspacePatchReadinessCheckSummary`, and a deterministic human-readable summary. Allowed readiness statuses are `Ready`, `NotReady`, and `Blocked`; allowed check statuses are `Pass`, `Fail`, `Blocked`, and `Skipped`.
+
+The method uses the reconstructed proposal summary and latest preflight snapshot. It does not need a fresh target-file read in normal operation, does not write files, and does not apply patches. `Ready` means ready for final human review, not ready to apply; the `apply_not_implemented` check is always `Skipped` with the Phase 3.4 reason.
+
+`WorkspacePatchReadinessReportCreated` is appended as summary-only ledger metadata. Readiness reports, checklists, snapshots, and ledger payloads must not expose raw file content, raw proposed content, raw input JSON, full patch content, raw diffs, canonical absolute paths, absolute paths, or secret-like text. Forbidden raw field names are `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, and `file_content`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -193,3 +193,11 @@ After `proposal.approve`, the runtime creates a blocked apply-plan summary. The 
 After a patch proposal is approved, callers may invoke `proposal.preflight` to capture metadata needed for stale detection before any future apply implementation. Preflight records a snapshot with SHA-256 hashes for the canonical path and readable regular-file content, records a blocked apply plan, and updates proposal inspection with `latest_snapshot`.
 
 Phase 3.3 preserves the no-write/no-apply guarantee: approval and preflight are ledger-only operations and do not modify workspace files. The runtime redacts secret-like approval and rejection reasons before storing or returning them.
+
+## Phase 3.4 proposal readiness
+
+After approval and preflight, callers may invoke `proposal.readiness` to create a final human-review report. The report summarizes whether the proposal is `Ready`, `NotReady`, or `Blocked` by relying on ledger reconstruction and the latest preflight snapshot rather than applying the patch.
+
+Readiness does not write workspace files, does not apply patches, and does not run process, network, service-control, destructive, or subtask actions. A `Ready` report means the proposal is ready for final human review only; patch apply remains unimplemented in Phase 3.4.
+
+Readiness ledger events are summary-only and must exclude raw content fields (`content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, `file_content`) and secret-like text.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -96,6 +96,10 @@
       {
         "command": "brownie.proposalPreflight",
         "title": "Brownie: Preflight Patch Proposal"
+      },
+      {
+        "command": "brownie.proposalReadiness",
+        "title": "Brownie: Patch Proposal Readiness"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -432,6 +432,24 @@ export function activate(context: vscode.ExtensionContext): void {
   });
 
 
+
+  const proposalReadinessCommand = vscode.commands.registerCommand('brownie.proposalReadiness', async () => {
+    const runId = await vscode.window.showInputBox({ prompt: 'Run ID', placeHolder: 'run_...', ignoreFocusOut: true });
+    if (runId === undefined) { return; }
+    const proposalId = await vscode.window.showInputBox({ prompt: 'Proposal ID', placeHolder: 'proposal_...', ignoreFocusOut: true });
+    if (proposalId === undefined) { return; }
+    try {
+      const result = await runtimeClient.readinessProposal(runId.trim(), proposalId.trim());
+      output.appendLine(`proposal.readiness:`);
+      output.appendLine(JSON.stringify(result, null, 2));
+      output.show(true);
+      await vscode.window.showInformationMessage(`Brownie patch readiness: ${result.report.readiness_status} (no apply performed)`);
+    } catch (error) {
+      output.appendLine(`proposal.readiness failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie proposal readiness failed: ${formatError(error)}`);
+    }
+  });
+
   const toolExecuteReadCommand = vscode.commands.registerCommand('brownie.toolExecuteRead', async () => {
     const modeIdInput = await vscode.window.showInputBox({
       prompt: 'Mode ID',
@@ -467,7 +485,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand, proposalInspectCommand, proposalApproveCommand, proposalRejectCommand, proposalPreflightCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand, proposalInspectCommand, proposalApproveCommand, proposalRejectCommand, proposalPreflightCommand, proposalReadinessCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -309,6 +309,27 @@ export interface ProposalApproveResult {
   apply_plan: WorkspacePatchApplyPlanSummary;
 }
 
+export interface WorkspacePatchReadinessReportSummary {
+  proposal_id: string;
+  report_id: string;
+  readiness_status: 'Ready' | 'NotReady' | 'Blocked';
+  readiness_reason: string | null;
+  generated_at: string;
+  checklist: WorkspacePatchReadinessCheckSummary[];
+  summary: string;
+}
+
+export interface WorkspacePatchReadinessCheckSummary {
+  name: string;
+  status: 'Pass' | 'Fail' | 'Blocked' | 'Skipped';
+  reason: string | null;
+}
+
+export interface ProposalReadinessResult {
+  proposal: WorkspacePatchProposalSummary;
+  report: WorkspacePatchReadinessReportSummary;
+}
+
 export interface ProposalRejectResult {
   proposal: WorkspacePatchProposalSummary;
 }
@@ -487,7 +508,7 @@ export function isToolPlanResult(value: unknown): value is ToolPlanResult {
 }
 
 export function hasNoForbiddenRawFields(value: object): boolean {
-  return !Object.prototype.hasOwnProperty.call(value, 'content') && !Object.prototype.hasOwnProperty.call(value, 'raw_content') && !Object.prototype.hasOwnProperty.call(value, 'full_content') && !Object.prototype.hasOwnProperty.call(value, 'patch') && !Object.prototype.hasOwnProperty.call(value, 'diff') && !Object.prototype.hasOwnProperty.call(value, 'raw_input') && !Object.prototype.hasOwnProperty.call(value, 'canonical_path') && !Object.prototype.hasOwnProperty.call(value, 'absolute_path');
+  return !Object.prototype.hasOwnProperty.call(value, 'content') && !Object.prototype.hasOwnProperty.call(value, 'raw_content') && !Object.prototype.hasOwnProperty.call(value, 'full_content') && !Object.prototype.hasOwnProperty.call(value, 'patch') && !Object.prototype.hasOwnProperty.call(value, 'diff') && !Object.prototype.hasOwnProperty.call(value, 'raw_input') && !Object.prototype.hasOwnProperty.call(value, 'canonical_path') && !Object.prototype.hasOwnProperty.call(value, 'absolute_path') && !Object.prototype.hasOwnProperty.call(value, 'file_content');
 }
 
 export function isWorkspacePatchPreflightSnapshotSummary(value: unknown): value is WorkspacePatchPreflightSnapshotSummary {
@@ -515,6 +536,14 @@ export function isWorkspacePatchApplyCheckSummary(value: unknown): value is Work
 
 export function isWorkspacePatchApplyPlanSummary(value: unknown): value is WorkspacePatchApplyPlanSummary {
   return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.plan_id === 'string' && typeof value.status === 'string' && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchApplyCheckSummary) && hasNoForbiddenRawFields(value);
+}
+
+export function isWorkspacePatchReadinessCheckSummary(value: unknown): value is WorkspacePatchReadinessCheckSummary {
+  return isRecord(value) && typeof value.name === 'string' && (value.status === 'Pass' || value.status === 'Fail' || value.status === 'Blocked' || value.status === 'Skipped') && (typeof value.reason === 'string' || value.reason === null) && hasNoForbiddenRawFields(value);
+}
+
+export function isWorkspacePatchReadinessReportSummary(value: unknown): value is WorkspacePatchReadinessReportSummary {
+  return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.report_id === 'string' && (value.readiness_status === 'Ready' || value.readiness_status === 'NotReady' || value.readiness_status === 'Blocked') && (typeof value.readiness_reason === 'string' || value.readiness_reason === null) && typeof value.generated_at === 'string' && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchReadinessCheckSummary) && typeof value.summary === 'string' && hasNoForbiddenRawFields(value);
 }
 
 export function isWorkspacePatchProposalSummary(value: unknown): value is WorkspacePatchProposalSummary {
@@ -568,6 +597,10 @@ export function isProposalPreflightResult(value: unknown): value is ProposalPref
 
 export function isProposalRejectResult(value: unknown): value is ProposalRejectResult {
   return isRecord(value) && isWorkspacePatchProposalSummary(value.proposal);
+}
+
+export function isProposalReadinessResult(value: unknown): value is ProposalReadinessResult {
+  return isRecord(value) && isWorkspacePatchProposalSummary(value.proposal) && isWorkspacePatchReadinessReportSummary(value.report) && hasNoForbiddenRawFields(value);
 }
 
 export function isToolExecuteResult(value: unknown): value is ToolExecuteResult {

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalApproveResult, ProposalPreflightResult, ProposalInspectResult, ProposalListResult, ProposalRejectResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalApproveResult, isProposalPreflightResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalApproveResult, ProposalPreflightResult, ProposalReadinessResult, ProposalInspectResult, ProposalListResult, ProposalRejectResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -174,6 +174,16 @@ export class RuntimeClient {
 
     if (!isProposalPreflightResult(result)) {
       throw new RuntimeProtocolError('proposal.preflight returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async readinessProposal(runId: string, proposalId: string): Promise<ProposalReadinessResult> {
+    const result = await this.call<ProposalReadinessResult>('proposal.readiness', { run_id: runId, proposal_id: proposalId });
+
+    if (!isProposalReadinessResult(result)) {
+      throw new RuntimeProtocolError('proposal.readiness returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApproveResult, isProposalPreflightResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -185,6 +185,10 @@ describe('protocol validation', () => {
     expect(isProposalPreflightResult({ proposal: { ...result.proposals[0], approval_status: 'Approved', approved_at: '2026-06-30T00:00:00Z', latest_snapshot: snapshot, latest_apply_plan: applyPlan }, snapshot, apply_plan: applyPlan })).toBe(true);
     expect(isProposalPreflightResult({ proposal: result.proposals[0], snapshot: { ...snapshot, canonical_path: '/tmp/README.md' }, apply_plan: applyPlan })).toBe(false);
     expect(isProposalPreflightResult({ proposal: result.proposals[0], snapshot: { ...snapshot, raw_input: {} }, apply_plan: applyPlan })).toBe(false);
+    const report = { proposal_id: 'proposal_1', report_id: 'report_1', readiness_status: 'Ready', readiness_reason: null, generated_at: '2026-07-01T00:00:00Z', checklist: [{ name: 'apply_not_implemented', status: 'Skipped', reason: 'Patch apply is not implemented in Phase 3.4.' }], summary: 'Ready for final human review. Patch apply is not implemented in Phase 3.4.' };
+    expect(isProposalReadinessResult({ proposal: { ...result.proposals[0], approval_status: 'Approved', approved_at: '2026-06-30T00:00:00Z', latest_snapshot: snapshot, latest_apply_plan: applyPlan }, report })).toBe(true);
+    expect(isProposalReadinessResult({ proposal: result.proposals[0], report: { ...report, file_content: 'secret' } })).toBe(false);
+    expect(isProposalReadinessResult({ proposal: result.proposals[0], report: { ...report, checklist: [{ ...report.checklist[0], diff: 'raw' }] } })).toBe(false);
     expect(isProposalRejectResult({ proposal: { ...result.proposals[0], approval_status: 'Rejected', rejected_at: '2026-06-30T00:00:00Z' } })).toBe(true);
     expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, raw_content: 'secret' } })).toBe(false);
     expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, canonical_path: '/tmp/README.md' } })).toBe(false);
@@ -435,6 +439,14 @@ describe('RuntimeClient', () => {
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { proposal, snapshot, apply_plan: applyPlan } });
     await expect(new RuntimeClient(transport).preflightProposal('run_1', 'proposal_1')).resolves.toEqual({ proposal, snapshot, apply_plan: applyPlan });
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.preflight', params: { run_id: 'run_1', proposal_id: 'proposal_1' } }]);
+  });
+
+  it('creates a proposal.readiness request', async () => {
+    const proposal = { proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false, validation_status: 'Valid', validation_reason: null, diff_preview: '--- a/README.md', diff_truncated: false, diff_redacted: false, approval_status: 'Approved', approval_reason: 'ok', approved_at: '2026-06-30T00:00:00Z', rejected_at: null, approval_reason_redacted: false };
+    const report = { proposal_id: 'proposal_1', report_id: 'report_1', readiness_status: 'Ready', readiness_reason: null, generated_at: '2026-07-01T00:00:00Z', checklist: [{ name: 'apply_not_implemented', status: 'Skipped', reason: 'Patch apply is not implemented in Phase 3.4.' }], summary: 'Ready for final human review. Patch apply is not implemented in Phase 3.4.' };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { proposal, report } });
+    await expect(new RuntimeClient(transport).readinessProposal('run_1', 'proposal_1')).resolves.toEqual({ proposal, report });
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.readiness', params: { run_id: 'run_1', proposal_id: 'proposal_1' } }]);
   });
 
   it('creates a tool.execute request', async () => {


### PR DESCRIPTION
### Motivation

- Provide a deterministic, user-visible final pre-apply review report for preflighted patch proposals without applying patches or writing files.
- Base readiness decisions on existing ledger state and latest preflight snapshot to detect stale or unsafe proposals.
- Surface a concise checklist and human-readable summary so humans can perform the final review before any future apply implementation.

### Description

- Added protocol types for readiness in Rust (`ProposalReadinessParams`, `ProposalReadinessResult`, `WorkspacePatchReadinessReportSummary`, `WorkspacePatchReadinessCheckSummary`) and corresponding TypeScript interfaces/validators for the VSIX.
- Implemented `proposal.readiness` JSON-RPC handler and `readiness_proposal` logic that reconstructs proposal state, evaluates the required checklist (approval, validation, preflight, stale, file-kind/hash, diff preview, redaction/sensitivity, and `apply_not_implemented`), produces a deterministic `Ready`/`NotReady`/`Blocked` summary, and returns sanitized summary-only report without exposing raw content.
- Appended new ledger event kind `WorkspacePatchReadinessReportCreated` with a summary-only payload (forbidden fields such as `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, `file_content` are never recorded).
- Added VSIX changes: `RuntimeClient.readinessProposal()` method, protocol validators for readiness results, and the `brownie.proposalReadiness` command that prompts for `run_id`/`proposal_id` and prints sanitized JSON (no apply performed).
- Updated documentation in `docs/specifications/*` to describe `proposal.readiness`, readiness semantics, no-write/no-apply guarantees, snapshot reliance, and forbidden raw fields.
- Added/updated tests: runtime JSON-RPC tests exercising Ready and NotReady flows, ledger event presence checks, and VSIX protocol/runtime client tests for the readiness result shape and command request.

### Testing

- Ran `cargo fmt --check`, `cargo check --workspace`, and `cargo test --workspace`, all of which succeeded.
- Ran the VSIX checks and tests via `pnpm install`, `pnpm --filter brownie-vsix check`, `pnpm --filter brownie-vsix test`, and `pnpm --filter brownie-vsix build`, all of which succeeded.
- Unit tests cover the new readiness flow (approve → preflight → `proposal.readiness` yields `Ready`, manual file change → preflight → `proposal.readiness` yields `NotReady`) and assert that readiness report/ledger payloads exclude forbidden raw fields and do not modify workspace files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4515f41c188328a6ecfeedaf15f2f6)