### PR TITLE
M5.12: admit queued child task runs

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -104,8 +104,8 @@ use brownie_protocol::{
     ProposalReviewVerdictResult, RunEventsParams, RunEventsResult, RunInspectParams,
     RunInspectResult, RunInspectSummary, RuntimeActionName, RuntimeConfigGetResult,
     RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState, RuntimeStatus, TaskGetParams,
-    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRunAgentLoopSummary, TaskRunParams,
-    TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
+    TaskInspectParams, TaskInspectResult, TaskListResult, TaskRecord, TaskRunAgentLoopSummary,
+    TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams,
     ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary,
     ToolIntentParseParams, ToolIntentParseResult, ToolIntentParserConfigSummary,
     ToolIntentParserSummary, ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary,
@@ -1744,8 +1744,15 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
 
-    if record.status != TaskStatus::Created {
-        return error_response(id, -32602, "invalid params: task must be Created");
+    if let Err(rejection) = validate_explicit_queued_child_task_run_admission(&record, &store) {
+        return match rejection {
+            TaskRunAdmissionRejection::InvalidParams(message) => {
+                error_response(id, -32602, message)
+            }
+            TaskRunAdmissionRejection::Internal(message) => {
+                error_response(id, -32603, &format!("internal error: {message}"))
+            }
+        };
     }
 
     let running = match store.tasks().update_task_status(
@@ -2115,6 +2122,93 @@ fn append_sensitive_scan_event(
             "message_indexes": message_indexes,
         })),
     )
+}
+
+enum TaskRunAdmissionRejection {
+    InvalidParams(&'static str),
+    Internal(String),
+}
+
+fn validate_explicit_queued_child_task_run_admission(
+    record: &TaskRecord,
+    store: &BrownieStore,
+) -> Result<(), TaskRunAdmissionRejection> {
+    match record.status {
+        TaskStatus::Created => Ok(()),
+        TaskStatus::Queued => validate_controlled_queued_child_task_provenance(record, store),
+        TaskStatus::Running
+        | TaskStatus::Completed
+        | TaskStatus::Failed
+        | TaskStatus::Cancelled => Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: task must be Created or a controlled Queued child task",
+        )),
+    }
+}
+
+fn validate_controlled_queued_child_task_provenance(
+    record: &TaskRecord,
+    store: &BrownieStore,
+) -> Result<(), TaskRunAdmissionRejection> {
+    let parent_task_id = required_task_run_provenance(record.parent_task_id.as_deref())?;
+    let parent_run_id = required_task_run_provenance(record.parent_run_id.as_deref())?;
+    let source_candidate_id = required_task_run_provenance(record.source_candidate_id.as_deref())?;
+    let source_handoff_envelope_id =
+        required_task_run_provenance(record.source_handoff_envelope_id.as_deref())?;
+    let source_handoff_envelope_fingerprint =
+        required_task_run_provenance(record.source_handoff_envelope_fingerprint.as_deref())?;
+
+    let parent = store
+        .tasks()
+        .get_task(parent_task_id)
+        .map_err(|error| TaskRunAdmissionRejection::Internal(error.to_string()))?
+        .ok_or(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: queued child task parent provenance is invalid",
+        ))?;
+    if parent.run_id != parent_run_id {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: queued child task parent provenance is invalid",
+        ));
+    }
+
+    let parent_events = store
+        .tasks()
+        .read_ledger_events(parent_run_id)
+        .map_err(|error| TaskRunAdmissionRejection::Internal(error.to_string()))?;
+    let covered_by_handoff_envelope = parent_events.iter().any(|event| {
+        if event.kind != LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded {
+            return false;
+        }
+        let Some(payload) = event.payload.as_ref() else {
+            return false;
+        };
+        payload.get("handoff_envelope_id").and_then(Value::as_str)
+            == Some(source_handoff_envelope_id)
+            && payload
+                .get("handoff_envelope_fingerprint")
+                .and_then(Value::as_str)
+                == Some(source_handoff_envelope_fingerprint)
+            && (payload_string_array(payload, "candidate_ids")
+                .iter()
+                .any(|candidate| candidate == source_candidate_id)
+                || payload_string_array(payload, "blocked_candidate_ids")
+                    .iter()
+                    .any(|candidate| candidate == source_candidate_id))
+    });
+    if !covered_by_handoff_envelope {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: queued child task source provenance is invalid",
+        ));
+    }
+
+    Ok(())
+}
+
+fn required_task_run_provenance(value: Option<&str>) -> Result<&str, TaskRunAdmissionRejection> {
+    value
+        .filter(|value| !value.trim().is_empty())
+        .ok_or(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: queued child task must include complete parent/source provenance",
+        ))
 }
 
 fn fail_llm_request(
@@ -13568,6 +13662,202 @@ mod tests {
                 LedgerEventKind::TaskCompleted,
             ]
         );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    fn start_parent_with_queued_child() -> (String, String, TaskRecord, usize) {
+        let start = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"task.start","params":{"goal":"Run parent orchestrator","mode_id":"orchestrator"}}"#,
+        );
+        let start_result = start.result.expect("start result");
+        let parent_task_id = start_result["task_id"]
+            .as_str()
+            .expect("parent task id")
+            .to_string();
+        let parent_run_id = start_result["run_id"]
+            .as_str()
+            .expect("parent run id")
+            .to_string();
+
+        let parent_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(parent_run.error.is_none());
+        assert_eq!(
+            parent_run.result.expect("parent run result")["status"],
+            "Completed"
+        );
+
+        let store = BrownieStore::from_env_or_cwd().expect("store");
+        let all_tasks = store.tasks().list_tasks().expect("list tasks");
+        let child = all_tasks
+            .into_iter()
+            .find(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+            .expect("queued child task");
+        assert_eq!(child.status, TaskStatus::Queued);
+        let parent_event_count = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent ledger")
+            .len();
+
+        (parent_task_id, parent_run_id, child, parent_event_count)
+    }
+
+    #[test]
+    fn task_run_accepts_valid_queued_child_task_with_provenance() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+        let child_result = child_run.result.expect("child run result");
+        assert_eq!(child_result["task_id"], child.task_id);
+        assert_eq!(child_result["run_id"], child.run_id);
+        assert_eq!(child_result["status"], "Completed");
+
+        let store = BrownieStore::new(temp.path());
+        let completed_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get child")
+            .expect("child record");
+        assert_eq!(completed_child.status, TaskStatus::Completed);
+        assert_eq!(
+            completed_child.parent_task_id.as_deref(),
+            Some(parent_task_id.as_str())
+        );
+        assert_eq!(
+            completed_child.parent_run_id.as_deref(),
+            Some(parent_run_id.as_str())
+        );
+        assert_eq!(
+            completed_child.source_candidate_id.as_deref(),
+            child.source_candidate_id.as_deref()
+        );
+        assert_eq!(
+            completed_child
+                .source_handoff_envelope_fingerprint
+                .as_deref(),
+            child.source_handoff_envelope_fingerprint.as_deref()
+        );
+
+        let child_events = store
+            .tasks()
+            .read_ledger_events(&child.run_id)
+            .expect("child ledger");
+        assert!(child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+        assert!(child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::AgentLoopStarted));
+        assert!(child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskCompleted));
+
+        assert_eq!(
+            store
+                .tasks()
+                .read_ledger_events(&parent_run_id)
+                .expect("parent ledger after child run")
+                .len(),
+            parent_event_count
+        );
+
+        let parent_inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"run.inspect","params":{{"run_id":"{parent_run_id}"}}}}"#
+        ));
+        let parent_summary = parent_inspect.result.expect("parent inspect")["run"].clone();
+        assert_eq!(parent_summary["child_task_count"], 1);
+        assert!(parent_summary["child_task_ids"]
+            .as_array()
+            .expect("child ids")
+            .iter()
+            .any(|value| value.as_str() == Some(child.task_id.as_str())));
+
+        let child_inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.inspect","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        let inspected_child = child_inspect.result.expect("child inspect")["task"].clone();
+        assert_eq!(inspected_child["status"], "Completed");
+        assert_eq!(inspected_child["parent_task_id"], parent_task_id);
+        assert_eq!(inspected_child["parent_run_id"], parent_run_id);
+        assert_eq!(
+            inspected_child["source_handoff_envelope_fingerprint"],
+            child
+                .source_handoff_envelope_fingerprint
+                .as_deref()
+                .expect("source handoff envelope fingerprint")
+        );
+
+        let rerun = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":6,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(rerun.result.is_none());
+        assert_eq!(rerun.error.expect("rerun error").code, -32602);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_rejects_queued_child_task_without_complete_provenance() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent_task_id, _parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+        let child_state_path = temp
+            .path()
+            .join(".brownie/runs")
+            .join(&child.run_id)
+            .join("state.json");
+        let mut child_state: Value =
+            serde_json::from_str(&std::fs::read_to_string(&child_state_path).expect("child state"))
+                .expect("child state json");
+        child_state["source_handoff_envelope_fingerprint"] = Value::Null;
+        std::fs::write(
+            &child_state_path,
+            serde_json::to_string_pretty(&child_state).expect("child state serialize"),
+        )
+        .expect("write child state");
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.result.is_none());
+        let error = child_run.error.expect("child run error");
+        assert_eq!(error.code, -32602);
+        assert!(error
+            .message
+            .contains("queued child task must include complete parent/source provenance"));
+
+        let store = BrownieStore::new(temp.path());
+        let rejected_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get child")
+            .expect("child record");
+        assert_eq!(rejected_child.status, TaskStatus::Queued);
+        let child_events = store
+            .tasks()
+            .read_ledger_events(&child.run_id)
+            .expect("child ledger");
+        assert!(!child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/docs/architecture/phase-value-manifest.m5.12.json
+++ b/docs/architecture/phase-value-manifest.m5.12.json
@@ -1,0 +1,81 @@
+{
+  "phase": "M5.12",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "explicit_queued_child_task_run_admission",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_without_child_task_run_admission",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Turns a materialized Queued child TaskRecord into an explicitly runnable runtime entity through task.run."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Reuses the existing Rust-owned task.run lifecycle, prompt materialization, ledger events, and completion status transitions for child tasks."
+    },
+    {
+      "capability": "runtime_permission_enforcement",
+      "relationship": "Admits queued children only when complete parent/source provenance links them to an accepted parent handoff envelope."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "queued_child_admitted",
+        "prompt": "Does this phase allow an explicit task.run call to run a valid queued child task?"
+      },
+      {
+        "id": "provenance_validated",
+        "prompt": "Does admission require parent_task_id, parent_run_id, source candidate ID, and source handoff envelope fingerprint?"
+      },
+      {
+        "id": "parent_not_auto_dispatching",
+        "prompt": "Does the parent run keep child execution non-automatic?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler auto-dispatch, external workers, process exec expansion, network bypass, service control, patch apply, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "queued_child_admitted": "Yes. task.run accepts TaskStatus::Queued only for a controlled child TaskRecord and transitions it through the existing task-run lifecycle.",
+      "provenance_validated": "Yes. Admission validates non-empty parent/source fields, verifies the parent task/run relation, and requires parent handoff envelope evidence covering the child candidate and fingerprint.",
+      "parent_not_auto_dispatching": "Yes. Parent runs still only materialize the queued child; the child enters Running only through an explicit task.run call on the child task id.",
+      "safety_boundary": "Yes. The phase adds no scheduler auto-dispatch, external worker, patch apply, direct workspace mutation path, service control, network bypass, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "An explicit task.run on a valid Queued child TaskRecord is accepted.",
+    "The child TaskRecord transitions through Running to Completed using the existing Rust-owned task.run lifecycle.",
+    "Child TaskRecord stores and retains parent_task_id and parent_run_id.",
+    "Child TaskRecord stores and retains source candidate ID and source handoff envelope fingerprint.",
+    "Queued child admission rejects incomplete parent/source provenance.",
+    "Completed, Failed, Cancelled, and Running tasks remain non-rerunnable.",
+    "Parent task.run does not auto-run child tasks.",
+    "run.inspect exposes parent child_task_count and child_task_ids, and task.inspect exposes child status and provenance.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, or direct workspace mutation path is added."
+  ],
+  "source_evidence": {
+    "rust_store_tokens": [
+      "pub fn start_child_task",
+      "pub fn find_child_task_by_handoff_fingerprint",
+      "source_handoff_envelope_fingerprint",
+      "TaskStatus::Queued"
+    ],
+    "rust_runtime_tokens": [
+      "validate_explicit_queued_child_task_run_admission",
+      "validate_controlled_queued_child_task_provenance",
+      "TaskStatus::Queued",
+      "TaskStatus::Created",
+      "task_run_accepts_valid_queued_child_task_with_provenance",
+      "task_run_rejects_queued_child_task_without_complete_provenance"
+    ],
+    "vsix_protocol_tokens": [
+      "child_task_count",
+      "child_task_ids",
+      "source_handoff_envelope_fingerprint",
+      "'Queued'"
+    ]
+  }
+}

--- a/docs/specifications/run-inspection-spec-v0.md
+++ b/docs/specifications/run-inspection-spec-v0.md
@@ -91,6 +91,12 @@ Run inspection also reports dispatch handoff envelope evidence. `has_subtask_dis
 
 Run inspection reports controlled child materialization with `child_task_count` and `child_task_ids`. These fields are derived from persisted child `TaskRecord` state whose `parent_run_id` matches the inspected run. They expose parent-child relation evidence only; a child listed here is `Queued` and has not executed an LLM loop or scheduler handoff in M5.11.
 
+## M5.12 queued child run inspection
+
+After M5.12, a child listed by parent `run.inspect` may still be `Queued`, or it may have entered the existing child `task.run` lifecycle through an explicit call on the child task id. Reviewers can use the listed `child_task_ids` with `task.inspect` to observe the child status and provenance fields: `parent_task_id`, `parent_run_id`, `source_candidate_id`, `source_handoff_envelope_id`, and `source_handoff_envelope_fingerprint`.
+
+M5.12 does not add scheduler auto-dispatch. Parent run inspection proves relation only; child execution evidence belongs to the child task/run ledger and appears only after explicit `task.run` admission for that child.
+
 ## Phase 2.1 LLM metadata redaction
 
 Run inspection may show LLM provider metadata and `LlmRequestFailed` / `SecondPassLlmRequestFailed` summaries, but all secret-bearing values must be redacted. API keys, Authorization headers, Bearer tokens, and URL query strings are not inspection data. `BROWNIE_LLM_STRICT` and fallback-to-Fake status are observable through `llm.status`; request ledger metadata may include redacted `base_url` and `strict` so users can verify which configured provider path was used.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -786,3 +786,11 @@ M5.11 consumes an accepted `SubtaskDispatchHandoffEnvelopeRecorded` event inside
 The child run receives only a `TaskStarted` ledger event with `status = "Queued"`, parent/source provenance, `execution_enabled = false`, `scheduler_handoff_enabled = false`, and a high-level reason. The runtime prevents duplicate child creation by checking existing child records for the same parent run and `source_handoff_envelope_fingerprint`.
 
 `run.inspect` / `task.inspect` expose `child_task_count` and `child_task_ids` for parent runs. M5.11 does not run the child LLM loop, execute process commands, access the network, control services, apply patches, write workspace files, perform scheduler handoff, or persist raw `input`, raw provider responses, raw prompts, raw file content, command strings, stdout, stderr, environment values, or serialized request bodies.
+
+## M5.12 explicit queued child task run admission
+
+M5.12 admits a materialized child `TaskRecord` with status `Queued` through the existing `task.run` method only when the child has complete controlled provenance. Admission requires non-empty `parent_task_id`, `parent_run_id`, `source_candidate_id`, `source_handoff_envelope_id`, and `source_handoff_envelope_fingerprint`, verifies that the parent task owns the parent run, and verifies that the parent run has a `SubtaskDispatchHandoffEnvelopeRecorded` event covering the child candidate and handoff envelope fingerprint.
+
+After admission, the child uses the same Rust-owned `task.run` lifecycle as a normal `Created` task: it transitions to `Running`, records the existing permission/tool/prompt/LLM ledger sequence, and finishes with the existing terminal task status. `Completed`, `Failed`, `Cancelled`, and already `Running` tasks remain non-rerunnable.
+
+Parent runs still do not auto-run children. `run.inspect` exposes the parent-to-child relation with `child_task_count` and `child_task_ids`, and `task.inspect` on the child exposes the child status plus parent/source provenance. M5.12 does not add scheduler auto-dispatch, external workers, process execution expansion, network bypass, service control, patch apply, direct workspace mutation paths, or a new blocked summary event wrapper.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -285,3 +285,13 @@ The candidate manifest is visible through the ledger, through `run.inspect` / `t
 M5.10 turns candidate manifest evidence into deterministic parent-run dispatch handoff envelope and replay guard blocker state. After `SubtaskDispatchCandidateManifestRecorded` exists, `task.run` appends a summary-only `SubtaskDispatchHandoffEnvelopeRecorded` event that records which manifest was evaluated, which queued candidate ids are covered by the handoff envelope, why the replay guard remains blocked, and which handoff-ticket checks prevent scheduler dispatch.
 
 The handoff envelope is visible through the ledger, through `run.inspect` / `task.inspect` summary counts, and through prompt materialization. M5.10 does not create child tasks, hand off scheduler work, run subprocesses, access the network, control services, apply patches, or write workspace files.
+
+## M5.11 controlled child task materialization
+
+M5.11 materializes one controlled child `TaskRecord` from an accepted parent-run handoff envelope. The child stores `parent_task_id`, `parent_run_id`, `source_candidate_id`, `source_handoff_envelope_id`, and `source_handoff_envelope_fingerprint`, starts with `status = Queued`, and receives only its own `TaskStarted` ledger event. Parent `task.run` does not run the child.
+
+## M5.12 explicit queued child task run admission
+
+M5.12 allows an explicit `task.run` call on a controlled queued child task. The admission gate accepts `TaskStatus::Created` tasks as before, and accepts `TaskStatus::Queued` only when the child has complete parent/source provenance and the parent ledger contains matching handoff envelope evidence for the candidate and fingerprint.
+
+Once admitted, the child uses the existing task-run lifecycle and terminal status rules. Completed, failed, cancelled, and already-running tasks remain non-rerunnable. This phase does not add scheduler auto-dispatch, external workers, process execution expansion, network bypass, service control, patch apply, direct workspace mutation paths, or another blocked summary event wrapper.

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,6 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
+const phase = 'M5.12';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.12.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -37,54 +39,54 @@ function requireManifestValue(condition, message) {
 }
 
 function validateManifest(manifest) {
-  requireManifestValue(manifest.phase === 'M5.11', 'phase-value-manifest.m5.11.json must describe phase M5.11.');
-  requireManifestValue(manifest.target_capability === 'subtask_orchestration', 'M5.11 target_capability must be subtask_orchestration.');
+  requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
+  requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'minimal_controlled_child_task_materialization',
-    'M5.11 must declare the minimal controlled child task materialization transition.'
+    manifest.concrete_capability_transition === 'explicit_queued_child_task_run_admission',
+    `${phase} must declare the explicit queued child task run admission transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_child_task_materialization',
-    'M5.11 must forbid adding another blocked summary wrapper without child task materialization.'
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_child_task_run_admission',
+    `${phase} must forbid adding another blocked summary wrapper without child task run admission.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
     ? manifest.strategic_capability_mapping
     : [];
-  requireManifestValue(mappings.length > 0, 'M5.11 must include strategic_capability_mapping.');
+  requireManifestValue(mappings.length > 0, `${phase} must include strategic_capability_mapping.`);
   requireManifestValue(
     mappings.some((mapping) => mapping.capability === 'subtask_orchestration' && isNonEmptyString(mapping.relationship)),
-    'M5.11 strategic_capability_mapping must include subtask_orchestration.'
+    `${phase} strategic_capability_mapping must include subtask_orchestration.`
   );
 
   const valueGate = manifest.phase_value_gate ?? {};
   const questions = Array.isArray(valueGate.questions) ? valueGate.questions : [];
   const answers = valueGate.answers ?? {};
-  requireManifestValue(questions.length > 0, 'M5.11 phase_value_gate.questions must be non-empty.');
+  requireManifestValue(questions.length > 0, `${phase} phase_value_gate.questions must be non-empty.`);
   for (const question of questions) {
-    requireManifestValue(isNonEmptyString(question.id), 'Every M5.11 phase_value_gate question must include an id.');
+    requireManifestValue(isNonEmptyString(question.id), `Every ${phase} phase_value_gate question must include an id.`);
     if (isNonEmptyString(question.id)) {
       requireManifestValue(
         isNonEmptyString(answers[question.id]),
-        `M5.11 phase_value_gate.answers.${question.id} must be non-empty.`
+        `${phase} phase_value_gate.answers.${question.id} must be non-empty.`
       );
     }
   }
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'child TaskRecord',
+    'explicit task.run',
     'parent_task_id',
     'parent_run_id',
     'source candidate ID',
     'source handoff envelope fingerprint',
-    'duplicate',
     'Queued',
-    'run.inspect'
+    'Completed',
+    'task.inspect'
   ]) {
     requireManifestValue(
       exitCriteria.some((criterion) => typeof criterion === 'string' && criterion.includes(token)),
-      `M5.11 exit_criteria must mention ${token}.`
+      `${phase} exit_criteria must mention ${token}.`
     );
   }
 }
@@ -114,16 +116,17 @@ function validateSourceEvidence(manifest) {
     'SubtaskDispatchTicketRecorded',
     'SubtaskAdmissionTokenRecorded',
     'SubtaskSchedulerPacketRecorded',
-    'SubtaskHandoffReceiptRecorded'
+    'SubtaskHandoffReceiptRecorded',
+    'SubtaskChildRunAdmissionSummaryRecorded'
   ];
   for (const token of forbiddenWrapperEvents) {
     if (runtimeText.includes(token) || storeText.includes(token)) {
-      errors.push(`M5.11 must not add wrapper-only event ${token}.`);
+      errors.push(`${phase} must not add wrapper-only event ${token}.`);
     }
   }
 }
 
-const manifest = readJson('docs/architecture/phase-value-manifest.m5.11.json');
+const manifest = readJson(manifestPath);
 validateManifest(manifest);
 validateSourceEvidence(manifest);
 


### PR DESCRIPTION
## 概要

M5.12 は、M5.11 で materialize された `TaskStatus::Queued` の controlled child `TaskRecord` を、明示的な `task.run` 呼び出しで既存の Rust-owned task-run lifecycle に入れる phase です。

これは scheduler auto-dispatch ではありません。parent run は child を自動実行せず、child task id に対する明示 `task.run` のみが admission path になります。

## 実装内容

- `task.run` の admission gate を更新し、従来の `Created` task は既存通り許可
- `Queued` task は controlled child かつ完全な provenance がある場合のみ許可
- admission で `parent_task_id`, `parent_run_id`, `source_candidate_id`, `source_handoff_envelope_id`, `source_handoff_envelope_fingerprint` を検証
- parent task/run の一致と、parent ledger の `SubtaskDispatchHandoffEnvelopeRecorded` が candidate/fingerprint を cover していることを確認
- 完了済み / failed / cancelled / running task の rerun 拒否は維持
- M5.12 用 `phase-value-manifest.m5.12.json` と `guard-phase-value.mjs` 更新
- runtime / inspection / task runtime spec に M5.12 の能力境界を追記

## Safety boundary

維持しています。

```text
scheduler auto-dispatch: なし
external worker:         なし
process exec expansion:  なし
network bypass:          なし
service control:         なし
patch apply:             なし
direct workspace write:  なし
new blocked wrapper:     なし
```

## Checks

```text
pnpm guard:diagnostics
pnpm guard:phase-value
cargo fmt --check
cargo check --workspace
cargo test --workspace
pnpm install
pnpm --filter brownie-vsix check
pnpm --filter brownie-vsix test
pnpm --filter brownie-vsix build
```
