### PR TITLE
Add apply capability status without execution

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -363,6 +363,12 @@ pub struct ProposalReadinessParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalApplyCapabilityParams {
+    pub run_id: String,
+    pub proposal_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskInspectParams {
     pub task_id: String,
 }
@@ -462,6 +468,30 @@ pub struct WorkspacePatchReadinessCheckSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchApplyCapabilitySummary {
+    pub proposal_id: String,
+    pub capability_id: String,
+    pub apply_supported: bool,
+    pub apply_enabled: bool,
+    pub mode: String,
+    pub reason: String,
+    pub required_gates: Vec<String>,
+    pub can_apply_now: bool,
+    pub checked_at: String,
+    pub check_count: usize,
+    pub failed_checks: Vec<String>,
+    pub blocked_checks: Vec<String>,
+    pub checklist: Vec<WorkspacePatchApplyCapabilityCheckSummary>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct WorkspacePatchApplyCapabilityCheckSummary {
+    pub name: String,
+    pub status: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalListResult {
     pub run_id: String,
     pub proposals: Vec<WorkspacePatchProposalSummary>,
@@ -494,6 +524,12 @@ pub struct ProposalPreflightResult {
 pub struct ProposalReadinessResult {
     pub proposal: WorkspacePatchProposalSummary,
     pub report: WorkspacePatchReadinessReportSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProposalApplyCapabilityResult {
+    pub proposal: WorkspacePatchProposalSummary,
+    pub capability: WorkspacePatchApplyCapabilitySummary,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -18,18 +18,20 @@ use brownie_protocol::{
     DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
     LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
     ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
-    PermissionCheckResult, ProposalApproveParams, ProposalApproveResult, ProposalInspectParams,
-    ProposalInspectResult, ProposalListParams, ProposalListResult, ProposalPreflightParams,
-    ProposalPreflightResult, ProposalReadinessParams, ProposalReadinessResult,
-    ProposalRejectParams, ProposalRejectResult, RunEventsParams, RunEventsResult, RunInspectParams,
-    RunInspectResult, RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult,
-    RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams,
-    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult,
-    TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult,
-    ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
-    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
-    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
-    ToolPlanResult, ToolSummary, WorkspacePatchApplyCheckSummary, WorkspacePatchApplyPlanSummary,
+    PermissionCheckResult, ProposalApplyCapabilityParams, ProposalApplyCapabilityResult,
+    ProposalApproveParams, ProposalApproveResult, ProposalInspectParams, ProposalInspectResult,
+    ProposalListParams, ProposalListResult, ProposalPreflightParams, ProposalPreflightResult,
+    ProposalReadinessParams, ProposalReadinessResult, ProposalRejectParams, ProposalRejectResult,
+    RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary,
+    RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult,
+    RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult,
+    TaskListResult, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus,
+    ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary,
+    ToolIntentInputSummary, ToolIntentParseParams, ToolIntentParseResult,
+    ToolIntentParserConfigSummary, ToolIntentParserSummary, ToolIntentRejectedSummary,
+    ToolListResult, ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
+    WorkspacePatchApplyCapabilityCheckSummary, WorkspacePatchApplyCapabilitySummary,
+    WorkspacePatchApplyCheckSummary, WorkspacePatchApplyPlanSummary,
     WorkspacePatchPreflightSnapshotSummary, WorkspacePatchProposalSummary,
     WorkspacePatchReadinessCheckSummary, WorkspacePatchReadinessReportSummary,
 };
@@ -70,6 +72,7 @@ const METHOD_PROPOSAL_APPROVE: &str = "proposal.approve";
 const METHOD_PROPOSAL_REJECT: &str = "proposal.reject";
 const METHOD_PROPOSAL_PREFLIGHT: &str = "proposal.preflight";
 const METHOD_PROPOSAL_READINESS: &str = "proposal.readiness";
+const METHOD_PROPOSAL_APPLY_CAPABILITY: &str = "proposal.applyCapability";
 const DEFAULT_DIFF_PREVIEW_CHARS: usize = 4000;
 const MAX_DIFF_PREVIEW_CHARS: usize = 20000;
 
@@ -126,6 +129,9 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_PROPOSAL_REJECT => handle_proposal_reject(request.id, request.params),
         METHOD_PROPOSAL_PREFLIGHT => handle_proposal_preflight(request.id, request.params),
         METHOD_PROPOSAL_READINESS => handle_proposal_readiness(request.id, request.params),
+        METHOD_PROPOSAL_APPLY_CAPABILITY => {
+            handle_proposal_apply_capability(request.id, request.params)
+        }
         _ => error_response(request.id, -32601, "method not found"),
     }
 }
@@ -1822,6 +1828,34 @@ fn handle_proposal_readiness(id: Value, params: Option<Value>) -> JsonRpcRespons
     }
 }
 
+fn handle_proposal_apply_capability(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params: ProposalApplyCapabilityParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if params.run_id.trim().is_empty() || params.proposal_id.trim().is_empty() {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: run_id and proposal_id are required",
+        );
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32602, &format!("invalid params: {error}")),
+    };
+    match inspect_apply_capability(&store, &params.run_id, &params.proposal_id) {
+        Ok((proposal, capability)) => result_response(
+            id,
+            json!(ProposalApplyCapabilityResult {
+                proposal,
+                capability
+            }),
+        ),
+        Err(message) => error_response(id, -32602, &message),
+    }
+}
+
 fn handle_task_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     let params: TaskInspectParams = match parse_params(params) {
         Ok(params) => params,
@@ -2340,6 +2374,185 @@ fn readiness_check(
     }
 }
 
+fn apply_capability_check(
+    name: &str,
+    status: &str,
+    reason: Option<&str>,
+) -> WorkspacePatchApplyCapabilityCheckSummary {
+    WorkspacePatchApplyCapabilityCheckSummary {
+        name: name.to_string(),
+        status: status.to_string(),
+        reason: reason.map(ToString::to_string),
+    }
+}
+
+fn inspect_apply_capability(
+    store: &BrownieStore,
+    run_id: &str,
+    proposal_id: &str,
+) -> Result<
+    (
+        WorkspacePatchProposalSummary,
+        WorkspacePatchApplyCapabilitySummary,
+    ),
+    String,
+> {
+    let task = store
+        .tasks()
+        .get_task_by_run_id(run_id)
+        .map_err(|e| format!("invalid params: {e}"))?
+        .ok_or_else(|| "invalid params: run not found".to_string())?;
+    let proposal = inspect_proposal(store, run_id, proposal_id)?;
+    let snapshot = proposal.latest_snapshot.as_ref();
+    let mut checklist = vec![apply_capability_check("proposal_exists", "Pass", None)];
+
+    if proposal.validation_status == "Blocked" {
+        checklist.push(apply_capability_check(
+            "proposal_is_valid",
+            "Blocked",
+            proposal.validation_reason.as_deref(),
+        ));
+    } else if proposal.validation_status == "Valid" {
+        checklist.push(apply_capability_check("proposal_is_valid", "Pass", None));
+    } else {
+        checklist.push(apply_capability_check(
+            "proposal_is_valid",
+            "Fail",
+            proposal
+                .validation_reason
+                .as_deref()
+                .or(Some("Proposal validation status is not Valid.")),
+        ));
+    }
+
+    checklist.push(if proposal.approval_status == "Approved" {
+        apply_capability_check("proposal_is_approved", "Pass", None)
+    } else {
+        apply_capability_check(
+            "proposal_is_approved",
+            "Fail",
+            Some("Proposal is not approved."),
+        )
+    });
+    checklist.push(if snapshot.is_some() {
+        apply_capability_check("proposal_has_preflight_snapshot", "Pass", None)
+    } else {
+        apply_capability_check(
+            "proposal_has_preflight_snapshot",
+            "Fail",
+            Some("Run proposal.preflight before final review."),
+        )
+    });
+    checklist.push(match snapshot {
+        Some(snapshot) if !snapshot.stale => {
+            apply_capability_check("proposal_not_stale", "Pass", None)
+        }
+        Some(snapshot) => apply_capability_check(
+            "proposal_not_stale",
+            "Fail",
+            snapshot
+                .stale_reason
+                .as_deref()
+                .or(Some("Latest preflight snapshot is stale.")),
+        ),
+        None => apply_capability_check(
+            "proposal_not_stale",
+            "Skipped",
+            Some("No preflight snapshot is available."),
+        ),
+    });
+    checklist.push(if proposal.diff_preview.is_some() {
+        apply_capability_check("sanitized_diff_preview_available", "Pass", None)
+    } else {
+        apply_capability_check(
+            "sanitized_diff_preview_available",
+            "Fail",
+            Some("Sanitized diff preview is unavailable."),
+        )
+    });
+    checklist.push(
+        if proposal.diff_redacted || proposal.content_preview == "[redacted]" {
+            apply_capability_check(
+                "sensitive_content_not_detected",
+                "Blocked",
+                Some("Sensitive-like content was detected or redacted."),
+            )
+        } else {
+            apply_capability_check("sensitive_content_not_detected", "Pass", None)
+        },
+    );
+    checklist.push(apply_capability_check(
+        "no_raw_content_exposed",
+        "Pass",
+        None,
+    ));
+    checklist.push(apply_capability_check(
+        "apply_execution_disabled",
+        "Blocked",
+        Some("Patch apply execution is not enabled in Phase 3.5."),
+    ));
+
+    let blocked_checks: Vec<String> = checklist
+        .iter()
+        .filter(|c| c.status == "Blocked")
+        .map(|c| c.name.clone())
+        .collect();
+    let failed_checks: Vec<String> = checklist
+        .iter()
+        .filter(|c| c.status == "Fail")
+        .map(|c| c.name.clone())
+        .collect();
+    let checked_at = now_rfc3339();
+    let capability_id = format!("apply_capability_{}", uuid::Uuid::new_v4().simple());
+    let reason = "Patch apply is not implemented in Phase 3.5.".to_string();
+    let required_gates = vec![
+        "proposal_valid".to_string(),
+        "proposal_approved".to_string(),
+        "preflight_snapshot_exists".to_string(),
+        "proposal_not_stale".to_string(),
+        "readiness_ready".to_string(),
+        "operator_apply_enabled".to_string(),
+        "runtime_apply_supported".to_string(),
+    ];
+    let capability = WorkspacePatchApplyCapabilitySummary {
+        proposal_id: proposal_id.to_string(),
+        capability_id: capability_id.clone(),
+        apply_supported: false,
+        apply_enabled: false,
+        mode: "dry_run_only".to_string(),
+        reason,
+        required_gates,
+        can_apply_now: false,
+        checked_at: checked_at.clone(),
+        check_count: checklist.len(),
+        failed_checks,
+        blocked_checks,
+        checklist,
+    };
+    store
+        .tasks()
+        .append_task_event_with_payload(
+            &task,
+            LedgerEventKind::WorkspacePatchApplyCapabilityChecked,
+            Some(json!({
+                "proposal_id": proposal_id,
+                "capability_id": capability_id,
+                "apply_supported": capability.apply_supported,
+                "apply_enabled": capability.apply_enabled,
+                "mode": &capability.mode,
+                "reason": &capability.reason,
+                "required_gates": &capability.required_gates,
+                "can_apply_now": capability.can_apply_now,
+                "checked_at": checked_at,
+                "check_count": capability.check_count,
+                "failed_checks": &capability.failed_checks,
+                "blocked_checks": &capability.blocked_checks,
+            })),
+        )
+        .map_err(|e| format!("invalid params: {e}"))?;
+    Ok((inspect_proposal(store, run_id, proposal_id)?, capability))
+}
+
 fn readiness_proposal(
     store: &BrownieStore,
     run_id: &str,
@@ -2843,6 +3056,13 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "stale",
         "stale_reason",
         "plan_id",
+        "capability_id",
+        "apply_supported",
+        "apply_enabled",
+        "mode",
+        "required_gates",
+        "can_apply_now",
+        "checked_at",
         "report_id",
         "readiness_status",
         "readiness_reason",
@@ -4231,6 +4451,64 @@ mod tests {
             std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
             "original README"
         );
+        let capability = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":72,"method":"proposal.applyCapability","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
+        ));
+        let capability_result = capability.result.expect("capability result");
+        assert_eq!(capability_result["capability"]["apply_supported"], false);
+        assert_eq!(capability_result["capability"]["apply_enabled"], false);
+        assert_eq!(capability_result["capability"]["mode"], "dry_run_only");
+        assert_eq!(
+            capability_result["capability"]["reason"],
+            "Patch apply is not implemented in Phase 3.5."
+        );
+        assert_eq!(capability_result["capability"]["can_apply_now"], false);
+        assert!(capability_result["capability"]["required_gates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|gate| gate == "runtime_apply_supported"));
+        assert_eq!(
+            capability_result["capability"]["check_count"],
+            capability_result["capability"]["checklist"]
+                .as_array()
+                .unwrap()
+                .len()
+        );
+        assert_eq!(
+            capability_result["capability"]["checklist"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|check| check["name"] == "apply_execution_disabled")
+                .unwrap()["status"],
+            "Blocked"
+        );
+        assert!(capability_result["capability"]["blocked_checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check == "apply_execution_disabled"));
+        let serialized_capability =
+            serde_json::to_string(&capability_result["capability"]).unwrap();
+        for forbidden in [
+            "content",
+            "raw_content",
+            "full_content",
+            "patch",
+            "diff",
+            "raw_input",
+            "canonical_path",
+            "absolute_path",
+            "file_content",
+            "original README",
+        ] {
+            assert!(!serialized_capability.contains(&format!(r#"\"{forbidden}\""#)));
+        }
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "original README"
+        );
         std::fs::write(temp.path().join("README.md"), "changed manually").expect("manual change");
         let second_preflight = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":8,"method":"proposal.preflight","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
@@ -4290,6 +4568,9 @@ mod tests {
         assert!(events_after_approval
             .iter()
             .any(|event| event["kind"] == "WorkspacePatchReadinessReportCreated"));
+        assert!(events_after_approval
+            .iter()
+            .any(|event| event["kind"] == "WorkspacePatchApplyCapabilityChecked"));
         let readiness_event = events_after_approval
             .iter()
             .find(|event| event["kind"] == "WorkspacePatchReadinessReportCreated")
@@ -4358,6 +4639,45 @@ mod tests {
             ] {
                 assert!(!serialized.contains(&format!(r#"\"{forbidden}\""#)));
             }
+        }
+        let capability_event = events_after_approval
+            .iter()
+            .find(|event| event["kind"] == "WorkspacePatchApplyCapabilityChecked")
+            .expect("apply capability event");
+        let capability_payload = capability_event["payload"]
+            .as_object()
+            .expect("apply capability payload");
+        assert_eq!(
+            capability_payload["capability_id"],
+            capability_result["capability"]["capability_id"]
+        );
+        assert_eq!(capability_payload["apply_supported"], false);
+        assert_eq!(capability_payload["apply_enabled"], false);
+        assert_eq!(capability_payload["mode"], "dry_run_only");
+        assert_eq!(
+            capability_payload["reason"],
+            "Patch apply is not implemented in Phase 3.5."
+        );
+        assert_eq!(capability_payload["can_apply_now"], false);
+        assert_eq!(
+            capability_payload["check_count"],
+            capability_result["capability"]["check_count"]
+        );
+        let serialized_capability_payload = serde_json::to_string(capability_payload).unwrap();
+        for forbidden in [
+            "content",
+            "raw_content",
+            "full_content",
+            "patch",
+            "diff",
+            "raw_input",
+            "canonical_path",
+            "absolute_path",
+            "file_content",
+            "original README",
+            "changed manually",
+        ] {
+            assert!(!serialized_capability_payload.contains(&format!(r#"\"{forbidden}\""#)));
         }
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
@@ -4435,6 +4755,51 @@ mod tests {
                 .expect("preflight check")
                 .status,
             "Fail"
+        );
+    }
+
+    #[test]
+    fn apply_capability_config_cannot_enable_execution() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::write(temp.path().join("README.md"), "original README").expect("write readme");
+        std::fs::create_dir_all(temp.path().join(".brownie")).expect("config dir");
+        std::fs::write(
+            temp.path().join(".brownie/config.json"),
+            r#"{"apply":{"enabled":true}}"#,
+        )
+        .expect("write config");
+        let store = BrownieStore::new(temp.path());
+        let record = store
+            .tasks()
+            .start_task(TaskStartParams {
+                goal: "apply capability".into(),
+                mode_id: Some("implementer".into()),
+            })
+            .expect("start task");
+        append_test_patch_proposal(
+            &store,
+            &record,
+            "proposal_apply_config",
+            "Valid",
+            Some("--- a/README.md\n+++ b/README.md"),
+            false,
+        );
+
+        let (_proposal, capability) =
+            inspect_apply_capability(&store, &record.run_id, "proposal_apply_config")
+                .expect("apply capability");
+
+        assert!(!capability.apply_supported);
+        assert!(!capability.apply_enabled);
+        assert!(!capability.can_apply_now);
+        assert_eq!(capability.mode, "dry_run_only");
+        assert_eq!(
+            capability.reason,
+            "Patch apply is not implemented in Phase 3.5."
+        );
+        assert_eq!(
+            std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
+            "original README"
         );
     }
 

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -281,6 +281,7 @@ pub enum LedgerEventKind {
     WorkspacePatchRejected,
     WorkspacePatchPreflightSnapshotCreated,
     WorkspacePatchApplyPlanCreated,
+    WorkspacePatchApplyCapabilityChecked,
     WorkspacePatchReadinessReportCreated,
     TaskRunning,
     PromptBuilt,

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -53,3 +53,7 @@ The Rust runtime owns:
 ## Boundary principle
 
 The runtime is the execution authority. The VSIX presents state and connects Code-OSS capabilities.
+
+## Patch apply boundary
+
+Phase 3.5 exposes `proposal.applyCapability` as a read-only design contract for future patch application. The runtime may inspect existing proposal metadata and append summary-only ledger events, but it still must not apply patches, write workspace files, execute shell or git commands, use network access, or return raw file content, raw diffs, raw input JSON, canonical paths, or absolute paths.

--- a/docs/specifications/patch-proposal-spec-v0.md
+++ b/docs/specifications/patch-proposal-spec-v0.md
@@ -76,3 +76,9 @@ Readiness relies on the latest `proposal.preflight` snapshot already recorded in
 `readiness_status` is `Ready`, `NotReady`, or `Blocked`. `Ready` means ready for final human review only. `NotReady` covers missing approval, missing preflight, stale snapshots, missing target hashes, and missing sanitized diff previews. `Blocked` covers blocked validation, redacted previews, unsafe state, or sensitive-like findings.
 
 The runtime appends `WorkspacePatchReadinessReportCreated` with summary-only metadata: proposal ID, report ID, status, reason, generated timestamp, check count, failed check names, and blocked check names. Ledger payloads and RPC responses must not include forbidden raw fields: `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, or `file_content`.
+
+## Phase 3.5 apply capability inspection
+
+`proposal.applyCapability` exposes a design-only apply capability contract for an existing proposal. It returns `WorkspacePatchApplyCapabilitySummary` metadata and appends `WorkspacePatchApplyCapabilityChecked` with summary-only fields. Phase 3.5 always reports `apply_supported = false`, `apply_enabled = false`, `mode = dry_run_only`, and `can_apply_now = false` with the reason `Patch apply is not implemented in Phase 3.5.` Patch application remains unimplemented.
+
+The method is not an apply trigger. It must not write workspace files, apply patches, execute shell or git commands, use network access, or store/return raw file content, raw diffs, raw input JSON, canonical absolute paths, `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, or `file_content`.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -306,3 +306,11 @@ Diff previews are synthetic unified diff previews only. They are capped before l
 The method uses the reconstructed proposal summary and latest preflight snapshot. It does not need a fresh target-file read in normal operation, does not write files, and does not apply patches. `Ready` means ready for final human review, not ready to apply; the `apply_not_implemented` check is always `Skipped` with the Phase 3.4 reason.
 
 `WorkspacePatchReadinessReportCreated` is appended as summary-only ledger metadata. Readiness reports, checklists, snapshots, and ledger payloads must not expose raw file content, raw proposed content, raw input JSON, full patch content, raw diffs, canonical absolute paths, absolute paths, or secret-like text. Forbidden raw field names are `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, and `file_content`.
+
+## Phase 3.5 `proposal.applyCapability`
+
+`proposal.applyCapability` accepts `{ "run_id": string, "proposal_id": string }` and returns `{ "proposal": WorkspacePatchProposalSummary, "capability": WorkspacePatchApplyCapabilitySummary }`. Empty IDs, unknown runs, and unknown proposals return JSON-RPC `-32602`.
+
+`WorkspacePatchApplyCapabilitySummary` contains summary metadata only: `proposal_id`, `capability_id`, `apply_supported`, `apply_enabled`, `mode`, `reason`, `required_gates`, `can_apply_now`, `checked_at`, `check_count`, `failed_checks`, `blocked_checks`, and a bounded checklist of `WorkspacePatchApplyCapabilityCheckSummary`. In Phase 3.5, `apply_supported`, `apply_enabled`, and `can_apply_now` are always `false`; `mode` is always `dry_run_only`; and `reason` is `Patch apply is not implemented in Phase 3.5.`
+
+`proposal.applyCapability` is an inspect-only design contract. It may inspect existing proposal state and append a summary-only `WorkspacePatchApplyCapabilityChecked` ledger event. It must not apply patches, write workspace files, run shell or git commands, use network access, expose canonical absolute paths, or return/store raw file content, raw diffs, raw input JSON, `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, or `file_content`.

--- a/extensions/brownie-vsix/package.json
+++ b/extensions/brownie-vsix/package.json
@@ -100,6 +100,10 @@
       {
         "command": "brownie.proposalReadiness",
         "title": "Brownie: Patch Proposal Readiness"
+      },
+      {
+        "command": "brownie.proposalApplyCapability",
+        "title": "Brownie: Patch Proposal Apply Capability"
       }
     ]
   },

--- a/extensions/brownie-vsix/src/extension.ts
+++ b/extensions/brownie-vsix/src/extension.ts
@@ -450,6 +450,23 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  const proposalApplyCapabilityCommand = vscode.commands.registerCommand('brownie.proposalApplyCapability', async () => {
+    const runId = await vscode.window.showInputBox({ prompt: 'Run ID', placeHolder: 'run_...', ignoreFocusOut: true });
+    if (runId === undefined) { return; }
+    const proposalId = await vscode.window.showInputBox({ prompt: 'Proposal ID', placeHolder: 'proposal_...', ignoreFocusOut: true });
+    if (proposalId === undefined) { return; }
+    try {
+      const result = await runtimeClient.inspectApplyCapability(runId.trim(), proposalId.trim());
+      output.appendLine(`proposal.applyCapability:`);
+      output.appendLine(JSON.stringify(result, null, 2));
+      output.show(true);
+      await vscode.window.showInformationMessage(`Brownie patch apply capability: enabled=${String(result.capability.apply_enabled)} (no apply performed)`);
+    } catch (error) {
+      output.appendLine(`proposal.applyCapability failed: ${formatError(error)}`);
+      await vscode.window.showErrorMessage(`Brownie proposal apply capability failed: ${formatError(error)}`);
+    }
+  });
+
   const toolExecuteReadCommand = vscode.commands.registerCommand('brownie.toolExecuteRead', async () => {
     const modeIdInput = await vscode.window.showInputBox({
       prompt: 'Mode ID',
@@ -485,7 +502,7 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand, proposalInspectCommand, proposalApproveCommand, proposalRejectCommand, proposalPreflightCommand, proposalReadinessCommand);
+  context.subscriptions.push(output, statusCommand, llmStatusCommand, llmHealthCommand, runtimeConfigCommand, modeListCommand, taskStartCommand, taskListCommand, permissionCheckCommand, taskRunCommand, toolPlanCommand, toolIntentParseCommand, toolExecuteReadCommand, taskInspectCommand, runInspectCommand, proposalListCommand, proposalInspectCommand, proposalApproveCommand, proposalRejectCommand, proposalPreflightCommand, proposalReadinessCommand, proposalApplyCapabilityCommand);
 }
 
 export function deactivate(): void {

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -295,6 +295,28 @@ export interface WorkspacePatchApplyCheckSummary {
   reason: string | null;
 }
 
+export interface WorkspacePatchApplyCapabilitySummary {
+  proposal_id: string;
+  capability_id: string;
+  apply_supported: false;
+  apply_enabled: false;
+  mode: 'dry_run_only';
+  reason: string;
+  required_gates: string[];
+  can_apply_now: false;
+  checked_at: string;
+  check_count: number;
+  failed_checks: string[];
+  blocked_checks: string[];
+  checklist: WorkspacePatchApplyCapabilityCheckSummary[];
+}
+
+export interface WorkspacePatchApplyCapabilityCheckSummary {
+  name: string;
+  status: 'Pass' | 'Fail' | 'Blocked' | 'Skipped';
+  reason: string | null;
+}
+
 export interface ProposalListResult {
   run_id: string;
   proposals: WorkspacePatchProposalSummary[];
@@ -307,6 +329,11 @@ export interface ProposalInspectResult {
 export interface ProposalApproveResult {
   proposal: WorkspacePatchProposalSummary;
   apply_plan: WorkspacePatchApplyPlanSummary;
+}
+
+export interface ProposalApplyCapabilityResult {
+  proposal: WorkspacePatchProposalSummary;
+  capability: WorkspacePatchApplyCapabilitySummary;
 }
 
 export interface WorkspacePatchReadinessReportSummary {
@@ -538,6 +565,14 @@ export function isWorkspacePatchApplyPlanSummary(value: unknown): value is Works
   return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.plan_id === 'string' && typeof value.status === 'string' && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchApplyCheckSummary) && hasNoForbiddenRawFields(value);
 }
 
+export function isWorkspacePatchApplyCapabilityCheckSummary(value: unknown): value is WorkspacePatchApplyCapabilityCheckSummary {
+  return isRecord(value) && typeof value.name === 'string' && (value.status === 'Pass' || value.status === 'Fail' || value.status === 'Blocked' || value.status === 'Skipped') && (typeof value.reason === 'string' || value.reason === null) && hasNoForbiddenRawFields(value);
+}
+
+export function isWorkspacePatchApplyCapabilitySummary(value: unknown): value is WorkspacePatchApplyCapabilitySummary {
+  return isRecord(value) && typeof value.proposal_id === 'string' && typeof value.capability_id === 'string' && value.apply_supported === false && value.apply_enabled === false && value.mode === 'dry_run_only' && typeof value.reason === 'string' && Array.isArray(value.required_gates) && value.required_gates.every((gate) => typeof gate === 'string') && value.can_apply_now === false && typeof value.checked_at === 'string' && isNonNegativeInteger(value.check_count) && Array.isArray(value.failed_checks) && value.failed_checks.every((check) => typeof check === 'string') && Array.isArray(value.blocked_checks) && value.blocked_checks.every((check) => typeof check === 'string') && Array.isArray(value.checklist) && value.checklist.every(isWorkspacePatchApplyCapabilityCheckSummary) && hasNoForbiddenRawFields(value);
+}
+
 export function isWorkspacePatchReadinessCheckSummary(value: unknown): value is WorkspacePatchReadinessCheckSummary {
   return isRecord(value) && typeof value.name === 'string' && (value.status === 'Pass' || value.status === 'Fail' || value.status === 'Blocked' || value.status === 'Skipped') && (typeof value.reason === 'string' || value.reason === null) && hasNoForbiddenRawFields(value);
 }
@@ -589,6 +624,10 @@ export function isProposalInspectResult(value: unknown): value is ProposalInspec
 
 export function isProposalApproveResult(value: unknown): value is ProposalApproveResult {
   return isRecord(value) && isWorkspacePatchProposalSummary(value.proposal) && isWorkspacePatchApplyPlanSummary(value.apply_plan);
+}
+
+export function isProposalApplyCapabilityResult(value: unknown): value is ProposalApplyCapabilityResult {
+  return isRecord(value) && isWorkspacePatchProposalSummary(value.proposal) && isWorkspacePatchApplyCapabilitySummary(value.capability) && hasNoForbiddenRawFields(value);
 }
 
 export function isProposalPreflightResult(value: unknown): value is ProposalPreflightResult {

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -1,6 +1,6 @@
 import { RuntimeJsonRpcError, RuntimeProtocolError } from './errors';
-import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalApproveResult, ProposalPreflightResult, ProposalReadinessResult, ProposalInspectResult, ProposalListResult, ProposalRejectResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
-import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
+import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalApplyCapabilityResult, ProposalApproveResult, ProposalPreflightResult, ProposalReadinessResult, ProposalInspectResult, ProposalListResult, ProposalRejectResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
+import { isLlmHealthResult, isLlmStatusResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isModeListResult, isModeSummary, isPermissionCheckResult, isProposalApplyCapabilityResult, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRunEventsResult, isRunInspectResult, isRuntimeStatusResult, isTaskInspectResult, isTaskRecord, isTaskRunResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, isTaskStartResult } from './protocol';
 import type { RuntimeTransport } from './runtimeProcess';
 
 const DEFAULT_TIMEOUT_MS = 10_000;
@@ -184,6 +184,16 @@ export class RuntimeClient {
 
     if (!isProposalReadinessResult(result)) {
       throw new RuntimeProtocolError('proposal.readiness returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async inspectApplyCapability(runId: string, proposalId: string): Promise<ProposalApplyCapabilityResult> {
+    const result = await this.call<ProposalApplyCapabilityResult>('proposal.applyCapability', { run_id: runId, proposal_id: proposalId });
+
+    if (!isProposalApplyCapabilityResult(result)) {
+      throw new RuntimeProtocolError('proposal.applyCapability returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
+import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApplyCapabilityResult, isProposalApproveResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -189,6 +189,11 @@ describe('protocol validation', () => {
     expect(isProposalReadinessResult({ proposal: { ...result.proposals[0], approval_status: 'Approved', approved_at: '2026-06-30T00:00:00Z', latest_snapshot: snapshot, latest_apply_plan: applyPlan }, report })).toBe(true);
     expect(isProposalReadinessResult({ proposal: result.proposals[0], report: { ...report, file_content: 'secret' } })).toBe(false);
     expect(isProposalReadinessResult({ proposal: result.proposals[0], report: { ...report, checklist: [{ ...report.checklist[0], diff: 'raw' }] } })).toBe(false);
+    const capability = { proposal_id: 'proposal_1', capability_id: 'apply_capability_1', apply_supported: false, apply_enabled: false, mode: 'dry_run_only', reason: 'Patch apply is not implemented in Phase 3.5.', required_gates: ['proposal_valid', 'runtime_apply_supported'], can_apply_now: false, checked_at: '2026-07-01T00:00:00Z', check_count: 2, failed_checks: [], blocked_checks: ['apply_execution_disabled'], checklist: [{ name: 'apply_execution_disabled', status: 'Blocked', reason: 'Patch apply execution is not enabled in Phase 3.5.' }, { name: 'no_raw_content_exposed', status: 'Pass', reason: null }] };
+    expect(isProposalApplyCapabilityResult({ proposal: result.proposals[0], capability })).toBe(true);
+    expect(isProposalApplyCapabilityResult({ proposal: result.proposals[0], capability: { ...capability, apply_enabled: true } })).toBe(false);
+    expect(isProposalApplyCapabilityResult({ proposal: result.proposals[0], capability: { ...capability, raw_input: { patch: 'raw' } } })).toBe(false);
+    expect(isProposalApplyCapabilityResult({ proposal: result.proposals[0], capability: { ...capability, checklist: [{ ...capability.checklist[0], diff: 'raw' }] } })).toBe(false);
     expect(isProposalRejectResult({ proposal: { ...result.proposals[0], approval_status: 'Rejected', rejected_at: '2026-06-30T00:00:00Z' } })).toBe(true);
     expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, raw_content: 'secret' } })).toBe(false);
     expect(isProposalApproveResult({ proposal: result.proposals[0], apply_plan: { ...applyPlan, canonical_path: '/tmp/README.md' } })).toBe(false);
@@ -447,6 +452,14 @@ describe('RuntimeClient', () => {
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { proposal, report } });
     await expect(new RuntimeClient(transport).readinessProposal('run_1', 'proposal_1')).resolves.toEqual({ proposal, report });
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.readiness', params: { run_id: 'run_1', proposal_id: 'proposal_1' } }]);
+  });
+
+  it('creates a proposal.applyCapability request', async () => {
+    const proposal = { proposal_id: 'proposal_1', path: 'README.md', operation: 'replace_file', content_preview: 'new', content_chars: 3, truncated: false, validation_status: 'Valid', validation_reason: null, diff_preview: '--- a/README.md', diff_truncated: false, diff_redacted: false, approval_status: 'Approved', approval_reason: 'ok', approved_at: '2026-06-30T00:00:00Z', rejected_at: null, approval_reason_redacted: false };
+    const capability = { proposal_id: 'proposal_1', capability_id: 'apply_capability_1', apply_supported: false, apply_enabled: false, mode: 'dry_run_only', reason: 'Patch apply is not implemented in Phase 3.5.', required_gates: ['proposal_valid', 'runtime_apply_supported'], can_apply_now: false, checked_at: '2026-07-01T00:00:00Z', check_count: 1, failed_checks: [], blocked_checks: ['apply_execution_disabled'], checklist: [{ name: 'apply_execution_disabled', status: 'Blocked', reason: 'Patch apply execution is not enabled in Phase 3.5.' }] };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { proposal, capability } });
+    await expect(new RuntimeClient(transport).inspectApplyCapability('run_1', 'proposal_1')).resolves.toEqual({ proposal, capability });
+    expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'proposal.applyCapability', params: { run_id: 'run_1', proposal_id: 'proposal_1' } }]);
   });
 
   it('creates a tool.execute request', async () => {


### PR DESCRIPTION
## Summary
- Added a read-only apply capability status API for patch proposals.
- Added summary-only runtime model and ledger event for apply capability checks.
- Kept apply unsupported and disabled in Phase 3.5.
- Confirmed config cannot enable patch apply in this phase.
- Added VSIX client/validator support.
- Updated docs to clarify no-write/no-apply behavior.

## Testing
- cargo fmt --check
- cargo check --workspace
- cargo test --workspace
- pnpm install
- pnpm --filter brownie-vsix check
- pnpm --filter brownie-vsix test
- pnpm --filter brownie-vsix build