### PR TITLE
M5.13: expose child run summaries

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -2294,6 +2294,7 @@ pub struct RunInspectSummary {
     pub status: Option<TaskStatus>,
     pub child_task_count: usize,
     pub child_task_ids: Vec<String>,
+    pub child_tasks: Vec<ChildTaskInspectSummary>,
     pub event_count: usize,
     pub has_tool_execution_completed: bool,
     pub has_subtask_orchestration_queued: bool,
@@ -2321,6 +2322,23 @@ pub struct RunInspectSummary {
     pub has_second_pass: bool,
     pub final_response_preview: Option<String>,
     pub timeline: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ChildTaskInspectSummary {
+    pub task_id: String,
+    pub run_id: String,
+    pub status: TaskStatus,
+    pub parent_task_id: Option<String>,
+    pub parent_run_id: Option<String>,
+    pub source_candidate_id: Option<String>,
+    pub source_handoff_envelope_id: Option<String>,
+    pub source_handoff_envelope_fingerprint: Option<String>,
+    pub event_count: usize,
+    pub has_agent_loop_completed: bool,
+    pub completion_final_state: Option<String>,
+    pub completion_summary_preview: Option<String>,
+    pub final_response_preview: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -16,9 +16,9 @@ use brownie_llm::{
 };
 use brownie_modepack::load_workspace_modepack;
 use brownie_protocol::{
-    DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
-    LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
-    ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
+    ChildTaskInspectSummary, DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse,
+    LedgerEventSummary, LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult,
+    ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
     PermissionCheckResult, ProposalApplyCapabilityParams, ProposalApplyCapabilityResult,
     ProposalApplyDryRunHistoryParams, ProposalApplyDryRunHistoryResult, ProposalApplyDryRunParams,
     ProposalApplyDryRunResult, ProposalApproveParams, ProposalApproveResult,
@@ -306,6 +306,7 @@ const MAX_DIFF_PREVIEW_CHARS: usize = 20000;
 const MAX_DRY_RUN_HISTORY_ENTRIES: usize = 10;
 const MAX_PROPOSAL_AUDIT_TRAIL_ENTRIES: usize = 50;
 const MAX_PROPOSAL_REVIEW_REPORT_AUDIT_EVENTS: usize = 5;
+const CHILD_COMPLETION_SUMMARY_PREVIEW_CHARS: usize = 512;
 
 pub fn runtime_status() -> RuntimeStatus {
     RuntimeStatus {
@@ -9234,14 +9235,21 @@ fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, 
         .tasks()
         .get_task_by_run_id(run_id)
         .map_err(|error| format!("invalid params: {error}"))?;
-    let child_task_ids = store
+    let child_tasks = store
         .tasks()
         .list_tasks()
         .map_err(|error| format!("invalid params: {error}"))?
         .into_iter()
         .filter(|task| task.parent_run_id.as_deref() == Some(run_id))
-        .map(|task| task.task_id)
         .collect::<Vec<_>>();
+    let child_task_ids = child_tasks
+        .iter()
+        .map(|task| task.task_id.clone())
+        .collect::<Vec<_>>();
+    let child_task_summaries = child_tasks
+        .iter()
+        .map(|task| child_task_inspect_summary(store, task))
+        .collect::<Result<Vec<_>, _>>()?;
     let has_tool_execution_completed = events
         .iter()
         .any(|event| event.kind == LedgerEventKind::ToolExecutionCompleted);
@@ -9301,6 +9309,7 @@ fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, 
         status: task.as_ref().map(|task| task.status.clone()),
         child_task_count: child_task_ids.len(),
         child_task_ids,
+        child_tasks: child_task_summaries,
         event_count: events.len(),
         has_tool_execution_completed,
         has_subtask_orchestration_queued: subtask_queue_count > 0,
@@ -9328,6 +9337,56 @@ fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, 
         has_second_pass,
         final_response_preview,
         timeline: events.iter().map(timeline_entry).collect(),
+    })
+}
+
+fn child_task_inspect_summary(
+    store: &BrownieStore,
+    task: &TaskRecord,
+) -> Result<ChildTaskInspectSummary, String> {
+    let events = store
+        .tasks()
+        .read_ledger_events(&task.run_id)
+        .map_err(|error| format!("invalid params: {error}"))?;
+    let completion_event = events
+        .iter()
+        .rev()
+        .find(|event| event.kind == LedgerEventKind::AgentLoopCompleted);
+    let (completion_final_state, completion_summary_preview) = completion_event
+        .and_then(|event| event.payload.as_ref())
+        .map(|payload| {
+            (
+                payload
+                    .get("final_state")
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string),
+                payload
+                    .get("completion_summary")
+                    .and_then(Value::as_str)
+                    .map(|summary| {
+                        preview_with_limit(summary, CHILD_COMPLETION_SUMMARY_PREVIEW_CHARS)
+                    }),
+            )
+        })
+        .unwrap_or((None, None));
+    let final_response_preview =
+        latest_content_preview(&events, LedgerEventKind::SecondPassLlmResponseReceived)
+            .or_else(|| latest_content_preview(&events, LedgerEventKind::LlmResponseReceived));
+
+    Ok(ChildTaskInspectSummary {
+        task_id: task.task_id.clone(),
+        run_id: task.run_id.clone(),
+        status: task.status.clone(),
+        parent_task_id: task.parent_task_id.clone(),
+        parent_run_id: task.parent_run_id.clone(),
+        source_candidate_id: task.source_candidate_id.clone(),
+        source_handoff_envelope_id: task.source_handoff_envelope_id.clone(),
+        source_handoff_envelope_fingerprint: task.source_handoff_envelope_fingerprint.clone(),
+        event_count: events.len(),
+        has_agent_loop_completed: completion_event.is_some(),
+        completion_final_state,
+        completion_summary_preview,
+        final_response_preview,
     })
 }
 
@@ -12296,6 +12355,24 @@ mod tests {
                 .len(),
             1
         );
+        let child_tasks = summary["child_tasks"].as_array().expect("child tasks");
+        assert_eq!(child_tasks.len(), 1);
+        assert_eq!(child_tasks[0]["status"], "Queued");
+        assert_eq!(child_tasks[0]["event_count"], 1);
+        assert_eq!(child_tasks[0]["has_agent_loop_completed"], false);
+        assert_eq!(child_tasks[0]["completion_final_state"], Value::Null);
+        assert_eq!(child_tasks[0]["completion_summary_preview"], Value::Null);
+        assert_eq!(child_tasks[0]["final_response_preview"], Value::Null);
+        assert_eq!(child_tasks[0]["parent_task_id"], task_id);
+        assert_eq!(child_tasks[0]["parent_run_id"], run_id);
+        assert!(child_tasks[0]["source_candidate_id"]
+            .as_str()
+            .expect("source candidate id")
+            .starts_with("subtask_run_"));
+        assert!(child_tasks[0]["source_handoff_envelope_fingerprint"]
+            .as_str()
+            .expect("source handoff envelope fingerprint")
+            .starts_with("sha256:"));
         assert_eq!(summary["has_second_pass"], true);
         assert!(summary["final_response_preview"]
             .as_str()
@@ -13783,6 +13860,41 @@ mod tests {
             .expect("child ids")
             .iter()
             .any(|value| value.as_str() == Some(child.task_id.as_str())));
+        let parent_child_summaries = parent_summary["child_tasks"]
+            .as_array()
+            .expect("child summaries");
+        assert_eq!(parent_child_summaries.len(), 1);
+        let child_summary = &parent_child_summaries[0];
+        assert_eq!(child_summary["task_id"], child.task_id);
+        assert_eq!(child_summary["run_id"], child.run_id);
+        assert_eq!(child_summary["status"], "Completed");
+        assert_eq!(child_summary["parent_task_id"], parent_task_id);
+        assert_eq!(child_summary["parent_run_id"], parent_run_id);
+        assert_eq!(
+            child_summary["source_candidate_id"],
+            child
+                .source_candidate_id
+                .as_deref()
+                .expect("source candidate id")
+        );
+        assert_eq!(
+            child_summary["source_handoff_envelope_fingerprint"],
+            child
+                .source_handoff_envelope_fingerprint
+                .as_deref()
+                .expect("source handoff envelope fingerprint")
+        );
+        assert!(child_summary["event_count"].as_u64().expect("event count") > 1);
+        assert_eq!(child_summary["has_agent_loop_completed"], true);
+        assert_eq!(child_summary["completion_final_state"], "Completed");
+        assert!(child_summary["completion_summary_preview"]
+            .as_str()
+            .expect("completion summary preview")
+            .contains(&child.task_id));
+        assert!(child_summary["final_response_preview"]
+            .as_str()
+            .expect("final response preview")
+            .contains("Fake LLM"));
 
         let child_inspect = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":5,"method":"task.inspect","params":{{"task_id":"{}"}}}}"#,

--- a/docs/architecture/phase-value-manifest.m5.13.json
+++ b/docs/architecture/phase-value-manifest.m5.13.json
@@ -1,0 +1,74 @@
+{
+  "phase": "M5.13",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "parent_child_run_result_inspection",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_without_parent_child_result_inspection",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Turns parent child_task_ids into structured child task summaries with status, provenance, and sanitized result evidence."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Makes explicit child task-run lifecycle outcomes visible from parent inspection without adding a scheduler."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Lets a headless caller inspect parent-child progress and terminal child outcomes through runtime-owned state."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "parent_child_result_visible",
+        "prompt": "Does parent inspection expose structured child status/result summaries?"
+      },
+      {
+        "id": "sanitized_evidence_only",
+        "prompt": "Does the summary avoid raw child prompts, provider responses, file contents, command output, and serialized request bodies?"
+      },
+      {
+        "id": "no_auto_dispatch",
+        "prompt": "Does parent inspection remain observational without running child tasks?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler auto-dispatch, external workers, process exec expansion, network bypass, service control, patch apply, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "parent_child_result_visible": "Yes. RunInspectSummary includes child_tasks with child task id, run id, status, provenance, event count, completion state, and sanitized previews.",
+      "sanitized_evidence_only": "Yes. Child summaries derive only event counts, status/provenance, completion final state, completion summary preview, and existing sanitized response previews.",
+      "no_auto_dispatch": "Yes. Parent task.run still materializes child records only; child execution remains limited to explicit child task.run admission.",
+      "safety_boundary": "Yes. The phase adds no scheduler auto-dispatch, external worker, patch apply, direct workspace mutation path, service control, network bypass, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "Parent run.inspect exposes structured child task summaries through child_tasks, not only child_task_ids.",
+    "A Queued child appears as queued child_tasks evidence without executing.",
+    "After explicit child task.run, parent inspection shows child Completed status and sanitized completion evidence.",
+    "Child summaries retain parent_task_id, parent_run_id, source candidate ID, and source handoff envelope fingerprint.",
+    "Parent task.run does not auto-run child tasks.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_protocol_tokens": [
+      "pub struct ChildTaskInspectSummary",
+      "pub child_tasks: Vec<ChildTaskInspectSummary>"
+    ],
+    "rust_runtime_tokens": [
+      "child_task_inspect_summary",
+      "completion_summary_preview",
+      "task_run_accepts_valid_queued_child_task_with_provenance",
+      "child_tasks"
+    ],
+    "vsix_protocol_tokens": [
+      "ChildTaskInspectSummary",
+      "child_tasks",
+      "isChildTaskInspectSummary",
+      "completion_summary_preview"
+    ]
+  }
+}

--- a/docs/specifications/run-inspection-spec-v0.md
+++ b/docs/specifications/run-inspection-spec-v0.md
@@ -97,6 +97,14 @@ After M5.12, a child listed by parent `run.inspect` may still be `Queued`, or it
 
 M5.12 does not add scheduler auto-dispatch. Parent run inspection proves relation only; child execution evidence belongs to the child task/run ledger and appears only after explicit `task.run` admission for that child.
 
+## M5.13 parent child result summaries
+
+Parent run inspection now includes `child_tasks`, a structured summary list aligned with `child_task_ids`. Each item reports child identity, run id, status, parent/source provenance, child ledger event count, `has_agent_loop_completed`, `completion_final_state`, `completion_summary_preview`, and sanitized `final_response_preview` when available.
+
+Queued children appear with `status = "Queued"`, their child ledger event count, and no completion preview. After an explicit child `task.run`, parent inspection reflects the child terminal status and sanitized completion evidence without mutating the parent ledger or auto-running additional children.
+
+Child summaries are inspection data only. They must not include raw prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, or serialized request bodies.
+
 ## Phase 2.1 LLM metadata redaction
 
 Run inspection may show LLM provider metadata and `LlmRequestFailed` / `SecondPassLlmRequestFailed` summaries, but all secret-bearing values must be redacted. API keys, Authorization headers, Bearer tokens, and URL query strings are not inspection data. `BROWNIE_LLM_STRICT` and fallback-to-Fake status are observable through `llm.status`; request ledger metadata may include redacted `base_url` and `strict` so users can verify which configured provider path was used.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -794,3 +794,11 @@ M5.12 admits a materialized child `TaskRecord` with status `Queued` through the 
 After admission, the child uses the same Rust-owned `task.run` lifecycle as a normal `Created` task: it transitions to `Running`, records the existing permission/tool/prompt/LLM ledger sequence, and finishes with the existing terminal task status. `Completed`, `Failed`, `Cancelled`, and already `Running` tasks remain non-rerunnable.
 
 Parent runs still do not auto-run children. `run.inspect` exposes the parent-to-child relation with `child_task_count` and `child_task_ids`, and `task.inspect` on the child exposes the child status plus parent/source provenance. M5.12 does not add scheduler auto-dispatch, external workers, process execution expansion, network bypass, service control, patch apply, direct workspace mutation paths, or a new blocked summary event wrapper.
+
+## M5.13 parent child run result inspection
+
+M5.13 extends parent run inspection with structured `child_tasks` summaries while preserving `child_task_count` and `child_task_ids` for compatibility. Each child summary includes the child `task_id`, child `run_id`, status, parent/source provenance, child ledger event count, whether the child agent loop completed, completion final state, a bounded completion summary preview, and the existing sanitized final response preview when available.
+
+These summaries are derived from persisted child `TaskRecord` state and sanitized child ledger events. They do not persist or expose raw child prompts, raw provider responses, raw file contents, command strings, stdout, stderr, environment values, or serialized request bodies. Parent `task.run` still does not execute children; child execution remains limited to explicit `task.run` admission for the child task.
+
+M5.13 adds no scheduler auto-dispatch, external workers, process execution expansion, network bypass, service control, patch apply, direct workspace mutation paths, diagnostics wrapper RPCs, or blocked summary event wrappers.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -295,3 +295,9 @@ M5.11 materializes one controlled child `TaskRecord` from an accepted parent-run
 M5.12 allows an explicit `task.run` call on a controlled queued child task. The admission gate accepts `TaskStatus::Created` tasks as before, and accepts `TaskStatus::Queued` only when the child has complete parent/source provenance and the parent ledger contains matching handoff envelope evidence for the candidate and fingerprint.
 
 Once admitted, the child uses the existing task-run lifecycle and terminal status rules. Completed, failed, cancelled, and already-running tasks remain non-rerunnable. This phase does not add scheduler auto-dispatch, external workers, process execution expansion, network bypass, service control, patch apply, direct workspace mutation paths, or another blocked summary event wrapper.
+
+## M5.13 parent child run result inspection
+
+M5.13 makes child run state visible from the parent inspection path. `RunInspectSummary` keeps `child_task_count` and `child_task_ids`, and adds `child_tasks` with structured summaries for each persisted child whose `parent_run_id` matches the inspected parent run.
+
+Each child summary is derived from child `TaskRecord` state and child ledger metadata. It reports child status, provenance, event count, completion final state, bounded completion summary preview, and sanitized final response preview when available. It does not run child tasks, mutate the parent ledger, expose raw prompts/provider responses/file content/command output, or add scheduler handoff.

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -238,6 +238,7 @@ export interface RunInspectSummary {
   status?: TaskStatus | null;
   child_task_count: number;
   child_task_ids: string[];
+  child_tasks: ChildTaskInspectSummary[];
   event_count: number;
   has_tool_execution_completed: boolean;
   has_subtask_orchestration_queued: boolean;
@@ -265,6 +266,22 @@ export interface RunInspectSummary {
   has_second_pass: boolean;
   final_response_preview?: string | null;
   timeline: string[];
+}
+
+export interface ChildTaskInspectSummary {
+  task_id: string;
+  run_id: string;
+  status: TaskStatus;
+  parent_task_id?: string | null;
+  parent_run_id?: string | null;
+  source_candidate_id?: string | null;
+  source_handoff_envelope_id?: string | null;
+  source_handoff_envelope_fingerprint?: string | null;
+  event_count: number;
+  has_agent_loop_completed: boolean;
+  completion_final_state?: string | null;
+  completion_summary_preview?: string | null;
+  final_response_preview?: string | null;
 }
 
 export interface RunEventsResult {
@@ -2553,6 +2570,25 @@ export function isRunEventsResult(value: unknown): value is RunEventsResult {
   return isRecord(value) && typeof value.run_id === 'string' && Array.isArray(value.events) && value.events.every(isLedgerEventSummary);
 }
 
+export function isChildTaskInspectSummary(value: unknown): value is ChildTaskInspectSummary {
+  return (
+    isRecord(value) &&
+    typeof value.task_id === 'string' &&
+    typeof value.run_id === 'string' &&
+    isTaskStatus(value.status) &&
+    (value.parent_task_id === undefined || value.parent_task_id === null || typeof value.parent_task_id === 'string') &&
+    (value.parent_run_id === undefined || value.parent_run_id === null || typeof value.parent_run_id === 'string') &&
+    (value.source_candidate_id === undefined || value.source_candidate_id === null || typeof value.source_candidate_id === 'string') &&
+    (value.source_handoff_envelope_id === undefined || value.source_handoff_envelope_id === null || typeof value.source_handoff_envelope_id === 'string') &&
+    (value.source_handoff_envelope_fingerprint === undefined || value.source_handoff_envelope_fingerprint === null || typeof value.source_handoff_envelope_fingerprint === 'string') &&
+    isNonNegativeInteger(value.event_count) &&
+    typeof value.has_agent_loop_completed === 'boolean' &&
+    (value.completion_final_state === undefined || value.completion_final_state === null || typeof value.completion_final_state === 'string') &&
+    (value.completion_summary_preview === undefined || value.completion_summary_preview === null || typeof value.completion_summary_preview === 'string') &&
+    (value.final_response_preview === undefined || value.final_response_preview === null || typeof value.final_response_preview === 'string')
+  );
+}
+
 export function isRunInspectSummary(value: unknown): value is RunInspectSummary {
   return (
     isRecord(value) &&
@@ -2562,6 +2598,8 @@ export function isRunInspectSummary(value: unknown): value is RunInspectSummary 
     isNonNegativeInteger(value.child_task_count) &&
     Array.isArray(value.child_task_ids) &&
     value.child_task_ids.every((taskId) => typeof taskId === 'string') &&
+    Array.isArray(value.child_tasks) &&
+    value.child_tasks.every(isChildTaskInspectSummary) &&
     typeof value.event_count === 'number' &&
     Number.isInteger(value.event_count) &&
     value.event_count >= 0 &&

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -166,6 +166,21 @@ describe('protocol validation', () => {
       status: 'Completed',
       child_task_count: 1,
       child_task_ids: ['task_child_1'],
+      child_tasks: [{
+        task_id: 'task_child_1',
+        run_id: 'run_child_1',
+        status: 'Completed',
+        parent_task_id: 'task_1',
+        parent_run_id: 'run_1',
+        source_candidate_id: 'subtask_1',
+        source_handoff_envelope_id: 'handoff_1',
+        source_handoff_envelope_fingerprint: 'sha256:child',
+        event_count: 8,
+        has_agent_loop_completed: true,
+        completion_final_state: 'Completed',
+        completion_summary_preview: 'completed child',
+        final_response_preview: 'done',
+      }],
       event_count: 3,
       has_tool_execution_completed: true,
       has_subtask_orchestration_queued: true,
@@ -198,6 +213,9 @@ describe('protocol validation', () => {
     expect(isRunInspectSummary({ ...summary, has_second_pass: 'true' })).toBe(false);
     expect(isRunInspectSummary({ ...summary, child_task_count: -1 })).toBe(false);
     expect(isRunInspectSummary({ ...summary, child_task_ids: ['task_child_1', 2] })).toBe(false);
+    expect(isRunInspectSummary({ ...summary, child_tasks: [] })).toBe(true);
+    expect(isRunInspectSummary({ ...summary, child_tasks: [{ ...summary.child_tasks[0], status: 'Nope' }] })).toBe(false);
+    expect(isRunInspectSummary({ ...summary, child_tasks: [{ ...summary.child_tasks[0], event_count: -1 }] })).toBe(false);
     expect(isRunInspectSummary({ ...summary, event_count: -1 })).toBe(false);
     expect(isRunInspectSummary({ ...summary, subtask_handoff_count: -1 })).toBe(false);
     expect(isRunInspectSummary({ ...summary, subtask_scheduler_readiness_count: -1 })).toBe(false);
@@ -638,7 +656,7 @@ describe('RuntimeClient', () => {
   it('creates a task.inspect request', async () => {
     const result = {
       task: { ...taskRecord, status: 'Completed' },
-      run: { run_id: 'run_1', task_id: 'task_1', status: 'Completed', child_task_count: 1, child_task_ids: ['task_child_1'], event_count: 2, has_tool_execution_completed: true, has_subtask_orchestration_queued: true, subtask_queue_count: 1, has_subtask_handoff_prepared: true, subtask_handoff_count: 1, has_subtask_scheduler_readiness: true, subtask_scheduler_readiness_count: 1, has_subtask_dispatch_plan_prepared: true, subtask_dispatch_plan_count: 1, has_subtask_dispatch_contract_prepared: true, subtask_dispatch_contract_count: 1, has_subtask_dispatch_admission_evaluated: true, subtask_dispatch_admission_count: 1, has_subtask_dispatch_readiness_snapshot: true, subtask_dispatch_readiness_snapshot_count: 1, has_subtask_dispatcher_guard_verdict: true, subtask_dispatcher_guard_verdict_count: 1, has_subtask_dispatch_decision: true, subtask_dispatch_decision_count: 1, has_subtask_dispatch_candidate_manifest: true, subtask_dispatch_candidate_manifest_count: 1, has_subtask_dispatch_handoff_envelope: true, subtask_dispatch_handoff_envelope_count: 1, has_second_pass: true, final_response_preview: 'done', timeline: ['TaskStarted'] },
+      run: { run_id: 'run_1', task_id: 'task_1', status: 'Completed', child_task_count: 1, child_task_ids: ['task_child_1'], child_tasks: [{ task_id: 'task_child_1', run_id: 'run_child_1', status: 'Completed', parent_task_id: 'task_1', parent_run_id: 'run_1', source_candidate_id: 'subtask_1', source_handoff_envelope_id: 'handoff_1', source_handoff_envelope_fingerprint: 'sha256:child', event_count: 8, has_agent_loop_completed: true, completion_final_state: 'Completed', completion_summary_preview: 'completed child', final_response_preview: 'done' }], event_count: 2, has_tool_execution_completed: true, has_subtask_orchestration_queued: true, subtask_queue_count: 1, has_subtask_handoff_prepared: true, subtask_handoff_count: 1, has_subtask_scheduler_readiness: true, subtask_scheduler_readiness_count: 1, has_subtask_dispatch_plan_prepared: true, subtask_dispatch_plan_count: 1, has_subtask_dispatch_contract_prepared: true, subtask_dispatch_contract_count: 1, has_subtask_dispatch_admission_evaluated: true, subtask_dispatch_admission_count: 1, has_subtask_dispatch_readiness_snapshot: true, subtask_dispatch_readiness_snapshot_count: 1, has_subtask_dispatcher_guard_verdict: true, subtask_dispatcher_guard_verdict_count: 1, has_subtask_dispatch_decision: true, subtask_dispatch_decision_count: 1, has_subtask_dispatch_candidate_manifest: true, subtask_dispatch_candidate_manifest_count: 1, has_subtask_dispatch_handoff_envelope: true, subtask_dispatch_handoff_envelope_count: 1, has_second_pass: true, final_response_preview: 'done', timeline: ['TaskStarted'] },
     };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
     const client = new RuntimeClient(transport);
@@ -648,7 +666,7 @@ describe('RuntimeClient', () => {
   });
 
   it('creates a run.inspect request', async () => {
-    const run = { run_id: 'run_1', task_id: 'task_1', status: 'Completed', child_task_count: 1, child_task_ids: ['task_child_1'], event_count: 2, has_tool_execution_completed: true, has_subtask_orchestration_queued: true, subtask_queue_count: 1, has_subtask_handoff_prepared: true, subtask_handoff_count: 1, has_subtask_scheduler_readiness: true, subtask_scheduler_readiness_count: 1, has_subtask_dispatch_plan_prepared: true, subtask_dispatch_plan_count: 1, has_subtask_dispatch_contract_prepared: true, subtask_dispatch_contract_count: 1, has_subtask_dispatch_admission_evaluated: true, subtask_dispatch_admission_count: 1, has_subtask_dispatch_readiness_snapshot: true, subtask_dispatch_readiness_snapshot_count: 1, has_subtask_dispatcher_guard_verdict: true, subtask_dispatcher_guard_verdict_count: 1, has_subtask_dispatch_decision: true, subtask_dispatch_decision_count: 1, has_subtask_dispatch_candidate_manifest: true, subtask_dispatch_candidate_manifest_count: 1, has_subtask_dispatch_handoff_envelope: true, subtask_dispatch_handoff_envelope_count: 1, has_second_pass: false, final_response_preview: 'done', timeline: ['TaskStarted'] };
+    const run = { run_id: 'run_1', task_id: 'task_1', status: 'Completed', child_task_count: 1, child_task_ids: ['task_child_1'], child_tasks: [{ task_id: 'task_child_1', run_id: 'run_child_1', status: 'Completed', parent_task_id: 'task_1', parent_run_id: 'run_1', source_candidate_id: 'subtask_1', source_handoff_envelope_id: 'handoff_1', source_handoff_envelope_fingerprint: 'sha256:child', event_count: 8, has_agent_loop_completed: true, completion_final_state: 'Completed', completion_summary_preview: 'completed child', final_response_preview: 'done' }], event_count: 2, has_tool_execution_completed: true, has_subtask_orchestration_queued: true, subtask_queue_count: 1, has_subtask_handoff_prepared: true, subtask_handoff_count: 1, has_subtask_scheduler_readiness: true, subtask_scheduler_readiness_count: 1, has_subtask_dispatch_plan_prepared: true, subtask_dispatch_plan_count: 1, has_subtask_dispatch_contract_prepared: true, subtask_dispatch_contract_count: 1, has_subtask_dispatch_admission_evaluated: true, subtask_dispatch_admission_count: 1, has_subtask_dispatch_readiness_snapshot: true, subtask_dispatch_readiness_snapshot_count: 1, has_subtask_dispatcher_guard_verdict: true, subtask_dispatcher_guard_verdict_count: 1, has_subtask_dispatch_decision: true, subtask_dispatch_decision_count: 1, has_subtask_dispatch_candidate_manifest: true, subtask_dispatch_candidate_manifest_count: 1, has_subtask_dispatch_handoff_envelope: true, subtask_dispatch_handoff_envelope_count: 1, has_second_pass: false, final_response_preview: 'done', timeline: ['TaskStarted'] };
     const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result: { run } });
     const client = new RuntimeClient(transport);
 

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.12';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.12.json';
+const phase = 'M5.13';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.13.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'explicit_queued_child_task_run_admission',
-    `${phase} must declare the explicit queued child task run admission transition.`
+    manifest.concrete_capability_transition === 'parent_child_run_result_inspection',
+    `${phase} must declare the parent child run result inspection transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_child_task_run_admission',
-    `${phase} must forbid adding another blocked summary wrapper without child task run admission.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_parent_child_result_inspection',
+    `${phase} must forbid adding another blocked summary wrapper without parent child result inspection.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,14 +75,14 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'explicit task.run',
+    'structured child task summaries',
     'parent_task_id',
     'parent_run_id',
     'source candidate ID',
     'source handoff envelope fingerprint',
     'Queued',
     'Completed',
-    'task.inspect'
+    'child_tasks'
   ]) {
     requireManifestValue(
       exitCriteria.some((criterion) => typeof criterion === 'string' && criterion.includes(token)),
@@ -103,6 +103,9 @@ function validateSourceEvidence(manifest) {
   for (const token of evidence.rust_store_tokens ?? []) {
     requireToken('crates/brownie-store/src/lib.rs', token);
   }
+  for (const token of evidence.rust_protocol_tokens ?? []) {
+    requireToken('crates/brownie-protocol/src/lib.rs', token);
+  }
   for (const token of evidence.rust_runtime_tokens ?? []) {
     requireToken('crates/brownie-runtime/src/lib.rs', token);
   }
@@ -117,7 +120,8 @@ function validateSourceEvidence(manifest) {
     'SubtaskAdmissionTokenRecorded',
     'SubtaskSchedulerPacketRecorded',
     'SubtaskHandoffReceiptRecorded',
-    'SubtaskChildRunAdmissionSummaryRecorded'
+    'SubtaskChildRunAdmissionSummaryRecorded',
+    'SubtaskChildRunResultSummaryRecorded'
   ];
   for (const token of forbiddenWrapperEvents) {
     if (runtimeText.includes(token) || storeText.includes(token)) {


### PR DESCRIPTION
## 概要

M5.13 は、parent `run.inspect` / `task.inspect` から child task の状態と sanitized result evidence を構造化して確認できるようにします。

M5.12 で child task は明示 `task.run` によって既存 lifecycle に入れるようになりましたが、parent inspection では `child_task_ids` だけが見えていました。この PR では `RunInspectSummary.child_tasks` を追加し、parent 側から queued / completed などの child 状態と provenance / result summary を確認できるようにします。

## 実装内容

- `ChildTaskInspectSummary` を protocol に追加
- `RunInspectSummary` に `child_tasks` を追加し、既存 `child_task_count` / `child_task_ids` は維持
- parent run inspection で child `TaskRecord` と child ledger から summary を生成
- summary には child task id / run id / status / parent-source provenance / event count / completion state / sanitized previews を含める
- VSIX protocol validator と tests を更新
- M5.13 用 `phase-value-manifest.m5.13.json` と `guard-phase-value.mjs` を更新
- runtime / inspection / task runtime spec に M5.13 contract を追記

## Safety boundary

維持しています。

```text
scheduler auto-dispatch: なし
external worker:         なし
process exec expansion:  なし
network bypass:          なし
service control:         なし
patch apply:             なし
direct workspace write:  なし
new blocked wrapper:     なし
raw prompt/provider data: parent summary へ露出なし
```

## Checks

```text
pnpm guard:diagnostics
pnpm guard:phase-value
cargo fmt --check
cargo check --workspace
cargo test --workspace
pnpm install
pnpm --filter brownie-vsix check
pnpm --filter brownie-vsix test
pnpm --filter brownie-vsix build
```
