### PR TITLE
M4: Bound task context window

### DIFF
--- a/crates/brownie-agent-loop/src/lib.rs
+++ b/crates/brownie-agent-loop/src/lib.rs
@@ -194,6 +194,7 @@ fn prompt_role_to_llm_role(role: &PromptRole) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use brownie_context::{ContextWindowSummary, MAX_LEDGER_CONTEXT_EVENTS};
     use brownie_llm::FAKE_LLM_MODEL;
 
     #[test]
@@ -221,6 +222,14 @@ mod tests {
             tool_plan_summary: vec![],
             tool_intent_summary: vec![],
             tool_execution_summary: vec![],
+            context_window: ContextWindowSummary {
+                total_events: 2,
+                included_events: 2,
+                omitted_events: 0,
+                max_events: MAX_LEDGER_CONTEXT_EVENTS,
+                first_included_event: Some("TaskStarted".into()),
+                last_included_event: Some("TaskRunning".into()),
+            },
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 
@@ -250,6 +259,14 @@ mod tests {
             tool_execution_summary: vec![
                 "workspace.read: Completed bytes_read=12 truncated=false".into()
             ],
+            context_window: ContextWindowSummary {
+                total_events: 1,
+                included_events: 1,
+                omitted_events: 0,
+                max_events: MAX_LEDGER_CONTEXT_EVENTS,
+                first_included_event: Some("ToolExecutionCompleted".into()),
+                last_included_event: Some("ToolExecutionCompleted".into()),
+            },
             ledger_summary: vec!["ToolExecutionCompleted".into()],
         });
 

--- a/crates/brownie-context/src/lib.rs
+++ b/crates/brownie-context/src/lib.rs
@@ -30,6 +30,31 @@ pub struct PromptView {
     pub messages: Vec<PromptMessage>,
 }
 
+pub const MAX_LEDGER_CONTEXT_EVENTS: usize = 12;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ContextWindowSummary {
+    pub total_events: usize,
+    pub included_events: usize,
+    pub omitted_events: usize,
+    pub max_events: usize,
+    pub first_included_event: Option<String>,
+    pub last_included_event: Option<String>,
+}
+
+impl ContextWindowSummary {
+    pub fn empty() -> Self {
+        Self {
+            total_events: 0,
+            included_events: 0,
+            omitted_events: 0,
+            max_events: MAX_LEDGER_CONTEXT_EVENTS,
+            first_included_event: None,
+            last_included_event: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PromptBuildInput {
     pub task_id: String,
@@ -41,6 +66,7 @@ pub struct PromptBuildInput {
     pub tool_plan_summary: Vec<String>,
     pub tool_intent_summary: Vec<String>,
     pub tool_execution_summary: Vec<String>,
+    pub context_window: ContextWindowSummary,
     pub ledger_summary: Vec<String>,
 }
 
@@ -71,12 +97,7 @@ impl ContextMaterializer {
         let tool_plan_summary = format_tool_plan_summary(&input.ledger_events);
         let tool_intent_summary = format_tool_intent_summary(&input.ledger_events);
         let tool_execution_summary = format_tool_execution_summary(&input.ledger_events);
-
-        let ledger_summary = input
-            .ledger_events
-            .iter()
-            .map(|event| format!("{:?}", event.kind))
-            .collect();
+        let (ledger_summary, context_window) = format_ledger_context_window(&input.ledger_events);
 
         PromptBuildInput {
             task_id: input.task.task_id,
@@ -88,9 +109,33 @@ impl ContextMaterializer {
             tool_plan_summary,
             tool_intent_summary,
             tool_execution_summary,
+            context_window,
             ledger_summary,
         }
     }
+}
+
+fn format_ledger_context_window(events: &[LedgerEvent]) -> (Vec<String>, ContextWindowSummary) {
+    let total_events = events.len();
+    let start = total_events.saturating_sub(MAX_LEDGER_CONTEXT_EVENTS);
+    let included = &events[start..];
+    let ledger_summary = included
+        .iter()
+        .map(|event| format!("{:?}", event.kind))
+        .collect::<Vec<_>>();
+    let first_included_event = ledger_summary.first().cloned();
+    let last_included_event = ledger_summary.last().cloned();
+    (
+        ledger_summary,
+        ContextWindowSummary {
+            total_events,
+            included_events: included.len(),
+            omitted_events: start,
+            max_events: MAX_LEDGER_CONTEXT_EVENTS,
+            first_included_event,
+            last_included_event,
+        },
+    )
 }
 
 fn format_mode_policy_summary(payload: &serde_json::Value) -> String {
@@ -230,6 +275,24 @@ fn format_tool_execution_summary(events: &[LedgerEvent]) -> Vec<String> {
         .collect()
 }
 
+fn format_context_window_summary(summary: &ContextWindowSummary) -> String {
+    format!(
+        "total_events: {}\nincluded_events: {}\nomitted_events: {}\nmax_events: {}\nfirst_included_event: {}\nlast_included_event: {}",
+        summary.total_events,
+        summary.included_events,
+        summary.omitted_events,
+        summary.max_events,
+        summary
+            .first_included_event
+            .as_deref()
+            .unwrap_or("<none>"),
+        summary
+            .last_included_event
+            .as_deref()
+            .unwrap_or("<none>")
+    )
+}
+
 pub struct PromptBuilder;
 
 impl PromptBuilder {
@@ -281,6 +344,7 @@ impl PromptBuilder {
                 .collect::<Vec<_>>()
                 .join("\n")
         };
+        let context_window = format_context_window_summary(&input.context_window);
 
         let ledger = if input.ledger_summary.is_empty() {
             "- <empty>".to_string()
@@ -302,8 +366,8 @@ impl PromptBuilder {
                 PromptMessage {
                     role: PromptRole::User,
                     content: format!(
-                        "Task ID: {}\nRun ID: {}\nMode ID: {}\n{}\n\nPermission Checks:\n{}\n\nTool Plan:\n{}\n\nAssistant Tool Intent:\n{}\n\nTool Execution:\n{}\n\nGoal:\n{}\n\nLedger:\n{}",
-                        input.task_id, input.run_id, mode_id, mode_policy_summary, permission_checks, tool_plan, tool_intent, tool_execution, input.goal, ledger
+                        "Task ID: {}\nRun ID: {}\nMode ID: {}\n{}\n\nPermission Checks:\n{}\n\nTool Plan:\n{}\n\nAssistant Tool Intent:\n{}\n\nTool Execution:\n{}\n\nContext Window:\n{}\n\nGoal:\n{}\n\nLedger:\n{}",
+                        input.task_id, input.run_id, mode_id, mode_policy_summary, permission_checks, tool_plan, tool_intent, tool_execution, context_window, input.goal, ledger
                     ),
                 },
             ],
@@ -372,6 +436,14 @@ mod tests {
             tool_plan_summary: vec![],
             tool_intent_summary: vec![],
             tool_execution_summary: vec![],
+            context_window: ContextWindowSummary {
+                total_events: 2,
+                included_events: 2,
+                omitted_events: 0,
+                max_events: MAX_LEDGER_CONTEXT_EVENTS,
+                first_included_event: Some("TaskStarted".into()),
+                last_included_event: Some("TaskRunning".into()),
+            },
             ledger_summary: vec!["TaskStarted".into(), "TaskRunning".into()],
         });
 
@@ -404,10 +476,70 @@ mod tests {
         let materialized = ContextMaterializer::materialize(input);
         assert_eq!(materialized.goal, "Ship Phase 1.2");
         assert_eq!(materialized.ledger_summary, vec!["TaskStarted"]);
+        assert_eq!(materialized.context_window.total_events, 1);
+        assert_eq!(materialized.context_window.included_events, 1);
+        assert_eq!(materialized.context_window.omitted_events, 0);
         assert_eq!(
             materialized.mode_policy_summary,
             Some("Mode Policy:\n<unresolved>".into())
         );
+    }
+
+    #[test]
+    fn context_materializer_bounds_ledger_summary_to_recent_events() {
+        let kinds = [
+            LedgerEventKind::TaskStarted,
+            LedgerEventKind::ModeResolved,
+            LedgerEventKind::PermissionChecked,
+            LedgerEventKind::ToolPlanned,
+            LedgerEventKind::ToolPermissionChecked,
+            LedgerEventKind::ToolPlanApproved,
+            LedgerEventKind::AgentLoopStarted,
+            LedgerEventKind::PromptBuilt,
+            LedgerEventKind::LlmRequestCreated,
+            LedgerEventKind::LlmResponseReceived,
+            LedgerEventKind::ToolIntentParsed,
+            LedgerEventKind::ToolIntentPermissionChecked,
+            LedgerEventKind::ToolExecutionRequested,
+            LedgerEventKind::ToolExecutionCompleted,
+            LedgerEventKind::TaskCompleted,
+        ];
+        let input = ContextMaterializerInput {
+            task: task_record(),
+            ledger_events: kinds
+                .iter()
+                .enumerate()
+                .map(|(index, kind)| LedgerEvent {
+                    event_id: format!("event_{index}"),
+                    task_id: "task_1".into(),
+                    run_id: "run_1".into(),
+                    kind: kind.clone(),
+                    timestamp: "2026-01-01T00:00:00Z".into(),
+                    payload: None,
+                })
+                .collect(),
+        };
+
+        let materialized = ContextMaterializer::materialize(input);
+        assert_eq!(materialized.context_window.total_events, kinds.len());
+        assert_eq!(
+            materialized.context_window.included_events,
+            MAX_LEDGER_CONTEXT_EVENTS
+        );
+        assert_eq!(materialized.context_window.omitted_events, 3);
+        assert_eq!(materialized.ledger_summary.len(), MAX_LEDGER_CONTEXT_EVENTS);
+        assert_eq!(materialized.ledger_summary.first().unwrap(), "ToolPlanned");
+        assert_eq!(materialized.ledger_summary.last().unwrap(), "TaskCompleted");
+        assert!(!materialized
+            .ledger_summary
+            .contains(&"TaskStarted".to_string()));
+
+        let prompt = PromptBuilder::build(materialized);
+        assert!(prompt.messages[1].content.contains("Context Window:"));
+        assert!(prompt.messages[1].content.contains("omitted_events: 3"));
+        assert!(prompt.messages[1]
+            .content
+            .contains("first_included_event: ToolPlanned"));
     }
 
     #[test]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -7,7 +7,7 @@ use brownie_agentmodes::{
 use brownie_config::{
     BrownieConfig, LlmProfile, LlmRequestBudgetConfig, RuntimeConfigLoader, CONFIG_RELATIVE_PATH,
 };
-use brownie_context::{ContextMaterializer, ContextMaterializerInput};
+use brownie_context::{ContextMaterializer, ContextMaterializerInput, ContextWindowSummary};
 use brownie_llm::{
     redact_secret, scan_prompt_for_sensitive_content, validate_llm_request_budget, FakeLlmProvider,
     LlmMessage, LlmProvider, LlmProviderKind, LlmProviderStatus, LlmRequestBudget,
@@ -1776,6 +1776,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         task: running.clone(),
         ledger_events,
     });
+    let prompt_context_window = prompt_input.context_window.clone();
     let provider = match llm_provider_from_workspace_for_task_run(store.workspace_root()) {
         Ok(provider) => provider,
         Err(error) => {
@@ -1861,6 +1862,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             provider_selection.budget.response_preview_chars,
             provider_selection.budget.max_prompt_chars,
             &result.sensitive_scan,
+            &prompt_context_window,
         )),
     ) {
         return error_response(id, -32603, &format!("internal error: {error}"));
@@ -1913,6 +1915,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
             task: running.clone(),
             ledger_events: second_pass_events,
         });
+        let second_pass_context_window = second_pass_prompt_input.context_window.clone();
         let second_pass = match AgentLoop::run_second_pass_with_llm(
             second_pass_prompt_input,
             provider.as_ref(),
@@ -1962,6 +1965,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                 provider_selection.budget.response_preview_chars,
                 provider_selection.budget.max_prompt_chars,
                 &second_pass.sensitive_scan,
+                &second_pass_context_window,
             )),
         ) {
             return error_response(id, -32603, &format!("internal error: {error}"));
@@ -9972,10 +9976,37 @@ fn prompt_built_payload(
     response_preview_chars: usize,
     max_prompt_chars: usize,
     sensitive_scan: &PromptSensitiveScanResult,
+    context_window: &ContextWindowSummary,
 ) -> Value {
     let mut payload = serde_json::Map::new();
     payload.insert("message_count".to_string(), json!(message_count));
     payload.insert("max_prompt_chars".to_string(), json!(max_prompt_chars));
+    payload.insert(
+        "context_total_events".to_string(),
+        json!(context_window.total_events),
+    );
+    payload.insert(
+        "context_included_events".to_string(),
+        json!(context_window.included_events),
+    );
+    payload.insert(
+        "context_omitted_events".to_string(),
+        json!(context_window.omitted_events),
+    );
+    payload.insert(
+        "context_max_events".to_string(),
+        json!(context_window.max_events),
+    );
+    payload.insert(
+        "context_window_bounded".to_string(),
+        json!(context_window.omitted_events > 0),
+    );
+    if let Some(first) = context_window.first_included_event.as_deref() {
+        payload.insert("context_first_included_event".to_string(), json!(first));
+    }
+    if let Some(last) = context_window.last_included_event.as_deref() {
+        payload.insert("context_last_included_event".to_string(), json!(last));
+    }
     if sensitive_scan.findings.is_empty() {
         payload.insert(
             "prompt_preview".to_string(),
@@ -10050,6 +10081,7 @@ fn error_response(id: Value, code: i64, message: &str) -> JsonRpcResponse<Value>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use brownie_context::MAX_LEDGER_CONTEXT_EVENTS;
     use brownie_protocol::{TaskRecord, TaskStatus};
     use std::sync::Mutex;
 
@@ -10200,6 +10232,31 @@ mod tests {
         assert!(events
             .iter()
             .any(|event| event.kind == LedgerEventKind::SecondPassPromptBuilt));
+        let second_prompt = events
+            .iter()
+            .find(|event| event.kind == LedgerEventKind::SecondPassPromptBuilt)
+            .expect("second pass prompt");
+        let second_prompt_payload = second_prompt.payload.as_ref().expect("prompt payload");
+        assert!(
+            second_prompt_payload["context_total_events"]
+                .as_u64()
+                .expect("context total")
+                > 0
+        );
+        assert_eq!(
+            second_prompt_payload["context_max_events"].as_u64(),
+            Some(MAX_LEDGER_CONTEXT_EVENTS as u64)
+        );
+        assert!(
+            second_prompt_payload["context_included_events"]
+                .as_u64()
+                .expect("context included")
+                <= MAX_LEDGER_CONTEXT_EVENTS as u64
+        );
+        assert_eq!(
+            second_prompt_payload["context_last_included_event"],
+            "LlmResponseReceived"
+        );
         assert!(events
             .iter()
             .any(|event| event.kind == LedgerEventKind::SecondPassLlmRequestCreated));

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -218,6 +218,14 @@ Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` afte
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
 
+## M4 bounded task context window
+
+M4 strengthens the existing `task.run` prompt materialization path without adding a new endpoint. The runtime-owned `ContextMaterializer` now assembles a deterministic bounded ledger context window for prompts. The prompt `Ledger` section includes only the latest 12 ledger event kinds, while a `Context Window` section records `total_events`, `included_events`, `omitted_events`, `max_events`, `first_included_event`, and `last_included_event`.
+
+`PromptBuilt` and `SecondPassPromptBuilt` ledger payloads persist the same summary-only context evidence as `context_total_events`, `context_included_events`, `context_omitted_events`, `context_max_events`, `context_window_bounded`, `context_first_included_event`, and `context_last_included_event`. These fields let callers and future agent-loop stages reason about bounded context reuse without exposing raw prompt text when sensitive guards redact previews.
+
+M4 does not add patch apply, direct workspace mutation, unrestricted process execution, network fetch, service-control, destructive actions, or new diagnostics wrapper RPCs. It only changes how existing task/run context is selected, summarized, and recorded.
+
 ## Phase 1.10 run inspection methods
 
 The runtime exposes read-only `run.events`, `run.inspect`, and `task.inspect` JSON-RPC methods. They return sanitized ledger previews and run summaries only; full file content and raw tool output are not returned through inspection responses. Unknown run or task IDs return `-32602 invalid params`.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -141,6 +141,14 @@ Phase 1.9 introduces a second-pass Fake LLM feedback loop inside `task.run` afte
 
 The second pass runs only when at least one `ToolExecutionCompleted` event exists. `workspace.read` results are summarized into prompt materialization as metadata such as status, `bytes_read`, and `truncated`; full file content is not persisted in the ledger. Phase 1.9 does not add write, process, network, service-control, destructive, or subtask execution, and it continues to use only the in-process Fake LLM.
 
+## M4 bounded task context window
+
+M4 keeps `task.run` as the runtime-owned context assembly path and bounds the ledger context materialized into prompts. Prompt materialization now includes a `Context Window` summary and limits the prompt `Ledger` section to the latest 12 ledger event kinds. Older events are counted as omitted instead of being copied into the prompt.
+
+`PromptBuilt` and `SecondPassPromptBuilt` ledger events record summary-only context evidence: total, included, omitted, and maximum event counts plus first/last included event kinds. This makes context selection deterministic and inspectable for future autonomous runs without persisting raw prompt text, raw file content, raw tool output, or raw provider responses.
+
+M4 does not add patch apply, direct workspace mutation, process execution, network access, service-control, destructive actions, or diagnostics wrapper capability.
+
 ## M1 agent-loop runtime summary
 
 M1 keeps `task.run` as the runtime-owned execution path and exposes the agent-loop transition directly. The runtime records `AgentLoopStarted` before invoking the Rust `brownie-agent-loop` path and records `AgentLoopCompleted` before the terminal task status update. The `task.run` result includes `agent_loop.final_state` and `agent_loop.completion_summary`, so callers can distinguish a completed agent-loop execution from a bare task status update.


### PR DESCRIPTION
## Summary

- `ContextMaterializer` が ledger 全件を prompt に入れるのではなく、最新 12 件の deterministic context window を組み立てるようにしました。
- prompt に `Context Window` summary を追加し、`PromptBuilt` / `SecondPassPromptBuilt` ledger payload に `context_total_events`、`context_included_events`、`context_omitted_events`、`context_window_bounded` などの summary-only context evidence を記録します。
- second-pass prompt でも同じ context evidence を使うため、task/run context が bounded かつ runtime-visible に追跡できます。
- patch apply、direct workspace mutation、unrestricted process exec、network fetch、service-control、diagnostics wrapper RPC は追加していません。

## Checks

- `pnpm guard:diagnostics`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`

## Phase value

- strategic_capability: `context_management`
- phase: `M4`
- capability gain: task prompt materialization now uses bounded, deterministic runtime-owned context selection and persists machine-readable context evidence for future autonomous loops.
- boundary: no patch apply, no direct workspace mutation, no unrestricted process exec, no network fetch, no service-control capability added.