### PR TITLE
M3: Add readiness fingerprint gate

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -723,6 +723,8 @@ pub struct WorkspacePatchReadinessReportSummary {
     pub report_id: String,
     pub readiness_status: String,
     pub readiness_reason: Option<String>,
+    pub readiness_fingerprint: String,
+    pub fingerprint_input_count: usize,
     pub generated_at: String,
     pub checklist: Vec<WorkspacePatchReadinessCheckSummary>,
     pub summary: String,

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -4506,10 +4506,16 @@ fn inspect_apply_capability(
     Ok((inspect_proposal(store, run_id, proposal_id)?, capability))
 }
 
-fn latest_readiness_status(
+struct LatestReadinessEvidence {
+    status: String,
+    reason: Option<String>,
+    fingerprint: Option<String>,
+}
+
+fn latest_readiness_evidence(
     events: &[LedgerEvent],
     proposal_id: &str,
-) -> Option<(String, Option<String>)> {
+) -> Option<LatestReadinessEvidence> {
     events.iter().rev().find_map(|event| {
         if event.kind != LedgerEventKind::WorkspacePatchReadinessReportCreated {
             return None;
@@ -4518,13 +4524,17 @@ fn latest_readiness_status(
         if payload.get("proposal_id").and_then(Value::as_str) != Some(proposal_id) {
             return None;
         }
-        Some((
-            payload.get("readiness_status")?.as_str()?.to_string(),
-            payload
+        Some(LatestReadinessEvidence {
+            status: payload.get("readiness_status")?.as_str()?.to_string(),
+            reason: payload
                 .get("readiness_reason")
                 .and_then(Value::as_str)
                 .map(ToString::to_string),
-        ))
+            fingerprint: payload
+                .get("readiness_fingerprint")
+                .and_then(Value::as_str)
+                .map(ToString::to_string),
+        })
     })
 }
 
@@ -4546,7 +4556,10 @@ fn inspect_apply_dry_run(
         .ok_or_else(|| "invalid params: run not found".to_string())?;
     let proposal = inspect_proposal(store, run_id, proposal_id)?;
     let events = read_existing_run_events(store, run_id)?;
-    let latest_readiness = latest_readiness_status(&events, proposal_id);
+    let latest_readiness = latest_readiness_evidence(&events, proposal_id);
+    let current_readiness_checklist = build_readiness_checklist(&proposal);
+    let (current_readiness_fingerprint, _) =
+        readiness_fingerprint(&proposal, &current_readiness_checklist);
     let snapshot = proposal.latest_snapshot.as_ref();
     let mut checklist = vec![apply_dry_run_check("proposal_exists", "Pass", None)];
 
@@ -4615,25 +4628,49 @@ fn inspect_apply_dry_run(
         )
     });
     checklist.push(match latest_readiness.as_ref() {
-        Some((status, _)) if status == "Ready" => {
+        Some(evidence) if evidence.status == "Ready" => {
             apply_dry_run_check("readiness_ready", "Pass", None)
         }
-        Some((status, reason)) if status == "Blocked" => apply_dry_run_check(
+        Some(evidence) if evidence.status == "Blocked" => apply_dry_run_check(
             "readiness_ready",
             "Blocked",
-            reason
+            evidence
+                .reason
                 .as_deref()
                 .or(Some("Latest readiness report is blocked.")),
         ),
-        Some((_, reason)) => apply_dry_run_check(
+        Some(evidence) => apply_dry_run_check(
             "readiness_ready",
             "Fail",
-            reason
+            evidence
+                .reason
                 .as_deref()
                 .or(Some("Latest readiness report is not ready.")),
         ),
         None => apply_dry_run_check(
             "readiness_ready",
+            "Fail",
+            Some("Run proposal.readiness before apply dry-run inspection."),
+        ),
+    });
+    checklist.push(match latest_readiness.as_ref() {
+        Some(evidence)
+            if evidence.fingerprint.as_deref() == Some(current_readiness_fingerprint.as_str()) =>
+        {
+            apply_dry_run_check("readiness_fingerprint_current", "Pass", None)
+        }
+        Some(evidence) if evidence.fingerprint.is_some() => apply_dry_run_check(
+            "readiness_fingerprint_current",
+            "Fail",
+            Some("Latest readiness report does not match current proposal evidence."),
+        ),
+        Some(_) => apply_dry_run_check(
+            "readiness_fingerprint_current",
+            "Fail",
+            Some("Latest readiness report has no machine-checkable fingerprint."),
+        ),
+        None => apply_dry_run_check(
+            "readiness_fingerprint_current",
             "Fail",
             Some("Run proposal.readiness before apply dry-run inspection."),
         ),
@@ -4668,6 +4705,7 @@ fn inspect_apply_dry_run(
         "preflight_snapshot_exists".to_string(),
         "proposal_not_stale".to_string(),
         "readiness_ready".to_string(),
+        "readiness_fingerprint_current".to_string(),
         "operator_dry_run_requested".to_string(),
         "runtime_apply_supported".to_string(),
     ];
@@ -8452,6 +8490,8 @@ fn proposal_audit_entry(
                     "report_id",
                     "readiness_status",
                     "readiness_reason",
+                    "readiness_fingerprint",
+                    "fingerprint_input_count",
                     "generated_at",
                     "check_count",
                     "failed_checks",
@@ -8573,23 +8613,9 @@ fn string_array_field(payload: &Value, key: &str) -> Option<Vec<String>> {
         .collect()
 }
 
-fn readiness_proposal(
-    store: &BrownieStore,
-    run_id: &str,
-    proposal_id: &str,
-) -> Result<
-    (
-        WorkspacePatchProposalSummary,
-        WorkspacePatchReadinessReportSummary,
-    ),
-    String,
-> {
-    let task = store
-        .tasks()
-        .get_task_by_run_id(run_id)
-        .map_err(|e| format!("invalid params: {e}"))?
-        .ok_or_else(|| "invalid params: run not found".to_string())?;
-    let proposal = inspect_proposal(store, run_id, proposal_id)?;
+fn build_readiness_checklist(
+    proposal: &WorkspacePatchProposalSummary,
+) -> Vec<WorkspacePatchReadinessCheckSummary> {
     let snapshot = proposal.latest_snapshot.as_ref();
     let mut checklist = vec![readiness_check("proposal_exists", "Pass", None)];
 
@@ -8732,6 +8758,104 @@ fn readiness_proposal(
         "Skipped",
         Some("Patch apply is not implemented in Phase 3.4."),
     ));
+    checklist
+}
+
+fn readiness_fingerprint(
+    proposal: &WorkspacePatchProposalSummary,
+    checklist: &[WorkspacePatchReadinessCheckSummary],
+) -> (String, usize) {
+    let mut inputs = vec![
+        format!("proposal_id={}", proposal.proposal_id),
+        format!("path={}", proposal.path),
+        format!("operation={}", proposal.operation),
+        format!("content_chars={}", proposal.content_chars),
+        format!("truncated={}", proposal.truncated),
+        format!("validation_status={}", proposal.validation_status),
+        format!(
+            "validation_reason={}",
+            proposal.validation_reason.as_deref().unwrap_or("")
+        ),
+        format!("diff_preview_available={}", proposal.diff_preview.is_some()),
+        format!("diff_truncated={}", proposal.diff_truncated),
+        format!("diff_redacted={}", proposal.diff_redacted),
+        format!("approval_status={}", proposal.approval_status),
+        format!(
+            "approved_at={}",
+            proposal.approved_at.as_deref().unwrap_or("")
+        ),
+        format!(
+            "rejected_at={}",
+            proposal.rejected_at.as_deref().unwrap_or("")
+        ),
+    ];
+    if let Some(snapshot) = proposal.latest_snapshot.as_ref() {
+        inputs.extend([
+            format!("snapshot_id={}", snapshot.snapshot_id),
+            format!("snapshot_path={}", snapshot.path),
+            format!("canonical_path_hash={}", snapshot.canonical_path_hash),
+            format!("file_exists={}", snapshot.file_exists),
+            format!("file_kind={}", snapshot.file_kind),
+            format!(
+                "file_size_bytes={}",
+                snapshot
+                    .file_size_bytes
+                    .map(|value| value.to_string())
+                    .unwrap_or_default()
+            ),
+            format!(
+                "file_modified_unix_ms={}",
+                snapshot
+                    .file_modified_unix_ms
+                    .map(|value| value.to_string())
+                    .unwrap_or_default()
+            ),
+            format!(
+                "file_sha256={}",
+                snapshot.file_sha256.as_deref().unwrap_or("")
+            ),
+            format!("stale={}", snapshot.stale),
+            format!(
+                "stale_reason={}",
+                snapshot.stale_reason.as_deref().unwrap_or("")
+            ),
+        ]);
+    } else {
+        inputs.push("snapshot_id=".to_string());
+    }
+    for (index, check) in checklist.iter().enumerate() {
+        inputs.push(format!(
+            "check[{index}]={}|{}|{}",
+            check.name,
+            check.status,
+            check.reason.as_deref().unwrap_or("")
+        ));
+    }
+    let input_count = inputs.len();
+    (
+        format!("sha256:{}", hex_sha256(inputs.join("\n").as_bytes())),
+        input_count,
+    )
+}
+
+fn readiness_proposal(
+    store: &BrownieStore,
+    run_id: &str,
+    proposal_id: &str,
+) -> Result<
+    (
+        WorkspacePatchProposalSummary,
+        WorkspacePatchReadinessReportSummary,
+    ),
+    String,
+> {
+    let task = store
+        .tasks()
+        .get_task_by_run_id(run_id)
+        .map_err(|e| format!("invalid params: {e}"))?
+        .ok_or_else(|| "invalid params: run not found".to_string())?;
+    let proposal = inspect_proposal(store, run_id, proposal_id)?;
+    let checklist = build_readiness_checklist(&proposal);
 
     let blocked_checks: Vec<String> = checklist
         .iter()
@@ -8768,11 +8892,15 @@ fn readiness_proposal(
     };
     let generated_at = now_rfc3339();
     let report_id = format!("report_{}", uuid::Uuid::new_v4().simple());
+    let (readiness_fingerprint, fingerprint_input_count) =
+        readiness_fingerprint(&proposal, &checklist);
     let report = WorkspacePatchReadinessReportSummary {
         proposal_id: proposal_id.to_string(),
         report_id: report_id.clone(),
         readiness_status: readiness_status.to_string(),
         readiness_reason: readiness_reason.map(ToString::to_string),
+        readiness_fingerprint: readiness_fingerprint.clone(),
+        fingerprint_input_count,
         generated_at: generated_at.clone(),
         checklist,
         summary: summary.to_string(),
@@ -8787,6 +8915,8 @@ fn readiness_proposal(
                 "report_id": report_id,
                 "readiness_status": readiness_status,
                 "readiness_reason": report.readiness_reason,
+                "readiness_fingerprint": readiness_fingerprint,
+                "fingerprint_input_count": fingerprint_input_count,
                 "generated_at": generated_at,
                 "check_count": report.checklist.len(),
                 "failed_checks": failed_checks,
@@ -9094,6 +9224,8 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "report_id",
         "readiness_status",
         "readiness_reason",
+        "readiness_fingerprint",
+        "fingerprint_input_count",
         "generated_at",
         "check_count",
         "failed_checks",
@@ -10764,6 +10896,16 @@ mod tests {
         ));
         let ready_result = ready.result.expect("ready result");
         assert_eq!(ready_result["report"]["readiness_status"], "Ready");
+        assert!(ready_result["report"]["readiness_fingerprint"]
+            .as_str()
+            .unwrap()
+            .starts_with("sha256:"));
+        assert!(
+            ready_result["report"]["fingerprint_input_count"]
+                .as_u64()
+                .unwrap()
+                > 0
+        );
         assert_eq!(
             ready_result["report"]["checklist"]
                 .as_array()
@@ -10852,6 +10994,11 @@ mod tests {
             .unwrap()
             .iter()
             .any(|gate| gate == "readiness_ready"));
+        assert!(dry_run_result["dry_run"]["required_gates"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|gate| gate == "readiness_fingerprint_current"));
         assert_eq!(
             dry_run_result["dry_run"]["check_count"],
             dry_run_result["dry_run"]["checklist"]
@@ -10865,6 +11012,15 @@ mod tests {
                 .unwrap()
                 .iter()
                 .find(|check| check["name"] == "readiness_ready")
+                .unwrap()["status"],
+            "Pass"
+        );
+        assert_eq!(
+            dry_run_result["dry_run"]["checklist"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|check| check["name"] == "readiness_fingerprint_current")
                 .unwrap()["status"],
             "Pass"
         );
@@ -11273,6 +11429,26 @@ mod tests {
             std::fs::read_to_string(temp.path().join("README.md")).unwrap(),
             "changed manually"
         );
+        let stale_fingerprint_dry_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":81,"method":"proposal.applyDryRun","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
+        ));
+        let stale_fingerprint_dry_run_result = stale_fingerprint_dry_run
+            .result
+            .expect("stale fingerprint dry-run result");
+        assert_eq!(
+            stale_fingerprint_dry_run_result["dry_run"]["checklist"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|check| check["name"] == "readiness_fingerprint_current")
+                .unwrap()["status"],
+            "Fail"
+        );
+        assert!(stale_fingerprint_dry_run_result["dry_run"]["failed_checks"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|check| check == "readiness_fingerprint_current"));
         let readiness = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":9,"method":"proposal.readiness","params":{{"run_id":"{run_id}","proposal_id":"{proposal_id}"}}}}"#
         ));
@@ -11413,6 +11589,14 @@ mod tests {
             ready_result["report"]["report_id"]
         );
         assert_eq!(readiness_payload["readiness_status"], "Ready");
+        assert_eq!(
+            readiness_payload["readiness_fingerprint"],
+            ready_result["report"]["readiness_fingerprint"]
+        );
+        assert_eq!(
+            readiness_payload["fingerprint_input_count"],
+            ready_result["report"]["fingerprint_input_count"]
+        );
         assert_eq!(
             readiness_payload["generated_at"],
             ready_result["report"]["generated_at"]

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -313,7 +313,7 @@ Diff previews are synthetic unified diff previews only. They are capped before l
 
 `proposal.readiness` accepts `{ "run_id": string, "proposal_id": string }` and returns `{ "proposal": WorkspacePatchProposalSummary, "report": WorkspacePatchReadinessReportSummary }`. Empty IDs, unknown runs, and unknown proposals return JSON-RPC `-32602`.
 
-`WorkspacePatchReadinessReportSummary` contains `proposal_id`, `report_id`, `readiness_status`, `readiness_reason`, `generated_at`, a bounded checklist of `WorkspacePatchReadinessCheckSummary`, and a deterministic human-readable summary. Allowed readiness statuses are `Ready`, `NotReady`, and `Blocked`; allowed check statuses are `Pass`, `Fail`, `Blocked`, and `Skipped`.
+`WorkspacePatchReadinessReportSummary` contains `proposal_id`, `report_id`, `readiness_status`, `readiness_reason`, `readiness_fingerprint`, `fingerprint_input_count`, `generated_at`, a bounded checklist of `WorkspacePatchReadinessCheckSummary`, and a deterministic human-readable summary. Allowed readiness statuses are `Ready`, `NotReady`, and `Blocked`; allowed check statuses are `Pass`, `Fail`, `Blocked`, and `Skipped`.
 
 The method uses the reconstructed proposal summary and latest preflight snapshot. It does not need a fresh target-file read in normal operation, does not write files, and does not apply patches. `Ready` means ready for final human review, not ready to apply; the `apply_not_implemented` check is always `Skipped` with the Phase 3.4 reason.
 
@@ -334,6 +334,12 @@ The method uses the reconstructed proposal summary and latest preflight snapshot
 `WorkspacePatchApplyDryRunSummary` contains summary metadata only: `proposal_id`, `dry_run_id`, `dry_run_status`, `dry_run_reason`, `checked_at`, `required_gates`, `check_count`, `failed_checks`, `blocked_checks`, `no_patch_applied`, `apply_executed`, `workspace_files_changed`, and a bounded checklist of `WorkspacePatchApplyDryRunCheckSummary`. In Phase 3.6, dry-run inspection never applies a patch and never writes workspace files, so `no_patch_applied` is always `true`, `apply_executed` is always `false`, and `workspace_files_changed` is always `false`.
 
 `proposal.applyDryRun` appends `WorkspacePatchApplyDryRunChecked` with summary-only metadata. It may inspect existing proposal, approval, preflight, readiness, and apply-disabled state, but it must not apply patches, write workspace files, run shell or git commands, use network access, expose canonical absolute paths, or return/store raw file content, raw diffs, raw input JSON, `content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, or `file_content`.
+
+## M3 controlled apply readiness fingerprint
+
+M3 strengthens the existing `proposal.readiness` and `proposal.applyDryRun` paths without adding a new endpoint. `proposal.readiness` records a `readiness_fingerprint` over stable summary-only proposal evidence, approval state, latest preflight snapshot metadata, and readiness checklist status. `proposal.applyDryRun` recomputes that fingerprint from the current reconstructed proposal state and fails the `readiness_fingerprint_current` gate when the latest readiness report no longer matches current evidence.
+
+The fingerprint is summary-only. It must not include raw file content, raw diffs, raw input JSON, canonical absolute paths, shell command text, stdout/stderr, environment values, or network-derived content. M3 still never applies patches, writes workspace files, runs shell or git commands, fetches network resources, or authorizes apply.
 
 ## Phase 3.7 `proposal.applyDryRunHistory`
 

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -204,4 +204,10 @@ After approval and preflight, callers may invoke `proposal.readiness` to create 
 
 Readiness does not write workspace files, does not apply patches, and does not run process, network, service-control, destructive, or subtask actions. A `Ready` report means the proposal is ready for final human review only; patch apply remains unimplemented in Phase 3.4.
 
+## M3 controlled apply readiness fingerprint
+
+M3 records a summary-only readiness fingerprint when `proposal.readiness` runs. The fingerprint covers stable proposal metadata, approval state, latest preflight snapshot metadata, and readiness checklist outcomes. `proposal.applyDryRun` recomputes the fingerprint and fails a `readiness_fingerprint_current` gate if the latest readiness report is stale relative to current proposal evidence.
+
+The M3 fingerprint is a readiness gate only. It does not enable patch apply, does not write workspace files, and does not expose raw file content, raw diffs, raw input JSON, canonical absolute paths, process output, environment values, or network-derived content.
+
 Readiness ledger events are summary-only and must exclude raw content fields (`content`, `raw_content`, `full_content`, `patch`, `diff`, `raw_input`, `canonical_path`, `absolute_path`, `file_content`) and secret-like text.


### PR DESCRIPTION
## Summary

- `proposal.readiness` が summary-only な `readiness_fingerprint` と `fingerprint_input_count` を返し、ledger にも記録するようにしました。
- `proposal.applyDryRun` が現在の proposal / approval / preflight / readiness checklist から fingerprint を再計算し、最新 readiness report と一致しない場合に `readiness_fingerprint_current` gate を Fail にします。
- 既存の no-write / no-apply 境界は維持し、patch apply、workspace mutation、unrestricted process execution、network fetch、service-control は追加していません。
- runtime/task protocol docs に M3 controlled apply readiness fingerprint の仕様を追記しました。

## Checks

- `pnpm guard:diagnostics`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`

## Phase value

- strategic_capability: `controlled_workspace_tools`
- phase: `M3`
- capability gain: readiness evidence is now machine-checkable by fingerprint, and dry-run can detect stale readiness evidence before any future apply path.
- boundary: no patch apply, no direct workspace mutation, no unrestricted process exec, no network fetch, no service-control capability added.