### PR TITLE
Implement M1 agent loop task run summary

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -639,6 +639,13 @@ pub struct TaskRunResult {
     pub task_id: String,
     pub run_id: String,
     pub status: TaskStatus,
+    pub agent_loop: TaskRunAgentLoopSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TaskRunAgentLoopSummary {
+    pub final_state: String,
+    pub completion_summary: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -103,12 +103,12 @@ use brownie_protocol::{
     ProposalReviewVerdictResult, RunEventsParams, RunEventsResult, RunInspectParams,
     RunInspectResult, RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult,
     RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams,
-    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunParams, TaskRunResult,
-    TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult,
-    ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
-    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
-    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
-    ToolPlanResult, ToolSummary, WorkspacePatchApplyCapabilityCheckSummary,
+    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunAgentLoopSummary, TaskRunParams,
+    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
+    ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary,
+    ToolIntentParseParams, ToolIntentParseResult, ToolIntentParserConfigSummary,
+    ToolIntentParserSummary, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
+    ToolPlanParams, ToolPlanResult, ToolSummary, WorkspacePatchApplyCapabilityCheckSummary,
     WorkspacePatchApplyCapabilitySummary, WorkspacePatchApplyCheckSummary,
     WorkspacePatchApplyDryRunCheckSummary, WorkspacePatchApplyDryRunHistoryEntry,
     WorkspacePatchApplyDryRunHistorySummary, WorkspacePatchApplyDryRunSummary,
@@ -1800,6 +1800,16 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         }
     };
     let provider_strict = provider_selection.strict;
+    if let Err(error) = store.tasks().append_task_event_with_payload(
+        &running,
+        LedgerEventKind::AgentLoopStarted,
+        Some(json!({
+            "entrypoint": METHOD_TASK_RUN,
+            "state": agent_loop_state_name(AgentLoopState::BuildingContext),
+        })),
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
     let result = match AgentLoop::run_with_llm(
         prompt_input,
         provider.as_ref(),
@@ -1828,6 +1838,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             );
         }
     };
+    let mut agent_loop_final_state = result.final_state;
+    let mut agent_loop_completion_summary = result.completion_summary.clone();
 
     if let Err(error) = append_sensitive_scan_event(
         &store,
@@ -1928,6 +1940,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                 );
             }
         };
+        agent_loop_final_state = second_pass.final_state;
+        agent_loop_completion_summary = second_pass.completion_summary.clone();
         if let Err(error) = append_sensitive_scan_event(
             &store,
             &running,
@@ -1977,7 +1991,18 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         }
     }
 
-    let final_status = match result.final_state {
+    if let Err(error) = store.tasks().append_task_event_with_payload(
+        &running,
+        LedgerEventKind::AgentLoopCompleted,
+        Some(json!({
+            "final_state": agent_loop_state_name(agent_loop_final_state),
+            "completion_summary": agent_loop_completion_summary.clone(),
+        })),
+    ) {
+        return error_response(id, -32603, &format!("internal error: {error}"));
+    }
+
+    let final_status = match agent_loop_final_state {
         AgentLoopState::Completed => TaskStatus::Completed,
         AgentLoopState::Cancelled => TaskStatus::Cancelled,
         AgentLoopState::Failed => TaskStatus::Failed,
@@ -2000,6 +2025,10 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                 task_id: record.task_id,
                 run_id: record.run_id,
                 status: record.status,
+                agent_loop: TaskRunAgentLoopSummary {
+                    final_state: agent_loop_state_name(agent_loop_final_state).to_string(),
+                    completion_summary: agent_loop_completion_summary,
+                },
             }),
         ),
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
@@ -9051,6 +9080,10 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "check_count",
         "failed_checks",
         "blocked_checks",
+        "entrypoint",
+        "state",
+        "final_state",
+        "completion_summary",
     ];
     let sanitized = map
         .into_iter()
@@ -9075,6 +9108,9 @@ fn timeline_entry(event: &LedgerEvent) -> String {
             "provider",
             "model",
             "message_count",
+            "state",
+            "final_state",
+            "completion_summary",
             "proposal_id",
             "operation",
             "path",
@@ -9097,6 +9133,24 @@ fn resolve_task_start_policy(mode_id: Option<&str>) -> Result<CompiledModePolicy
         Some(mode_id) if !mode_id.trim().is_empty() => BuiltinModeRegistry::get(mode_id)
             .ok_or_else(|| "invalid params: unknown mode_id".to_string()),
         _ => Ok(BuiltinModeRegistry::default_policy()),
+    }
+}
+
+fn agent_loop_state_name(state: AgentLoopState) -> &'static str {
+    match state {
+        AgentLoopState::Created => "Created",
+        AgentLoopState::LoadingMode => "LoadingMode",
+        AgentLoopState::BuildingContext => "BuildingContext",
+        AgentLoopState::CallingLlm => "CallingLlm",
+        AgentLoopState::ParsingResponse => "ParsingResponse",
+        AgentLoopState::ExecutingTool => "ExecutingTool",
+        AgentLoopState::ApplyingPatch => "ApplyingPatch",
+        AgentLoopState::SpawningSubtask => "SpawningSubtask",
+        AgentLoopState::Waiting => "Waiting",
+        AgentLoopState::Verifying => "Verifying",
+        AgentLoopState::Completed => "Completed",
+        AgentLoopState::Failed => "Failed",
+        AgentLoopState::Cancelled => "Cancelled",
     }
 }
 
@@ -10205,6 +10259,11 @@ mod tests {
         assert_eq!(result["task_id"], task_id);
         assert_eq!(result["run_id"], run_id);
         assert_eq!(result["status"], "Completed");
+        assert_eq!(result["agent_loop"]["final_state"], "Completed");
+        assert!(result["agent_loop"]["completion_summary"]
+            .as_str()
+            .expect("completion summary")
+            .contains(&task_id));
 
         let get = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":3,"method":"task.get","params":{{"task_id":"{task_id}"}}}}"#
@@ -10234,17 +10293,32 @@ mod tests {
         .expect("ledger");
         assert!(ledger.contains("TaskStarted"));
         assert!(ledger.contains("TaskRunning"));
+        assert!(ledger.contains("AgentLoopStarted"));
+        assert!(ledger.contains("AgentLoopCompleted"));
         assert!(ledger.contains("PromptBuilt"));
         assert!(ledger.contains("LlmRequestCreated"));
         assert!(ledger.contains("LlmResponseReceived"));
         assert!(ledger.contains("TaskCompleted"));
-        let events: Vec<LedgerEventKind> = ledger
+        let ledger_events: Vec<brownie_store::LedgerEvent> = ledger
             .lines()
-            .map(|line| {
-                serde_json::from_str::<brownie_store::LedgerEvent>(line)
-                    .expect("event")
-                    .kind
-            })
+            .map(|line| serde_json::from_str::<brownie_store::LedgerEvent>(line).expect("event"))
+            .collect();
+        let completion_event = ledger_events
+            .iter()
+            .find(|event| event.kind == LedgerEventKind::AgentLoopCompleted)
+            .expect("agent loop completed event");
+        let completion_payload = completion_event
+            .payload
+            .as_ref()
+            .expect("agent loop completion payload");
+        assert_eq!(completion_payload["final_state"], "Completed");
+        assert!(completion_payload["completion_summary"]
+            .as_str()
+            .expect("completion summary")
+            .contains(&task_id));
+        let events: Vec<LedgerEventKind> = ledger_events
+            .iter()
+            .map(|event| event.kind.clone())
             .collect();
         assert_eq!(
             events,
@@ -10265,6 +10339,7 @@ mod tests {
                 LedgerEventKind::ToolPlanDenied,
                 LedgerEventKind::ToolPermissionChecked,
                 LedgerEventKind::ToolPlanApproved,
+                LedgerEventKind::AgentLoopStarted,
                 LedgerEventKind::PromptBuilt,
                 LedgerEventKind::LlmRequestCreated,
                 LedgerEventKind::ToolIntentParsed,
@@ -10278,6 +10353,7 @@ mod tests {
                 LedgerEventKind::ToolExecutionPermissionChecked,
                 LedgerEventKind::ToolExecutionFailed,
                 LedgerEventKind::LlmResponseReceived,
+                LedgerEventKind::AgentLoopCompleted,
                 LedgerEventKind::TaskCompleted,
             ]
         );

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -285,6 +285,8 @@ pub enum LedgerEventKind {
     WorkspacePatchApplyDryRunChecked,
     WorkspacePatchReadinessReportCreated,
     TaskRunning,
+    AgentLoopStarted,
+    AgentLoopCompleted,
     PromptBuilt,
     PromptSensitiveScanCompleted,
     PromptSensitiveScanFailed,

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -110,7 +110,7 @@ Request line:
 Expected response line:
 
 ```json
-{"jsonrpc":"2.0","id":2,"result":{"task_id":"task_<uuid>","run_id":"run_<uuid>","status":"Completed"}}
+{"jsonrpc":"2.0","id":2,"result":{"task_id":"task_<uuid>","run_id":"run_<uuid>","status":"Completed","agent_loop":{"final_state":"Completed","completion_summary":"LLM agent loop completed for task_<uuid>"}}}
 ```
 
 Unknown tasks and tasks whose status is not `Created` return `-32602`. Phase 1.1 does not call an LLM, execute tools, parse AgentModes, use Qdrant, use llama-server, or run an indexer.
@@ -163,6 +163,10 @@ TaskCompleted
 The response still reports `Completed` on success. The additional ledger events contain metadata only, such as message counts, fake model name, and short previews. Full prompt text is not persisted by default.
 
 The fake LLM adapter is deterministic and local-only. Phase 1.2 performs no real LLM network calls and does not introduce tool execution, AgentModes parsing, Mode Pack fetch or activation, Qdrant, llama-server, or indexing behavior.
+
+## M1 agent-loop runtime summary
+
+M1 makes the existing Rust-owned agent-loop execution visible on the task runtime path without adding a new RPC. During `task.run`, the runtime records `AgentLoopStarted` and `AgentLoopCompleted` ledger events around the agent-loop call. Successful responses include an `agent_loop` summary with `final_state` and `completion_summary`, allowing VSIX and headless callers to confirm that the runtime path exercised the agent loop rather than only observing task status.
 
 ## Phase 1.3 mode protocol methods
 

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -141,6 +141,10 @@ Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` afte
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
 
+## M1 agent-loop runtime summary
+
+M1 keeps `task.run` as the runtime-owned execution path and exposes the agent-loop transition directly. The runtime records `AgentLoopStarted` before invoking the Rust `brownie-agent-loop` path and records `AgentLoopCompleted` before the terminal task status update. The `task.run` result includes `agent_loop.final_state` and `agent_loop.completion_summary`, so callers can distinguish a completed agent-loop execution from a bare task status update.
+
 ## Phase 1.10 task inspection
 
 `task.inspect` is the preferred task-centric inspection method for VSIX clients. It returns the persisted `TaskRecord` plus the associated sanitized `RunInspectSummary` without changing task state or executing additional work.

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -200,6 +200,12 @@ export interface TaskRunResult {
   task_id: string;
   run_id: string;
   status: TaskStatus;
+  agent_loop: AgentLoopRunSummary;
+}
+
+export interface AgentLoopRunSummary {
+  final_state: string;
+  completion_summary: string;
 }
 
 export interface TaskRecord {
@@ -2472,7 +2478,16 @@ export function isTaskRunResult(value: unknown): value is TaskRunResult {
     isRecord(value) &&
     typeof value.task_id === 'string' &&
     typeof value.run_id === 'string' &&
-    isTaskStatus(value.status)
+    isTaskStatus(value.status) &&
+    isAgentLoopRunSummary(value.agent_loop)
+  );
+}
+
+export function isAgentLoopRunSummary(value: unknown): value is AgentLoopRunSummary {
+  return (
+    isRecord(value) &&
+    typeof value.final_state === 'string' &&
+    typeof value.completion_summary === 'string'
   );
 }
 

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -568,10 +568,11 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a task.run request', async () => {
-    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { task_id: 'task_1', run_id: 'run_1', status: 'Completed' } });
+    const result = { task_id: 'task_1', run_id: 'run_1', status: 'Completed', agent_loop: { final_state: 'Completed', completion_summary: 'LLM agent loop completed for task_1' } };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
 
-    await expect(client.runTask('task_1')).resolves.toEqual({ task_id: 'task_1', run_id: 'run_1', status: 'Completed' });
+    await expect(client.runTask('task_1')).resolves.toEqual(result);
     expect(transport.requests).toEqual([{ jsonrpc: '2.0', id: 1, method: 'task.run', params: { task_id: 'task_1' } }]);
   });
 


### PR DESCRIPTION
## 概要

M1 Agent Loop Integration の最小 slice です。新しい RPC は追加せず、既存の `task.run` runtime path で Rust-owned `brownie-agent-loop` の実行結果を observable にしました。

## Capability gain

- `task.run` が `AgentLoopStarted` / `AgentLoopCompleted` ledger event を記録します。
- `task.run` result に `agent_loop.final_state` と `agent_loop.completion_summary` を返します。
- VSIX は thin client のまま、protocol 型と validator だけを追随します。
- deterministic Rust test で、`task.run` が task status だけでなく agent-loop summary と ledger transition を返すことを確認します。

## Safety / boundary

- diagnostics wrapper RPC は追加していません。
- patch apply、unrestricted process execution、新しい network capability、service-control は追加していません。
- 既存の no-write / no-apply boundary を維持しています。

## Checks

- `pnpm guard:diagnostics`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
