### PR TITLE
M5.16: materialize children per handoff candidate

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -11707,6 +11707,19 @@ fn queued_subtask_source_intent_summary(
         })
 }
 
+fn handoff_envelope_candidate_ids(envelope_payload: &Value) -> Vec<String> {
+    let mut candidate_ids = Vec::new();
+    for key in ["candidate_ids", "blocked_candidate_ids"] {
+        for candidate_id in payload_string_array(envelope_payload, key) {
+            if candidate_id.trim().is_empty() || candidate_ids.contains(&candidate_id) {
+                continue;
+            }
+            candidate_ids.push(candidate_id);
+        }
+    }
+    candidate_ids
+}
+
 fn materialize_controlled_child_task_from_handoff_envelope(
     store: &BrownieStore,
     record: &brownie_protocol::TaskRecord,
@@ -11735,13 +11748,6 @@ fn materialize_controlled_child_task_from_handoff_envelope(
     else {
         return Ok(None);
     };
-    if let Some(existing) = store.tasks().find_child_task_by_handoff_fingerprint(
-        &record.run_id,
-        &source_handoff_envelope_fingerprint,
-    )? {
-        return Ok(Some(existing));
-    }
-
     let Some(source_handoff_envelope_id) = envelope_payload
         .get("handoff_envelope_id")
         .and_then(Value::as_str)
@@ -11749,38 +11755,48 @@ fn materialize_controlled_child_task_from_handoff_envelope(
     else {
         return Ok(None);
     };
-    let source_candidate_id = payload_string_array(envelope_payload, "candidate_ids")
-        .into_iter()
-        .next()
-        .or_else(|| {
-            payload_string_array(envelope_payload, "blocked_candidate_ids")
-                .into_iter()
-                .next()
-        });
-    let Some(source_candidate_id) = source_candidate_id else {
+
+    let candidate_ids = handoff_envelope_candidate_ids(envelope_payload);
+    if candidate_ids.is_empty() {
         return Ok(None);
-    };
+    }
 
-    let source_intent_summary = queued_subtask_source_intent_summary(&events, &source_candidate_id);
-    let goal = child_goal_from_source_intent(&source_candidate_id, source_intent_summary.as_ref());
-    let mode_id = source_intent_summary
-        .as_ref()
-        .and_then(|summary| summary.requested_mode_id.clone())
-        .or_else(|| record.mode_id.clone());
+    let mut first_child = None;
+    for source_candidate_id in candidate_ids {
+        let child = if let Some(existing) = store
+            .tasks()
+            .find_child_task_by_candidate_and_handoff_fingerprint(
+                &record.run_id,
+                &source_candidate_id,
+                &source_handoff_envelope_fingerprint,
+            )? {
+            existing
+        } else {
+            let source_intent_summary =
+                queued_subtask_source_intent_summary(&events, &source_candidate_id);
+            let goal =
+                child_goal_from_source_intent(&source_candidate_id, source_intent_summary.as_ref());
+            let mode_id = source_intent_summary
+                .as_ref()
+                .and_then(|summary| summary.requested_mode_id.clone())
+                .or_else(|| record.mode_id.clone());
 
-    store
-        .tasks()
-        .start_child_task(ChildTaskStartParams {
-            goal,
-            mode_id,
-            parent_task_id: record.task_id.clone(),
-            parent_run_id: record.run_id.clone(),
-            source_candidate_id,
-            source_handoff_envelope_id,
-            source_handoff_envelope_fingerprint,
-            source_intent_summary,
-        })
-        .map(Some)
+            store.tasks().start_child_task(ChildTaskStartParams {
+                goal,
+                mode_id,
+                parent_task_id: record.task_id.clone(),
+                parent_run_id: record.run_id.clone(),
+                source_candidate_id,
+                source_handoff_envelope_id: source_handoff_envelope_id.clone(),
+                source_handoff_envelope_fingerprint: source_handoff_envelope_fingerprint.clone(),
+                source_intent_summary,
+            })?
+        };
+        if first_child.is_none() {
+            first_child = Some(child);
+        }
+    }
+    Ok(first_child)
 }
 
 fn append_workspace_patch_proposal(
@@ -14037,6 +14053,239 @@ mod tests {
         );
         assert!(child_started_payload["source_intent_summary"]
             .get("input")
+            .is_none());
+    }
+
+    #[test]
+    fn accepted_handoff_envelope_materializes_one_child_per_distinct_candidate() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = BrownieStore::new(temp.path());
+        let parent = store
+            .tasks()
+            .start_task(brownie_protocol::TaskStartParams {
+                goal: "Parent orchestration".into(),
+                mode_id: Some("orchestrator".into()),
+            })
+            .expect("start parent");
+        let parser_decision = ToolIntentDecision {
+            tool_id: SUBTASK_SPAWN_TOOL_ID.to_string(),
+            required_action: RuntimeAction::SpawnSubtask,
+            allowed: true,
+            reason: "Mode orchestrator allows SpawnSubtask.".into(),
+            request_reason: "Create parser child.".into(),
+            input: json!({
+                "goal": "Review parser boundary A.",
+                "mode_id": "implementer"
+            }),
+        };
+        let verifier_decision = ToolIntentDecision {
+            tool_id: SUBTASK_SPAWN_TOOL_ID.to_string(),
+            required_action: RuntimeAction::SpawnSubtask,
+            allowed: true,
+            reason: "Mode orchestrator allows SpawnSubtask.".into(),
+            request_reason: "Create verifier child.".into(),
+            input: json!({
+                "goal": "Verify child result B.",
+                "mode_id": "verifier"
+            }),
+        };
+
+        append_subtask_orchestration_queued(&store, &parent, &parser_decision)
+            .expect("queue parser subtask");
+        append_subtask_orchestration_queued(&store, &parent, &verifier_decision)
+            .expect("queue verifier subtask");
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent.run_id)
+            .expect("parent events");
+        let candidate_ids: Vec<String> = parent_events
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskOrchestrationQueued)
+            .filter_map(|event| {
+                event
+                    .payload
+                    .as_ref()?
+                    .get("subtask_id")?
+                    .as_str()
+                    .map(str::to_string)
+            })
+            .collect();
+        assert_eq!(candidate_ids.len(), 2);
+
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &parent,
+                LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded,
+                Some(json!({
+                    "handoff_envelope_status": "Accepted",
+                    "handoff_envelope_id": "handoff_envelope_multi",
+                    "handoff_envelope_fingerprint": "sha256:multi-subtask",
+                    "candidate_ids": [
+                        candidate_ids[0].clone(),
+                        candidate_ids[1].clone(),
+                        candidate_ids[0].clone()
+                    ],
+                    "blocked_candidate_ids": [candidate_ids[1].clone()],
+                })),
+            )
+            .expect("append handoff envelope");
+
+        let first_child = materialize_controlled_child_task_from_handoff_envelope(&store, &parent)
+            .expect("materialize children")
+            .expect("first child");
+        assert_eq!(
+            first_child.source_candidate_id.as_deref(),
+            Some(candidate_ids[0].as_str())
+        );
+
+        let child_tasks: Vec<TaskRecord> = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .collect();
+        assert_eq!(child_tasks.len(), 2);
+        let children_by_candidate: std::collections::BTreeMap<String, TaskRecord> = child_tasks
+            .into_iter()
+            .map(|child| {
+                (
+                    child
+                        .source_candidate_id
+                        .clone()
+                        .expect("source candidate id"),
+                    child,
+                )
+            })
+            .collect();
+
+        for (candidate_id, expected_goal, expected_mode_id, expected_reason) in [
+            (
+                candidate_ids[0].as_str(),
+                "Review parser boundary A.",
+                "implementer",
+                "Create parser child.",
+            ),
+            (
+                candidate_ids[1].as_str(),
+                "Verify child result B.",
+                "verifier",
+                "Create verifier child.",
+            ),
+        ] {
+            let child = children_by_candidate
+                .get(candidate_id)
+                .expect("candidate child");
+            assert_eq!(child.status, TaskStatus::Queued);
+            assert_eq!(child.goal, expected_goal);
+            assert_eq!(child.mode_id.as_deref(), Some(expected_mode_id));
+            assert_eq!(
+                child.parent_task_id.as_deref(),
+                Some(parent.task_id.as_str())
+            );
+            assert_eq!(child.parent_run_id.as_deref(), Some(parent.run_id.as_str()));
+            assert_eq!(
+                child.source_handoff_envelope_id.as_deref(),
+                Some("handoff_envelope_multi")
+            );
+            assert_eq!(
+                child.source_handoff_envelope_fingerprint.as_deref(),
+                Some("sha256:multi-subtask")
+            );
+            assert!(validate_controlled_queued_child_task_provenance(child, &store).is_ok());
+
+            let source_intent_summary = child
+                .source_intent_summary
+                .as_ref()
+                .expect("source intent summary");
+            assert_eq!(source_intent_summary.tool_id, SUBTASK_SPAWN_TOOL_ID);
+            assert_eq!(
+                source_intent_summary.required_action,
+                RuntimeActionName::SpawnSubtask
+            );
+            assert_eq!(source_intent_summary.request_reason, expected_reason);
+            assert_eq!(
+                source_intent_summary.requested_goal_preview.as_deref(),
+                Some(expected_goal)
+            );
+            assert_eq!(
+                source_intent_summary.requested_mode_id.as_deref(),
+                Some(expected_mode_id)
+            );
+            assert_eq!(source_intent_summary.input_summary.field_count, 2);
+
+            let child_events = store
+                .tasks()
+                .read_ledger_events(&child.run_id)
+                .expect("child ledger");
+            assert_eq!(child_events.len(), 1);
+            assert_eq!(child_events[0].kind, LedgerEventKind::TaskStarted);
+            let child_started_payload = child_events[0].payload.as_ref().expect("child payload");
+            assert_eq!(child_started_payload["status"], "Queued");
+            assert_eq!(child_started_payload["source_candidate_id"], candidate_id);
+            assert_eq!(
+                child_started_payload["source_intent_summary"]["request_reason"],
+                expected_reason
+            );
+            assert_eq!(
+                child_started_payload["source_intent_summary"]["requested_goal_preview"],
+                expected_goal
+            );
+            assert_eq!(
+                child_started_payload["source_intent_summary"]["requested_mode_id"],
+                expected_mode_id
+            );
+            assert!(child_started_payload["source_intent_summary"]
+                .get("input")
+                .is_none());
+
+            assert_eq!(
+                store
+                    .tasks()
+                    .find_child_task_by_candidate_and_handoff_fingerprint(
+                        &parent.run_id,
+                        candidate_id,
+                        "sha256:multi-subtask"
+                    )
+                    .expect("find candidate child")
+                    .as_ref()
+                    .map(|record| record.task_id.as_str()),
+                Some(child.task_id.as_str())
+            );
+        }
+
+        let parent_state = store
+            .tasks()
+            .get_task(&parent.task_id)
+            .expect("get parent")
+            .expect("parent");
+        let duplicate =
+            materialize_controlled_child_task_from_handoff_envelope(&store, &parent_state)
+                .expect("idempotent materialization")
+                .expect("existing child");
+        assert_eq!(
+            duplicate.source_candidate_id.as_deref(),
+            Some(candidate_ids[0].as_str())
+        );
+        assert_eq!(
+            store
+                .tasks()
+                .list_tasks()
+                .expect("list tasks after idempotency")
+                .iter()
+                .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+                .count(),
+            2
+        );
+        assert!(store
+            .tasks()
+            .find_child_task_by_candidate_and_handoff_fingerprint(
+                &parent.run_id,
+                "subtask_missing",
+                "sha256:multi-subtask"
+            )
+            .expect("missing candidate child")
             .is_none());
     }
 

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -14058,7 +14058,9 @@ mod tests {
 
     #[test]
     fn accepted_handoff_envelope_materializes_one_child_per_distinct_candidate() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
         let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
         let store = BrownieStore::new(temp.path());
         let parent = store
             .tasks()
@@ -14287,6 +14289,46 @@ mod tests {
             )
             .expect("missing candidate child")
             .is_none());
+
+        for child in children_by_candidate.values() {
+            let child_run = parse_line(&format!(
+                r#"{{"jsonrpc":"2.0","id":100,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+                child.task_id
+            ));
+            assert!(child_run.error.is_none());
+            let child_result = child_run.result.expect("child run result");
+            assert_eq!(child_result["task_id"], child.task_id);
+            assert_eq!(child_result["run_id"], child.run_id);
+            assert_eq!(child_result["status"], "Completed");
+
+            let completed_child = store
+                .tasks()
+                .get_task(&child.task_id)
+                .expect("get completed child")
+                .expect("completed child");
+            assert_eq!(completed_child.status, TaskStatus::Completed);
+            assert_eq!(
+                completed_child.source_candidate_id.as_deref(),
+                child.source_candidate_id.as_deref()
+            );
+            assert_eq!(
+                completed_child
+                    .source_handoff_envelope_fingerprint
+                    .as_deref(),
+                Some("sha256:multi-subtask")
+            );
+        }
+        assert_eq!(
+            store
+                .tasks()
+                .list_tasks()
+                .expect("list tasks after child runs")
+                .iter()
+                .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+                .count(),
+            2
+        );
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }
 
     #[test]

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -190,6 +190,24 @@ impl TaskStore {
         Ok(None)
     }
 
+    pub fn find_child_task_by_candidate_and_handoff_fingerprint(
+        &self,
+        parent_run_id: &str,
+        source_candidate_id: &str,
+        source_handoff_envelope_fingerprint: &str,
+    ) -> Result<Option<TaskRecord>> {
+        for record in self.list_tasks()? {
+            if record.parent_run_id.as_deref() == Some(parent_run_id)
+                && record.source_candidate_id.as_deref() == Some(source_candidate_id)
+                && record.source_handoff_envelope_fingerprint.as_deref()
+                    == Some(source_handoff_envelope_fingerprint)
+            {
+                return Ok(Some(record));
+            }
+        }
+        Ok(None)
+    }
+
     pub fn list_tasks(&self) -> Result<Vec<TaskRecord>> {
         let runs_dir = self.runs_dir();
         if !runs_dir.exists() {
@@ -586,6 +604,26 @@ mod tests {
                 .map(|record| record.task_id.as_str()),
             Some(child.task_id.as_str())
         );
+        assert_eq!(
+            store
+                .find_child_task_by_candidate_and_handoff_fingerprint(
+                    &parent.run_id,
+                    "subtask_1",
+                    "sha256:child"
+                )
+                .expect("find child by candidate")
+                .as_ref()
+                .map(|record| record.task_id.as_str()),
+            Some(child.task_id.as_str())
+        );
+        assert!(store
+            .find_child_task_by_candidate_and_handoff_fingerprint(
+                &parent.run_id,
+                "subtask_missing",
+                "sha256:child"
+            )
+            .expect("missing candidate child")
+            .is_none());
         assert!(store
             .find_child_task_by_handoff_fingerprint(&parent.run_id, "sha256:missing")
             .expect("missing child")

--- a/docs/architecture/phase-value-manifest.m5.16.json
+++ b/docs/architecture/phase-value-manifest.m5.16.json
@@ -1,0 +1,73 @@
+{
+  "phase": "M5.16",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "multi_candidate_child_task_materialization",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_without_multi_child_materialization",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Turns one accepted handoff envelope covering multiple subtask candidates into multiple concrete child TaskRecords instead of stopping after the first candidate."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Preserves explicit task.run admission for each controlled child by maintaining per-candidate provenance against the parent handoff envelope."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Lets headless callers inspect distinct child task entities for each approved candidate without scheduler handoff or raw tool input persistence."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "multi_candidate_materialization",
+        "prompt": "Does an accepted handoff envelope with multiple distinct candidates create multiple controlled child TaskRecords?"
+      },
+      {
+        "id": "candidate_scoped_idempotency",
+        "prompt": "Is duplicate prevention scoped by parent run, source candidate, and handoff envelope fingerprint?"
+      },
+      {
+        "id": "per_candidate_intent",
+        "prompt": "Does each child preserve its own sanitized source intent summary, requested goal, and requested mode?"
+      },
+      {
+        "id": "explicit_child_run_admission",
+        "prompt": "Does each materialized child remain eligible for the existing explicit queued child task.run admission path?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler auto-dispatch, external workers, process exec expansion, network bypass, service control, patch apply, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "multi_candidate_materialization": "Yes. The runtime deduplicates accepted envelope candidate ids and materializes one queued child TaskRecord per distinct candidate.",
+      "candidate_scoped_idempotency": "Yes. Existing children are looked up by parent_run_id, source_candidate_id, and source_handoff_envelope_fingerprint before creating a new child.",
+      "per_candidate_intent": "Yes. Each child reconstructs source_intent_summary from its own SubtaskOrchestrationQueued evidence, including requested_goal_preview and requested_mode_id when present.",
+      "explicit_child_run_admission": "Yes. The existing queued child provenance validator accepts each child because parent/source candidate/envelope evidence remains complete.",
+      "safety_boundary": "Yes. The phase adds no scheduler auto-dispatch, external worker, patch apply, direct workspace mutation path, service control, network bypass, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "An accepted handoff envelope covering multiple distinct candidate ids materializes multiple controlled child TaskRecords.",
+    "Every materialized child stores source_candidate_id, parent_task_id, parent_run_id, source_handoff_envelope_id, and source_handoff_envelope_fingerprint.",
+    "Duplicate prevention uses parent_run_id + source_candidate_id + source_handoff_envelope_fingerprint.",
+    "Each child preserves a per-candidate source_intent_summary with requested_goal_preview and requested_mode_id when available.",
+    "Child source_intent_summary and child TaskStarted payloads do not persist raw input objects.",
+    "Parent task.run does not auto-run child tasks.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_store_tokens": [
+      "find_child_task_by_candidate_and_handoff_fingerprint"
+    ],
+    "rust_runtime_tokens": [
+      "handoff_envelope_candidate_ids",
+      "find_child_task_by_candidate_and_handoff_fingerprint",
+      "accepted_handoff_envelope_materializes_one_child_per_distinct_candidate",
+      "validate_controlled_queued_child_task_provenance"
+    ]
+  }
+}

--- a/docs/specifications/agent-loop-spec-v0.md
+++ b/docs/specifications/agent-loop-spec-v0.md
@@ -179,3 +179,9 @@ This remains handoff envelope recording only. No child task is launched, no sche
 M5.15 gives `subtask.spawn` a bounded structured input surface. Approved requests may include an optional child `goal` and optional child `mode_id`; invalid shape, unknown fields, unsafe `mode_id` syntax, and unresolved modes are rejected before queueing or child materialization.
 
 Valid structured input changes the runtime entity rather than adding another blocked parent-run wrapper: `requested_goal_preview` becomes the materialized child task goal, and `requested_mode_id` becomes the child mode. Parent runs still do not auto-run children, and no scheduler handoff, process execution, network access, service control, patch apply, or workspace write capability is added.
+
+## M5.16 multi-candidate child materialization
+
+M5.16 lets one accepted handoff envelope materialize one queued child task for each distinct covered candidate. The agent loop still performs no scheduler handoff and does not run those children automatically; it only creates controlled runtime entities with parent/source provenance and candidate-scoped replay protection.
+
+Each child keeps the per-candidate sanitized `source_intent_summary`, requested goal, and requested mode when present. Explicit child `task.run` remains the only execution path, and no process execution, network access, service control, patch apply, or workspace write capability is added.

--- a/docs/specifications/run-inspection-spec-v0.md
+++ b/docs/specifications/run-inspection-spec-v0.md
@@ -111,6 +111,12 @@ Materialized child tasks now carry a sanitized `source_intent_summary` derived f
 
 The summary includes `tool_id`, `required_action`, bounded `request_reason`, and bounded `input_summary`. It must not include raw `input`, raw prompts, provider responses, file content, command output, environment values, or serialized request bodies. Parent inspection remains observational and does not auto-run child tasks.
 
+## M5.16 multi-candidate child relation inspection
+
+Parent run inspection may now list multiple controlled child tasks materialized from one accepted handoff envelope. `child_task_count`, `child_task_ids`, and `child_tasks` are derived from persisted child records, so every distinct candidate child appears independently with its own `source_candidate_id`, handoff envelope fingerprint, status, and sanitized `source_intent_summary`.
+
+Inspection remains observational. It must not trigger child execution, scheduler handoff, workspace writes, patch apply, process execution, network access, service control, or raw input exposure.
+
 ## Phase 2.1 LLM metadata redaction
 
 Run inspection may show LLM provider metadata and `LlmRequestFailed` / `SecondPassLlmRequestFailed` summaries, but all secret-bearing values must be redacted. API keys, Authorization headers, Bearer tokens, and URL query strings are not inspection data. `BROWNIE_LLM_STRICT` and fallback-to-Fake status are observable through `llm.status`; request ledger metadata may include redacted `base_url` and `strict` so users can verify which configured provider path was used.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -818,3 +818,11 @@ M5.15 adds bounded structured input for approved `subtask.spawn` intent. The opt
 Before approval, queueing, or child materialization, the runtime resolves requested `mode_id` values against the workspace mode policy set. Unknown modes use the existing `ToolIntentDenied` event path and do not create `ToolIntentApproved`, queued subtask evidence, or child records. Valid requested inputs are persisted only as sanitized summary fields: `requested_goal_preview` and `requested_mode_id`.
 
 Controlled child materialization uses `requested_goal_preview` as the child `TaskRecord.goal` and `requested_mode_id` as the child `TaskRecord.mode_id` when present. `run.inspect`, `task.inspect`, child `TaskStarted`, and `ChildTaskSourceIntentSummary` expose the same sanitized fields without raw `input` objects or serialized request bodies. M5.15 preserves duplicate prevention, explicit child `task.run` admission, and the no scheduler auto-dispatch / no process / no network / no service-control / no patch-apply / no direct workspace mutation boundary.
+
+## M5.16 multi-candidate child task materialization
+
+M5.16 extends controlled child materialization across all distinct candidates covered by one accepted `SubtaskDispatchHandoffEnvelopeRecorded` event. A handoff envelope with multiple `candidate_ids` or `blocked_candidate_ids` materializes one queued child `TaskRecord` per distinct source candidate instead of stopping after the first candidate.
+
+Duplicate prevention is scoped to `parent_run_id + source_candidate_id + source_handoff_envelope_fingerprint`, so rerunning materialization for the same envelope reuses existing children without blocking different candidates from the same envelope. Each child keeps its own parent/source provenance, per-candidate `source_intent_summary`, sanitized `requested_goal_preview`, and sanitized `requested_mode_id` when available.
+
+Parent `task.run` still does not run child tasks, and each child remains limited to the existing explicit queued child `task.run` admission path. M5.16 adds no scheduler handoff, external worker, process execution expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, raw `input` persistence, or new blocked summary wrapper.

--- a/docs/specifications/tool-intent-spec-v0.md
+++ b/docs/specifications/tool-intent-spec-v0.md
@@ -60,6 +60,12 @@ The runtime resolves a requested `mode_id` against the built-in plus local Mode 
 
 When a later accepted handoff envelope materializes a child, a valid `requested_goal_preview` becomes the child goal and a valid `requested_mode_id` becomes the child `mode_id`. M5.15 still does not execute the child LLM loop, scheduler handoff, process execution, network access, service control, patch apply, or workspace mutation.
 
+## M5.16 multi-candidate child materialization
+
+When an accepted handoff envelope covers multiple distinct queued candidates, `task.run` may materialize one controlled child `TaskRecord` per candidate. The duplicate guard is candidate-aware: an existing child blocks only the same `parent_run_id`, `source_candidate_id`, and `source_handoff_envelope_fingerprint` tuple, not other candidates in the same envelope.
+
+Each child carries its own sanitized source intent summary and requested goal/mode fields when present. M5.16 still does not execute the child LLM loop, scheduler handoff, process execution, network access, service control, patch apply, workspace mutation, or raw input persistence.
+
 M5.1 does not execute the requested subtask. It only prepares deterministic parent-run handoff state for future runtime scheduling.
 
 ## M5.2 subtask scheduler readiness

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.15';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.15.json';
+const phase = 'M5.16';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.16.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'structured_subtask_spawn_child_materialization',
-    `${phase} must declare the structured subtask spawn child materialization transition.`
+    manifest.concrete_capability_transition === 'multi_candidate_child_task_materialization',
+    `${phase} must declare the multi-candidate child task materialization transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_structured_child_task_materialization',
-    `${phase} must forbid adding another blocked summary wrapper without structured child task materialization.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_multi_child_materialization',
+    `${phase} must forbid adding another blocked summary wrapper without multi-child materialization.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,10 +75,10 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'bounded subtask.spawn input schema',
-    'requested_goal_preview',
-    'requested_mode_id',
-    'unknown mode_id',
+    'multiple controlled child TaskRecords',
+    'source_candidate_id',
+    'parent_run_id + source_candidate_id + source_handoff_envelope_fingerprint',
+    'per-candidate source_intent_summary',
     'raw input objects',
     'Parent task.run does not auto-run child tasks',
     'No scheduler handoff'


### PR DESCRIPTION
## Summary

- M5.16 として、accepted `SubtaskDispatchHandoffEnvelopeRecorded` に含まれる複数の distinct candidate から、candidate ごとに controlled child `TaskRecord` を materialize するようにしました。
- duplicate prevention を `parent_run_id + source_candidate_id + source_handoff_envelope_fingerprint` に変更し、同じ envelope 内の別 candidate が既存 child によって抑止されないようにしました。
- 各 child が per-candidate `source_intent_summary`、`requested_goal_preview`、`requested_mode_id`、parent/source provenance を保持することをテストで固定しました。
- `guard-phase-value` を M5.16 固有 manifest に更新し、追加 blocked wrapper ではなく multi-child materialization を検証するようにしました。

## Safety boundary

- scheduler handoff: 追加なし
- child auto-run: 追加なし
- external worker: 追加なし
- process exec / network / service control: 追加なし
- patch apply / direct workspace mutation: 追加なし
- raw input persistence: 追加なし
- diagnostics wrapper RPC: 追加なし

## Validation

- `pnpm guard:phase-value`
- `cargo test -p brownie-runtime accepted_handoff_envelope_materializes_one_child_per_distinct_candidate`
- `cargo test -p brownie-store start_child_task_records_parent_provenance_and_fingerprint_lookup`
- `cargo check --workspace`
- `pnpm guard:diagnostics`
- `cargo fmt --check`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`