### PR TITLE
M5.18: guard parent join replay

### DIFF
--- a/crates/brownie-context/src/lib.rs
+++ b/crates/brownie-context/src/lib.rs
@@ -694,6 +694,29 @@ fn format_subtask_orchestration_summary(events: &[LedgerEvent]) -> Vec<String> {
                         "{handoff_envelope_id}: {handoff_envelope_status} manifest_count={manifest_count} candidate_count={candidate_count} handoff_ticket_count={handoff_ticket_count} replay_guard_status={replay_guard_status} dispatch_enabled={dispatch_enabled} next_action={next_action}"
                     ))
                 }
+                LedgerEventKind::ParentJoinContinuationFingerprintConsumed => {
+                    let parent_join_continuation_status = payload
+                        .get("parent_join_continuation_status")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("<unknown>");
+                    let child_completion_fingerprint = payload
+                        .get("child_completion_fingerprint")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("<unknown>");
+                    let child_completion_child_count = payload
+                        .get("child_completion_child_count")
+                        .and_then(|value| value.as_u64())
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    let fingerprint_input_count = payload
+                        .get("fingerprint_input_count")
+                        .and_then(|value| value.as_u64())
+                        .map(|value| value.to_string())
+                        .unwrap_or_else(|| "<unknown>".to_string());
+                    Some(format!(
+                        "parent_join_continuation: {parent_join_continuation_status} child_completion_fingerprint={child_completion_fingerprint} child_completion_child_count={child_completion_child_count} fingerprint_input_count={fingerprint_input_count}"
+                    ))
+                }
                 _ => None,
             }
         })

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1762,6 +1762,22 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     };
     let child_completion_summaries = admission.child_completion_summaries();
 
+    if let Some(consumption) = admission.parent_join_continuation_consumption() {
+        if let Err(error) = store.tasks().append_task_event_with_payload(
+            &record,
+            LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
+            Some(json!({
+                "parent_join_continuation_status": "Consumed",
+                "child_completion_fingerprint": consumption.child_completion_fingerprint,
+                "child_completion_child_count": consumption.child_completion_child_count,
+                "fingerprint_input_count": consumption.child_completion_fingerprint_input_count,
+                "reason": "Parent join continuation admitted for this completed controlled child result fingerprint."
+            })),
+        ) {
+            return error_response(id, -32603, &format!("internal error: {error}"));
+        }
+    }
+
     let running = match store.tasks().update_task_status(
         &record.task_id,
         TaskStatus::Running,
@@ -2140,20 +2156,41 @@ enum TaskRunAdmissionRejection {
 
 enum TaskRunAdmission {
     Standard,
-    ParentJoinContinuation {
-        child_completion_summaries: Vec<String>,
-    },
+    ParentJoinContinuation(ParentJoinContinuationAdmission),
+}
+
+struct ParentJoinContinuationAdmission {
+    child_completion_summaries: Vec<String>,
+    child_completion_fingerprint: String,
+    child_completion_fingerprint_input_count: usize,
+    child_completion_child_count: usize,
 }
 
 impl TaskRunAdmission {
     fn child_completion_summaries(&self) -> Vec<String> {
         match self {
             Self::Standard => Vec::new(),
-            Self::ParentJoinContinuation {
-                child_completion_summaries,
-            } => child_completion_summaries.clone(),
+            Self::ParentJoinContinuation(admission) => admission.child_completion_summaries.clone(),
         }
     }
+
+    fn parent_join_continuation_consumption(&self) -> Option<ParentJoinContinuationConsumption> {
+        match self {
+            Self::Standard => None,
+            Self::ParentJoinContinuation(admission) => Some(ParentJoinContinuationConsumption {
+                child_completion_fingerprint: admission.child_completion_fingerprint.clone(),
+                child_completion_fingerprint_input_count: admission
+                    .child_completion_fingerprint_input_count,
+                child_completion_child_count: admission.child_completion_child_count,
+            }),
+        }
+    }
+}
+
+struct ParentJoinContinuationConsumption {
+    child_completion_fingerprint: String,
+    child_completion_fingerprint_input_count: usize,
+    child_completion_child_count: usize,
 }
 
 fn validate_task_run_admission(
@@ -2166,11 +2203,9 @@ fn validate_task_run_admission(
             validate_controlled_queued_child_task_provenance(record, store)?;
             Ok(TaskRunAdmission::Standard)
         }
-        TaskStatus::Completed => Ok(TaskRunAdmission::ParentJoinContinuation {
-            child_completion_summaries: validate_completed_parent_join_continuation_admission(
-                record, store,
-            )?,
-        }),
+        TaskStatus::Completed => Ok(TaskRunAdmission::ParentJoinContinuation(
+            validate_completed_parent_join_continuation_admission(record, store)?,
+        )),
         TaskStatus::Running | TaskStatus::Failed | TaskStatus::Cancelled => {
             Err(TaskRunAdmissionRejection::InvalidParams(
                 "invalid params: task must be Created, a controlled Queued child task, or a completed parent with completed controlled child tasks",
@@ -2182,7 +2217,7 @@ fn validate_task_run_admission(
 fn validate_completed_parent_join_continuation_admission(
     record: &TaskRecord,
     store: &BrownieStore,
-) -> Result<Vec<String>, TaskRunAdmissionRejection> {
+) -> Result<ParentJoinContinuationAdmission, TaskRunAdmissionRejection> {
     if record.parent_run_id.is_some() {
         return Err(TaskRunAdmissionRejection::InvalidParams(
             "invalid params: completed child task cannot be rerun",
@@ -2222,18 +2257,39 @@ fn validate_completed_parent_join_continuation_admission(
         }
     }
 
-    let mut summaries = child_tasks
+    let child_evidence = child_tasks
+        .iter()
+        .map(|child| parent_join_child_completion_evidence(store, child))
+        .collect::<Result<Vec<_>, _>>()?;
+    let (child_completion_fingerprint, child_completion_fingerprint_input_count) =
+        parent_join_child_completion_fingerprint(&child_evidence);
+    if parent_join_child_completion_fingerprint_consumed(
+        store,
+        record,
+        &child_completion_fingerprint,
+    )? {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: parent join continuation for this completed child result set has already been consumed",
+        ));
+    }
+
+    let mut summaries = child_evidence
         .iter()
         .take(MAX_PARENT_JOIN_CHILD_CONTEXT_SUMMARIES)
-        .map(|child| parent_join_child_completion_summary(store, child))
-        .collect::<Result<Vec<_>, _>>()?;
+        .map(|evidence| evidence.summary.clone())
+        .collect::<Vec<_>>();
     if child_tasks.len() > MAX_PARENT_JOIN_CHILD_CONTEXT_SUMMARIES {
         summaries.push(format!(
             "completed_child_summary_omitted count={}",
             child_tasks.len() - MAX_PARENT_JOIN_CHILD_CONTEXT_SUMMARIES
         ));
     }
-    Ok(summaries)
+    Ok(ParentJoinContinuationAdmission {
+        child_completion_summaries: summaries,
+        child_completion_fingerprint,
+        child_completion_fingerprint_input_count,
+        child_completion_child_count: child_tasks.len(),
+    })
 }
 
 fn child_has_completed_agent_loop(
@@ -2259,13 +2315,42 @@ fn child_has_completed_agent_loop(
     Ok(has_completed_agent_loop && has_task_completed)
 }
 
-fn parent_join_child_completion_summary(
+struct ParentJoinChildCompletionEvidence {
+    summary: String,
+    fingerprint_inputs: Vec<String>,
+}
+
+fn parent_join_child_completion_evidence(
     store: &BrownieStore,
     child: &TaskRecord,
-) -> Result<String, TaskRunAdmissionRejection> {
+) -> Result<ParentJoinChildCompletionEvidence, TaskRunAdmissionRejection> {
     let summary =
         child_task_inspect_summary(store, child).map_err(TaskRunAdmissionRejection::Internal)?;
-    Ok(format!(
+    let source_candidate_id = summary.source_candidate_id.as_deref().unwrap_or("<none>");
+    let source_handoff_envelope_id = summary
+        .source_handoff_envelope_id
+        .as_deref()
+        .unwrap_or("<none>");
+    let source_handoff_envelope_fingerprint = summary
+        .source_handoff_envelope_fingerprint
+        .as_deref()
+        .unwrap_or("<none>");
+    let parent_task_id = summary.parent_task_id.as_deref().unwrap_or("<none>");
+    let parent_run_id = summary.parent_run_id.as_deref().unwrap_or("<none>");
+    let completion_final_state = summary
+        .completion_final_state
+        .as_deref()
+        .unwrap_or("<none>");
+    let completion_summary_preview = summary
+        .completion_summary_preview
+        .as_deref()
+        .unwrap_or("<none>");
+    let final_response_preview = summary
+        .final_response_preview
+        .as_deref()
+        .unwrap_or("<none>");
+    let status = format!("{:?}", summary.status);
+    let summary_text = format!(
         "completed_child task_id={} run_id={} status={:?} source_candidate_id={} source_handoff_envelope_fingerprint={} completion_final_state={} completion_summary_preview={} final_response_preview={}",
         summary.task_id,
         summary.run_id,
@@ -2290,7 +2375,60 @@ fn parent_join_child_completion_summary(
             .final_response_preview
             .as_deref()
             .unwrap_or("<none>")
-    ))
+    );
+    Ok(ParentJoinChildCompletionEvidence {
+        summary: summary_text,
+        fingerprint_inputs: vec![
+            format!("task_id={}", summary.task_id),
+            format!("run_id={}", summary.run_id),
+            format!("status={status}"),
+            format!("parent_task_id={parent_task_id}"),
+            format!("parent_run_id={parent_run_id}"),
+            format!("source_candidate_id={source_candidate_id}"),
+            format!("source_handoff_envelope_id={source_handoff_envelope_id}"),
+            format!("source_handoff_envelope_fingerprint={source_handoff_envelope_fingerprint}"),
+            format!("completion_final_state={completion_final_state}"),
+            format!("completion_summary_preview={completion_summary_preview}"),
+            format!("final_response_preview={final_response_preview}"),
+        ],
+    })
+}
+
+fn parent_join_child_completion_fingerprint(
+    child_evidence: &[ParentJoinChildCompletionEvidence],
+) -> (String, usize) {
+    let mut inputs = vec![
+        "parent_join_child_completion_fingerprint_v1".to_string(),
+        format!("child_count={}", child_evidence.len()),
+    ];
+    for evidence in child_evidence {
+        inputs.extend(evidence.fingerprint_inputs.iter().cloned());
+    }
+    let input_count = inputs.len();
+    (
+        format!("sha256:{}", hex_sha256(inputs.join("\n").as_bytes())),
+        input_count,
+    )
+}
+
+fn parent_join_child_completion_fingerprint_consumed(
+    store: &BrownieStore,
+    record: &TaskRecord,
+    child_completion_fingerprint: &str,
+) -> Result<bool, TaskRunAdmissionRejection> {
+    let events = store
+        .tasks()
+        .read_ledger_events(&record.run_id)
+        .map_err(|error| TaskRunAdmissionRejection::Internal(error.to_string()))?;
+    Ok(events.iter().any(|event| {
+        event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            && event
+                .payload
+                .as_ref()
+                .and_then(|payload| payload.get("child_completion_fingerprint"))
+                .and_then(Value::as_str)
+                == Some(child_completion_fingerprint)
+    }))
 }
 
 fn validate_controlled_queued_child_task_provenance(
@@ -9649,10 +9787,13 @@ fn sanitize_ledger_payload(payload: Option<Value>) -> Option<Value> {
         "handoff_envelope_status",
         "handoff_ticket_status",
         "replay_guard_status",
+        "parent_join_continuation_status",
         "dispatch_decision",
         "dispatch_denial_reason",
         "candidate_denial_reason",
         "replay_guard_reason",
+        "child_completion_fingerprint",
+        "child_completion_child_count",
         "candidate_ids",
         "eligible_candidate_ids",
         "blocked_candidate_ids",
@@ -9795,10 +9936,13 @@ fn timeline_entry(event: &LedgerEvent) -> String {
             "handoff_envelope_status",
             "handoff_ticket_status",
             "replay_guard_status",
+            "parent_join_continuation_status",
             "dispatch_decision",
             "dispatch_denial_reason",
             "candidate_denial_reason",
             "replay_guard_reason",
+            "child_completion_fingerprint",
+            "child_completion_child_count",
             "candidate_manifest_fingerprint",
             "handoff_envelope_fingerprint",
             "source_handoff_envelope_fingerprint",
@@ -14918,6 +15062,40 @@ mod tests {
                 .count(),
             2
         );
+        let consumption_payload = parent_events
+            .iter()
+            .find(|event| event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed)
+            .and_then(|event| event.payload.as_ref())
+            .expect("parent join continuation consumption payload");
+        assert_eq!(
+            consumption_payload["parent_join_continuation_status"],
+            "Consumed"
+        );
+        assert!(consumption_payload["child_completion_fingerprint"]
+            .as_str()
+            .expect("child completion fingerprint")
+            .starts_with("sha256:"));
+        assert_eq!(consumption_payload["child_completion_child_count"], 1);
+        assert!(
+            consumption_payload["fingerprint_input_count"]
+                .as_u64()
+                .expect("fingerprint input count")
+                > 0
+        );
+        let consumption_index = parent_events
+            .iter()
+            .position(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .expect("consumption event index");
+        let second_running_index = parent_events
+            .iter()
+            .enumerate()
+            .filter(|(_, event)| event.kind == LedgerEventKind::TaskRunning)
+            .nth(1)
+            .map(|(index, _)| index)
+            .expect("second TaskRunning index");
+        assert!(consumption_index < second_running_index);
         let continuation_prompt_payload = parent_events
             .iter()
             .rev()
@@ -14939,6 +15117,190 @@ mod tests {
         assert!(continuation_prompt_preview.contains("final_response_preview=Fake LLM"));
         assert!(!continuation_prompt_preview.contains("RAW_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
         assert!(!continuation_prompt_preview.contains("RAW_CHILD_FILE_CONTENT_SHOULD_NOT_APPEAR"));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_rejects_repeated_parent_join_for_same_child_completion_fingerprint() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+
+        let parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(parent_join.error.is_none());
+
+        let store = BrownieStore::new(temp.path());
+        let parent_events_before_repeat = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events before repeat");
+        assert_eq!(
+            parent_events_before_repeat
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                .count(),
+            2
+        );
+        assert_eq!(
+            parent_events_before_repeat
+                .iter()
+                .filter(|event| {
+                    event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+                })
+                .count(),
+            1
+        );
+
+        let repeat_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(repeat_join.result.is_none());
+        let error = repeat_join.error.expect("repeat parent join error");
+        assert_eq!(error.code, -32602);
+        assert!(error
+            .message
+            .contains("completed child result set has already been consumed"));
+
+        let parent = store
+            .tasks()
+            .get_task(&parent_task_id)
+            .expect("get parent")
+            .expect("parent");
+        assert_eq!(parent.status, TaskStatus::Completed);
+        let parent_events_after_repeat = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after repeat");
+        assert_eq!(
+            parent_events_after_repeat.len(),
+            parent_events_before_repeat.len()
+        );
+        assert_eq!(
+            parent_events_after_repeat
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                .count(),
+            2
+        );
+        assert_eq!(
+            parent_events_after_repeat
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::AgentLoopStarted)
+                .count(),
+            2
+        );
+        assert_eq!(
+            parent_events_after_repeat
+                .iter()
+                .filter(|event| {
+                    event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+                })
+                .count(),
+            1
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_admits_parent_join_when_child_completion_fingerprint_changes() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+
+        let first_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(first_parent_join.error.is_none());
+
+        let store = BrownieStore::new(temp.path());
+        let completed_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get completed child")
+            .expect("completed child");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_child,
+                LedgerEventKind::AgentLoopCompleted,
+                Some(json!({
+                    "final_state": "Completed",
+                    "completion_summary": "updated bounded child completion summary"
+                })),
+            )
+            .expect("append updated child completion summary");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_child,
+                LedgerEventKind::LlmResponseReceived,
+                Some(json!({
+                    "provider": "Fake",
+                    "content_preview": "updated bounded child final response"
+                })),
+            )
+            .expect("append updated child final response");
+
+        let second_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(second_parent_join.error.is_none());
+        assert_eq!(
+            second_parent_join
+                .result
+                .expect("second parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events");
+        assert_eq!(
+            parent_events
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                .count(),
+            3
+        );
+        let fingerprints = parent_events
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| {
+                event
+                    .payload
+                    .as_ref()
+                    .and_then(|payload| payload.get("child_completion_fingerprint"))
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(fingerprints.len(), 2);
+        assert_ne!(fingerprints[0], fingerprints[1]);
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -377,6 +377,7 @@ pub enum LedgerEventKind {
     SubtaskDispatchDecisionRecorded,
     SubtaskDispatchCandidateManifestRecorded,
     SubtaskDispatchHandoffEnvelopeRecorded,
+    ParentJoinContinuationFingerprintConsumed,
     ToolExecutionRequested,
     ToolExecutionPermissionChecked,
     ToolExecutionCompleted,

--- a/docs/architecture/phase-value-manifest.m5.18.json
+++ b/docs/architecture/phase-value-manifest.m5.18.json
@@ -1,0 +1,83 @@
+{
+  "phase": "M5.18",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "replay_safe_parent_join_continuation",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_without_parent_join_replay_guard",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Makes completed-parent join continuation deterministic by consuming each completed controlled child result fingerprint at most once."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Prevents repeated parent agent-loop passes over unchanged child completion evidence while preserving explicit task.run admission."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Turns parent-child result integration into replay-safe runtime state instead of relying on operator memory."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "deterministic_child_result_fingerprint",
+        "prompt": "Does the phase derive a deterministic summary-safe child completion fingerprint for parent join continuation?"
+      },
+      {
+        "id": "same_fingerprint_replay_guard",
+        "prompt": "Does the runtime reject or no-op a repeated parent continuation for the same child completion fingerprint before another parent agent-loop pass starts?"
+      },
+      {
+        "id": "changed_result_admission",
+        "prompt": "Can a materially different controlled completed child result set still admit parent continuation?"
+      },
+      {
+        "id": "bounded_child_context",
+        "prompt": "Does the fingerprint and continuation context use bounded child summaries instead of raw child data?"
+      },
+      {
+        "id": "no_auto_child_run",
+        "prompt": "Does parent continuation avoid auto-running child tasks?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "deterministic_child_result_fingerprint": "Yes. The runtime hashes stable summary-safe child task/run IDs, source provenance, final state, bounded completion summary preview, and bounded final response preview.",
+      "same_fingerprint_replay_guard": "Yes. Parent task.run checks for an already consumed child_completion_fingerprint before appending TaskRunning or starting another parent agent-loop pass.",
+      "changed_result_admission": "Yes. A different bounded child completion evidence set produces a different fingerprint and can be admitted separately.",
+      "bounded_child_context": "Yes. The fingerprint inputs are the same bounded inspection summaries used for parent join context and exclude raw prompts, provider responses, files, command output, environment values, tool inputs, and request bodies.",
+      "no_auto_child_run": "Yes. Parent task.run only inspects existing controlled child completion state and never invokes task.run for children.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "Parent continuation has a deterministic summary-safe child completion fingerprint.",
+    "The first continuation for a completed controlled child result set is admitted.",
+    "Repeating parent continuation for the same child completion fingerprint does not start another parent agent-loop pass.",
+    "A materially different controlled completed child result set can be admitted.",
+    "Incomplete or non-controlled child tasks do not satisfy the join continuation gate.",
+    "Parent continuation does not auto-run child tasks.",
+    "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, or serialized request bodies are added to parent continuation context or replay guard state.",
+    "Existing single-child and multi-child materialization behavior remains compatible.",
+    "Explicit controlled child task.run admission remains compatible.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_context_tokens": [
+      "ParentJoinContinuationFingerprintConsumed",
+      "parent_join_continuation:"
+    ],
+    "rust_runtime_tokens": [
+      "ParentJoinContinuationFingerprintConsumed",
+      "parent_join_child_completion_fingerprint",
+      "parent_join_child_completion_fingerprint_consumed",
+      "task_run_rejects_repeated_parent_join_for_same_child_completion_fingerprint",
+      "task_run_admits_parent_join_when_child_completion_fingerprint_changes"
+    ]
+  }
+}

--- a/docs/specifications/agent-loop-spec-v0.md
+++ b/docs/specifications/agent-loop-spec-v0.md
@@ -185,3 +185,9 @@ Valid structured input changes the runtime entity rather than adding another blo
 M5.16 lets one accepted handoff envelope materialize one queued child task for each distinct covered candidate. The agent loop still performs no scheduler handoff and does not run those children automatically; it only creates controlled runtime entities with parent/source provenance and candidate-scoped replay protection.
 
 Each child keeps the per-candidate sanitized `source_intent_summary`, requested goal, and requested mode when present. Explicit child `task.run` remains the only execution path, and no process execution, network access, service control, patch apply, or workspace write capability is added.
+
+## M5.17-M5.18 controlled parent join continuation
+
+Once controlled children have been explicitly run to completion, a completed parent can be explicitly continued through `task.run`. The continuation receives only bounded child completion summaries as context; it does not run children, schedule work, or expose raw child prompts, raw provider responses, files, command output, environment values, raw tool input objects, or serialized request bodies.
+
+M5.18 adds replay protection for that join point. The runtime records a deterministic summary-safe child completion fingerprint when parent continuation is admitted, and it rejects another parent agent-loop pass for the same fingerprint before `TaskRunning` is appended. If the controlled child result evidence materially changes, the new fingerprint can be admitted separately.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -826,3 +826,15 @@ M5.16 extends controlled child materialization across all distinct candidates co
 Duplicate prevention is scoped to `parent_run_id + source_candidate_id + source_handoff_envelope_fingerprint`, so rerunning materialization for the same envelope reuses existing children without blocking different candidates from the same envelope. Each child keeps its own parent/source provenance, per-candidate `source_intent_summary`, sanitized `requested_goal_preview`, and sanitized `requested_mode_id` when available.
 
 Parent `task.run` still does not run child tasks, and each child remains limited to the existing explicit queued child `task.run` admission path. M5.16 adds no scheduler handoff, external worker, process execution expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, raw `input` persistence, or new blocked summary wrapper.
+
+## M5.17 parent join continuation
+
+M5.17 allows an explicit `task.run` call on a completed parent task after all controlled child tasks for that parent run have completed. The parent continuation consumes bounded `child_completion_summaries` derived from child inspection state, including child task/run IDs, source candidate IDs, source handoff envelope fingerprints, completion final state, bounded completion summary previews, and bounded final response previews.
+
+The parent does not auto-run child tasks. Incomplete or non-controlled children reject the parent continuation before the parent status is changed to `Running`. Raw child prompts, provider responses, file content, command strings, stdout, stderr, environment values, raw tool inputs, and serialized request bodies are not exposed in the parent continuation context.
+
+## M5.18 parent join continuation replay guard
+
+M5.18 makes parent join continuation replay-safe. Before a completed parent is moved back to `Running`, the runtime derives a deterministic summary-safe child completion fingerprint from the controlled completed child evidence and records `ParentJoinContinuationFingerprintConsumed` for the admitted fingerprint.
+
+Repeating `task.run` for the same parent and unchanged child completion fingerprint is rejected before another `TaskRunning` / agent-loop pass starts. A materially different controlled completed child result set produces a different fingerprint and can be admitted. This phase adds no scheduler handoff, child auto-run, external worker, process execution expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, raw child data persistence, or blocked summary wrapper.

--- a/docs/specifications/task-runtime-spec-v0.md
+++ b/docs/specifications/task-runtime-spec-v0.md
@@ -302,6 +302,14 @@ M5.13 makes child run state visible from the parent inspection path. `RunInspect
 
 Each child summary is derived from child `TaskRecord` state and child ledger metadata. It reports child status, provenance, event count, completion final state, bounded completion summary preview, and sanitized final response preview when available. It does not run child tasks, mutate the parent ledger, expose raw prompts/provider responses/file content/command output, or add scheduler handoff.
 
+## M5.17 parent join continuation
+
+M5.17 permits explicit `task.run` on a completed parent task only when every controlled child for the parent run is also completed and has completed agent-loop evidence. The parent receives bounded child completion summaries and remains responsible for its own agent-loop pass; child tasks are not run automatically.
+
+## M5.18 parent join continuation replay guard
+
+M5.18 records a deterministic summary-safe child completion fingerprint when parent join continuation is admitted. The same completed child result fingerprint cannot start another parent agent-loop pass, while materially different completed child evidence can produce a new fingerprint and be admitted. The guard is enforced before the parent status changes back to `Running`.
+
 ## M5.14 child task source intent materialization
 
 M5.14 stores a sanitized `source_intent_summary` on controlled child `TaskRecord` state when the child is materialized from an accepted handoff envelope. The summary is reconstructed from the parent run's approved `SubtaskOrchestrationQueued` evidence and includes only `tool_id`, `required_action`, bounded `request_reason`, and bounded `input_summary`.

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.17';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.17.json';
+const phase = 'M5.18';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.18.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'completed_child_parent_join_continuation',
-    `${phase} must declare the completed child parent join continuation transition.`
+    manifest.concrete_capability_transition === 'replay_safe_parent_join_continuation',
+    `${phase} must declare the replay-safe parent join continuation transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_parent_join_continuation',
-    `${phase} must forbid adding another blocked summary wrapper without parent join continuation.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_parent_join_replay_guard',
+    `${phase} must forbid adding another blocked summary wrapper without parent join replay protection.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,13 +75,13 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'completed controlled child tasks',
-    'parent join continuation',
-    'child_completion_summaries',
-    'bounded completion_summary_preview and final_response_preview',
-    'Non-controlled child tasks do not satisfy parent join continuation',
+    'deterministic summary-safe child completion fingerprint',
+    'first continuation',
+    'same child completion fingerprint',
+    'materially different controlled completed child result set',
+    'Incomplete or non-controlled child tasks',
+    'Parent continuation does not auto-run child tasks',
     'No raw child prompts',
-    'Parent task.run does not auto-run child tasks',
     'No scheduler handoff'
   ]) {
     requireManifestValue(
@@ -121,6 +121,17 @@ function validateSourceEvidence(manifest) {
 
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   const storeText = readText('crates/brownie-store/src/lib.rs');
+  for (const token of [
+    'parent_join_child_completion_fingerprint',
+    'parent_join_child_completion_fingerprint_consumed',
+    'ParentJoinContinuationFingerprintConsumed',
+    'task_run_rejects_repeated_parent_join_for_same_child_completion_fingerprint',
+    'task_run_admits_parent_join_when_child_completion_fingerprint_changes'
+  ]) {
+    if (!runtimeText.includes(token) && !storeText.includes(token)) {
+      errors.push(`${phase} source must include ${token}.`);
+    }
+  }
   const forbiddenWrapperEvents = [
     'SubtaskDispatchTicketRecorded',
     'SubtaskAdmissionTokenRecorded',


### PR DESCRIPTION
## 概要

M5.18 の実装です。M5.17 で追加された completed parent の parent join / continuation に、summary-safe な replay guard を追加しました。

## 変更内容

- controlled completed child evidence から deterministic な `child_completion_fingerprint` を生成
- parent continuation admit 時に `ParentJoinContinuationFingerprintConsumed` を parent run ledger へ記録
- 同じ `child_completion_fingerprint` の再 `task.run` を `TaskRunning` / agent-loop 開始前に拒否
- child completion evidence が materially different な場合は別 fingerprint として parent continuation を admit
- context materializer / sanitized ledger timeline に replay guard metadata を追加
- `guard-phase-value.mjs` を M5.18 固有 manifest 検証へ更新
- M5.18 phase value manifest と runtime/task/agent-loop specs を追加更新

## Safety boundary

この PR は次を追加しません。

- scheduler handoff
- child auto-run
- external worker
- process exec expansion
- network bypass
- service control
- patch apply
- direct workspace mutation path
- diagnostics wrapper RPC
- raw child data persistence
- new blocked summary wrapper

Replay guard の fingerprint input は bounded inspection evidence のみです。raw child prompts、raw provider responses、raw file content、command strings、stdout/stderr、environment values、raw tool input objects、serialized request bodies は保存・露出しません。

## 検証

- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
