### PR TITLE
M5.19: atomic parent continuation admission

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -2338,6 +2338,7 @@ pub struct ChildTaskInspectSummary {
     pub event_count: usize,
     pub has_agent_loop_completed: bool,
     pub completion_final_state: Option<String>,
+    pub completion_result_fingerprint: Option<String>,
     pub completion_summary_preview: Option<String>,
     pub final_response_preview: Option<String>,
 }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -179,7 +179,10 @@ use brownie_protocol::{
     WorkspacePatchReviewReportSummary, WorkspacePatchReviewSignalSummary,
     WorkspacePatchReviewVerdictSummary,
 };
-use brownie_store::{BrownieStore, ChildTaskStartParams, LedgerEvent, LedgerEventKind};
+use brownie_store::{
+    BrownieStore, ChildTaskStartParams, LedgerEvent, LedgerEventKind,
+    ParentJoinContinuationRunAdmission,
+};
 use brownie_tools::{
     BuiltinToolRegistry, RejectedToolIntent, ToolExecutionRequest, ToolExecutionStatus,
     ToolExecutor, ToolIntentDecision, ToolIntentEvaluator, ToolIntentParser, ToolPlanDecision,
@@ -1762,29 +1765,34 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     };
     let child_completion_summaries = admission.child_completion_summaries();
 
-    if let Some(consumption) = admission.parent_join_continuation_consumption() {
-        if let Err(error) = store.tasks().append_task_event_with_payload(
-            &record,
-            LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
-            Some(json!({
-                "parent_join_continuation_status": "Consumed",
-                "child_completion_fingerprint": consumption.child_completion_fingerprint,
-                "child_completion_child_count": consumption.child_completion_child_count,
-                "fingerprint_input_count": consumption.child_completion_fingerprint_input_count,
-                "reason": "Parent join continuation admitted for this completed controlled child result fingerprint."
-            })),
+    let running = match admission.parent_join_continuation_consumption() {
+        Some(consumption) => match store.tasks().admit_parent_join_continuation(
+            &record.task_id,
+            ParentJoinContinuationRunAdmission {
+                child_completion_fingerprint: consumption.child_completion_fingerprint,
+                child_completion_child_count: consumption.child_completion_child_count,
+                child_completion_fingerprint_input_count: consumption
+                    .child_completion_fingerprint_input_count,
+            },
         ) {
-            return error_response(id, -32603, &format!("internal error: {error}"));
-        }
-    }
-
-    let running = match store.tasks().update_task_status(
-        &record.task_id,
-        TaskStatus::Running,
-        LedgerEventKind::TaskRunning,
-    ) {
-        Ok(record) => record,
-        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+            Ok(Some(record)) => record,
+            Ok(None) => {
+                return error_response(
+                    id,
+                    -32602,
+                    "invalid params: parent join continuation for this completed child result set has already been consumed",
+                );
+            }
+            Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+        },
+        None => match store.tasks().update_task_status(
+            &record.task_id,
+            TaskStatus::Running,
+            LedgerEventKind::TaskRunning,
+        ) {
+            Ok(record) => record,
+            Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+        },
     };
 
     let policy = match resolve_policy_for_task_run(&running, &store) {
@@ -1874,6 +1882,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
     };
     let mut agent_loop_final_state = result.final_state;
     let mut agent_loop_completion_summary = result.completion_summary.clone();
+    let mut agent_loop_final_response_content = result.llm_response.content.clone();
 
     if let Err(error) = append_sensitive_scan_event(
         &store,
@@ -2012,6 +2021,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         };
         agent_loop_final_state = second_pass.final_state;
         agent_loop_completion_summary = second_pass.completion_summary.clone();
+        agent_loop_final_response_content = second_pass.llm_response.content.clone();
         if let Err(error) = append_sensitive_scan_event(
             &store,
             &running,
@@ -2068,6 +2078,11 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Some(json!({
             "final_state": agent_loop_state_name(agent_loop_final_state),
             "completion_summary": agent_loop_completion_summary.clone(),
+            "completion_result_fingerprint": completion_result_fingerprint(
+                agent_loop_final_state,
+                &agent_loop_completion_summary,
+                &agent_loop_final_response_content,
+            ),
         })),
     ) {
         return error_response(id, -32603, &format!("internal error: {error}"));
@@ -2149,6 +2164,7 @@ fn append_sensitive_scan_event(
     )
 }
 
+#[derive(Debug)]
 enum TaskRunAdmissionRejection {
     InvalidParams(&'static str),
     Internal(String),
@@ -2341,17 +2357,13 @@ fn parent_join_child_completion_evidence(
         .completion_final_state
         .as_deref()
         .unwrap_or("<none>");
-    let completion_summary_preview = summary
-        .completion_summary_preview
-        .as_deref()
-        .unwrap_or("<none>");
-    let final_response_preview = summary
-        .final_response_preview
+    let completion_result_fingerprint = summary
+        .completion_result_fingerprint
         .as_deref()
         .unwrap_or("<none>");
     let status = format!("{:?}", summary.status);
     let summary_text = format!(
-        "completed_child task_id={} run_id={} status={:?} source_candidate_id={} source_handoff_envelope_fingerprint={} completion_final_state={} completion_summary_preview={} final_response_preview={}",
+        "completed_child task_id={} run_id={} status={:?} source_candidate_id={} source_handoff_envelope_fingerprint={} completion_final_state={} completion_result_fingerprint={} completion_summary_preview={} final_response_preview={}",
         summary.task_id,
         summary.run_id,
         summary.status,
@@ -2365,6 +2377,10 @@ fn parent_join_child_completion_evidence(
             .unwrap_or("<none>"),
         summary
             .completion_final_state
+            .as_deref()
+            .unwrap_or("<none>"),
+        summary
+            .completion_result_fingerprint
             .as_deref()
             .unwrap_or("<none>"),
         summary
@@ -2388,8 +2404,7 @@ fn parent_join_child_completion_evidence(
             format!("source_handoff_envelope_id={source_handoff_envelope_id}"),
             format!("source_handoff_envelope_fingerprint={source_handoff_envelope_fingerprint}"),
             format!("completion_final_state={completion_final_state}"),
-            format!("completion_summary_preview={completion_summary_preview}"),
-            format!("final_response_preview={final_response_preview}"),
+            format!("completion_result_fingerprint={completion_result_fingerprint}"),
         ],
     })
 }
@@ -2398,7 +2413,7 @@ fn parent_join_child_completion_fingerprint(
     child_evidence: &[ParentJoinChildCompletionEvidence],
 ) -> (String, usize) {
     let mut inputs = vec![
-        "parent_join_child_completion_fingerprint_v1".to_string(),
+        "parent_join_child_completion_fingerprint_v2".to_string(),
         format!("child_count={}", child_evidence.len()),
     ];
     for evidence in child_evidence {
@@ -2421,13 +2436,31 @@ fn parent_join_child_completion_fingerprint_consumed(
         .read_ledger_events(&record.run_id)
         .map_err(|error| TaskRunAdmissionRejection::Internal(error.to_string()))?;
     Ok(events.iter().any(|event| {
-        event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
-            && event
-                .payload
-                .as_ref()
-                .and_then(|payload| payload.get("child_completion_fingerprint"))
-                .and_then(Value::as_str)
-                == Some(child_completion_fingerprint)
+        if event.kind != LedgerEventKind::ParentJoinContinuationFingerprintConsumed {
+            return false;
+        }
+        let Some(payload) = event.payload.as_ref() else {
+            return false;
+        };
+        if payload
+            .get("child_completion_fingerprint")
+            .and_then(Value::as_str)
+            != Some(child_completion_fingerprint)
+        {
+            return false;
+        }
+        let Some(admission_id) = payload.get("admission_id").and_then(Value::as_str) else {
+            return true;
+        };
+        events.iter().any(|candidate| {
+            candidate.kind == LedgerEventKind::TaskRunning
+                && candidate
+                    .payload
+                    .as_ref()
+                    .and_then(|payload| payload.get("admission_id"))
+                    .and_then(Value::as_str)
+                    == Some(admission_id)
+        })
     }))
 }
 
@@ -9497,6 +9530,22 @@ fn hex_sha256(bytes: &[u8]) -> String {
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
+fn completion_result_fingerprint(
+    final_state: AgentLoopState,
+    completion_summary: &str,
+    final_response_content: &str,
+) -> String {
+    let canonical = json!({
+        "version": "completion_result_fingerprint_v1",
+        "final_state": agent_loop_state_name(final_state),
+        "completion_summary_chars": completion_summary.chars().count(),
+        "completion_summary_sha256": format!("sha256:{}", hex_sha256(completion_summary.as_bytes())),
+        "final_response_chars": final_response_content.chars().count(),
+        "final_response_sha256": format!("sha256:{}", hex_sha256(final_response_content.as_bytes())),
+    });
+    format!("sha256:{}", hex_sha256(canonical.to_string().as_bytes()))
+}
+
 fn system_time_unix_ms(time: std::time::SystemTime) -> Option<i64> {
     time.duration_since(std::time::UNIX_EPOCH)
         .ok()
@@ -9654,6 +9703,8 @@ fn child_task_inspect_summary(
             )
         })
         .unwrap_or((None, None));
+    let completion_result_fingerprint =
+        child_completion_result_fingerprint(&events, completion_event);
     let final_response_preview =
         latest_content_preview(&events, LedgerEventKind::SecondPassLlmResponseReceived)
             .or_else(|| latest_content_preview(&events, LedgerEventKind::LlmResponseReceived));
@@ -9671,9 +9722,46 @@ fn child_task_inspect_summary(
         event_count: events.len(),
         has_agent_loop_completed: completion_event.is_some(),
         completion_final_state,
+        completion_result_fingerprint,
         completion_summary_preview,
         final_response_preview,
     })
+}
+
+fn child_completion_result_fingerprint(
+    events: &[LedgerEvent],
+    completion_event: Option<&LedgerEvent>,
+) -> Option<String> {
+    let payload = completion_event?.payload.as_ref()?;
+    if let Some(fingerprint) = payload
+        .get("completion_result_fingerprint")
+        .and_then(Value::as_str)
+        .filter(|fingerprint| fingerprint.starts_with("sha256:"))
+    {
+        return Some(fingerprint.to_string());
+    }
+
+    let final_state = payload.get("final_state").and_then(Value::as_str)?;
+    let completion_summary = payload
+        .get("completion_summary")
+        .and_then(Value::as_str)
+        .unwrap_or("");
+    let final_response_preview =
+        latest_content_preview(events, LedgerEventKind::SecondPassLlmResponseReceived)
+            .or_else(|| latest_content_preview(events, LedgerEventKind::LlmResponseReceived))
+            .unwrap_or_default();
+    let canonical = json!({
+        "version": "completion_result_fingerprint_legacy_v1",
+        "final_state": final_state,
+        "completion_summary_chars": completion_summary.chars().count(),
+        "completion_summary_sha256": format!("sha256:{}", hex_sha256(completion_summary.as_bytes())),
+        "final_response_preview_chars": final_response_preview.chars().count(),
+        "final_response_preview_sha256": format!("sha256:{}", hex_sha256(final_response_preview.as_bytes())),
+    });
+    Some(format!(
+        "sha256:{}",
+        hex_sha256(canonical.to_string().as_bytes())
+    ))
 }
 
 fn latest_content_preview(events: &[LedgerEvent], kind: LedgerEventKind) -> Option<String> {
@@ -14877,6 +14965,10 @@ mod tests {
         assert!(child_summary["event_count"].as_u64().expect("event count") > 1);
         assert_eq!(child_summary["has_agent_loop_completed"], true);
         assert_eq!(child_summary["completion_final_state"], "Completed");
+        assert!(child_summary["completion_result_fingerprint"]
+            .as_str()
+            .expect("completion result fingerprint")
+            .starts_with("sha256:"));
         assert!(child_summary["completion_summary_preview"]
             .as_str()
             .expect("completion summary preview")
@@ -15075,6 +15167,9 @@ mod tests {
             .as_str()
             .expect("child completion fingerprint")
             .starts_with("sha256:"));
+        let admission_id = consumption_payload["admission_id"]
+            .as_str()
+            .expect("parent join admission id");
         assert_eq!(consumption_payload["child_completion_child_count"], 1);
         assert!(
             consumption_payload["fingerprint_input_count"]
@@ -15096,6 +15191,11 @@ mod tests {
             .map(|(index, _)| index)
             .expect("second TaskRunning index");
         assert!(consumption_index < second_running_index);
+        let second_running_payload = parent_events[second_running_index]
+            .payload
+            .as_ref()
+            .expect("second TaskRunning payload");
+        assert_eq!(second_running_payload["admission_id"], admission_id);
         let continuation_prompt_payload = parent_events
             .iter()
             .rev()
@@ -15117,6 +15217,266 @@ mod tests {
         assert!(continuation_prompt_preview.contains("final_response_preview=Fake LLM"));
         assert!(!continuation_prompt_preview.contains("RAW_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
         assert!(!continuation_prompt_preview.contains("RAW_CHILD_FILE_CONTENT_SHOULD_NOT_APPEAR"));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_parent_join_fingerprint_uses_result_fingerprint_not_preview() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+
+        let store = BrownieStore::new(temp.path());
+        let completed_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get completed child")
+            .expect("completed child");
+        let common_preview = "x".repeat(CHILD_COMPLETION_SUMMARY_PREVIEW_CHARS);
+        let first_summary = format!("{common_preview}A");
+        let second_summary = format!("{common_preview}B");
+        assert_eq!(
+            preview_with_limit(&first_summary, CHILD_COMPLETION_SUMMARY_PREVIEW_CHARS),
+            preview_with_limit(&second_summary, CHILD_COMPLETION_SUMMARY_PREVIEW_CHARS)
+        );
+
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_child,
+                LedgerEventKind::AgentLoopCompleted,
+                Some(json!({
+                    "final_state": "Completed",
+                    "completion_summary": first_summary.clone(),
+                    "completion_result_fingerprint": completion_result_fingerprint(
+                        AgentLoopState::Completed,
+                        &first_summary,
+                        "same final response content"
+                    )
+                })),
+            )
+            .expect("append first long completion");
+
+        let first_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(first_parent_join.error.is_none());
+
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_child,
+                LedgerEventKind::AgentLoopCompleted,
+                Some(json!({
+                    "final_state": "Completed",
+                    "completion_summary": second_summary.clone(),
+                    "completion_result_fingerprint": completion_result_fingerprint(
+                        AgentLoopState::Completed,
+                        &second_summary,
+                        "same final response content"
+                    )
+                })),
+            )
+            .expect("append second long completion");
+
+        let second_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(second_parent_join.error.is_none());
+        assert_eq!(
+            second_parent_join
+                .result
+                .expect("second parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events");
+        let fingerprints = parent_events
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| {
+                event
+                    .payload
+                    .as_ref()
+                    .and_then(|payload| payload.get("child_completion_fingerprint"))
+                    .and_then(Value::as_str)
+                    .map(ToString::to_string)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(fingerprints.len(), 2);
+        assert_ne!(fingerprints[0], fingerprints[1]);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_parent_join_recovers_orphaned_consumption_without_running() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+
+        let store = BrownieStore::new(temp.path());
+        let parent = store
+            .tasks()
+            .get_task(&parent_task_id)
+            .expect("get parent")
+            .expect("parent");
+        let completed_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get completed child")
+            .expect("completed child");
+        let child_evidence = vec![
+            parent_join_child_completion_evidence(&store, &completed_child)
+                .expect("child evidence"),
+        ];
+        let (child_completion_fingerprint, input_count) =
+            parent_join_child_completion_fingerprint(&child_evidence);
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &parent,
+                LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
+                Some(json!({
+                    "parent_join_continuation_status": "Consumed",
+                    "admission_id": "orphaned-admission",
+                    "child_completion_fingerprint": child_completion_fingerprint,
+                    "child_completion_child_count": 1,
+                    "fingerprint_input_count": input_count,
+                    "reason": "Synthetic orphaned consumption without TaskRunning."
+                })),
+            )
+            .expect("append orphaned consumption");
+
+        let parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(parent_join.error.is_none());
+        assert_eq!(
+            parent_join.result.expect("parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events");
+        let committed_consumptions = parent_events
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter(|event| {
+                let admission_id = event
+                    .payload
+                    .as_ref()
+                    .and_then(|payload| payload.get("admission_id"))
+                    .and_then(Value::as_str);
+                admission_id.is_some_and(|admission_id| {
+                    parent_events.iter().any(|candidate| {
+                        candidate.kind == LedgerEventKind::TaskRunning
+                            && candidate
+                                .payload
+                                .as_ref()
+                                .and_then(|payload| payload.get("admission_id"))
+                                .and_then(Value::as_str)
+                                == Some(admission_id)
+                    })
+                })
+            })
+            .count();
+        assert_eq!(committed_consumptions, 1);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_parent_join_concurrent_admission_consumes_once() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+
+        let request_a = format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        );
+        let request_b = format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        );
+        let handle_a = std::thread::spawn(move || parse_line(&request_a));
+        let handle_b = std::thread::spawn(move || parse_line(&request_b));
+        let responses = vec![
+            handle_a.join().expect("join parent run a"),
+            handle_b.join().expect("join parent run b"),
+        ];
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| response.result.is_some())
+                .count(),
+            1
+        );
+        assert_eq!(
+            responses
+                .iter()
+                .filter(|response| response.error.is_some())
+                .count(),
+            1
+        );
+
+        let store = BrownieStore::new(temp.path());
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events");
+        assert_eq!(
+            parent_events
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                .count(),
+            2
+        );
+        assert_eq!(
+            parent_events
+                .iter()
+                .filter(|event| {
+                    event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+                })
+                .count(),
+            1
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -2452,7 +2452,7 @@ fn parent_join_child_completion_fingerprint_consumed(
         let Some(admission_id) = payload.get("admission_id").and_then(Value::as_str) else {
             return true;
         };
-        events.iter().any(|candidate| {
+        let Some(running_index) = events.iter().position(|candidate| {
             candidate.kind == LedgerEventKind::TaskRunning
                 && candidate
                     .payload
@@ -2460,7 +2460,23 @@ fn parent_join_child_completion_fingerprint_consumed(
                     .and_then(|payload| payload.get("admission_id"))
                     .and_then(Value::as_str)
                     == Some(admission_id)
-        })
+        }) else {
+            return false;
+        };
+        for candidate in events.iter().skip(running_index + 1) {
+            if candidate.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed {
+                return false;
+            }
+            if matches!(
+                candidate.kind,
+                LedgerEventKind::TaskCompleted
+                    | LedgerEventKind::TaskFailed
+                    | LedgerEventKind::TaskCancelled
+            ) {
+                return true;
+            }
+        }
+        false
     }))
 }
 
@@ -15325,7 +15341,7 @@ mod tests {
     }
 
     #[test]
-    fn task_run_parent_join_recovers_orphaned_consumption_without_running() {
+    fn task_run_parent_join_recovers_orphaned_admission_without_terminal() {
         let _guard = ENV_LOCK.lock().expect("env lock");
         let temp = tempfile::tempdir().expect("tempdir");
         std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
@@ -15371,6 +15387,18 @@ mod tests {
                 })),
             )
             .expect("append orphaned consumption");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &parent,
+                LedgerEventKind::TaskRunning,
+                Some(json!({
+                    "admission_id": "orphaned-admission",
+                    "admission_kind": "parent_join_continuation",
+                    "reason": "Synthetic TaskRunning without terminal completion."
+                })),
+            )
+            .expect("append orphaned TaskRunning");
 
         let parent_join = parse_line(&format!(
             r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
@@ -15397,7 +15425,7 @@ mod tests {
                     .and_then(|payload| payload.get("admission_id"))
                     .and_then(Value::as_str);
                 admission_id.is_some_and(|admission_id| {
-                    parent_events.iter().any(|candidate| {
+                    let Some(running_index) = parent_events.iter().position(|candidate| {
                         candidate.kind == LedgerEventKind::TaskRunning
                             && candidate
                                 .payload
@@ -15405,7 +15433,25 @@ mod tests {
                                 .and_then(|payload| payload.get("admission_id"))
                                 .and_then(Value::as_str)
                                 == Some(admission_id)
-                    })
+                    }) else {
+                        return false;
+                    };
+                    for candidate in parent_events.iter().skip(running_index + 1) {
+                        if candidate.kind
+                            == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+                        {
+                            return false;
+                        }
+                        if matches!(
+                            candidate.kind,
+                            LedgerEventKind::TaskCompleted
+                                | LedgerEventKind::TaskFailed
+                                | LedgerEventKind::TaskCancelled
+                        ) {
+                            return true;
+                        }
+                    }
+                    false
                 })
             })
             .count();

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -1,8 +1,10 @@
 //! Brownie persistence crate.
 
 use std::fs::{self, OpenOptions};
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, ErrorKind, Write};
 use std::path::PathBuf;
+use std::thread;
+use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use brownie_protocol::{ChildTaskSourceIntentSummary, TaskRecord, TaskStartParams, TaskStatus};
@@ -12,6 +14,8 @@ use uuid::Uuid;
 
 pub const WORKSPACE_STATE_DIR: &str = ".brownie";
 pub const RUNS_DIR: &str = "runs";
+const RUN_ADMISSION_LOCK_RETRIES: usize = 200;
+const RUN_ADMISSION_LOCK_SLEEP: Duration = Duration::from_millis(10);
 
 #[derive(Debug, Clone)]
 pub struct BrownieStore {
@@ -57,6 +61,13 @@ pub struct ChildTaskStartParams {
     pub source_handoff_envelope_id: String,
     pub source_handoff_envelope_fingerprint: String,
     pub source_intent_summary: Option<ChildTaskSourceIntentSummary>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentJoinContinuationRunAdmission {
+    pub child_completion_fingerprint: String,
+    pub child_completion_child_count: usize,
+    pub child_completion_fingerprint_input_count: usize,
 }
 
 impl TaskStore {
@@ -154,6 +165,63 @@ impl TaskStore {
         self.write_task_state(&record)?;
         self.append_task_event(&record, event_kind)?;
         Ok(record)
+    }
+
+    pub fn admit_parent_join_continuation(
+        &self,
+        task_id: &str,
+        admission: ParentJoinContinuationRunAdmission,
+    ) -> Result<Option<TaskRecord>> {
+        let Some(initial_record) = self.get_task(task_id)? else {
+            bail!("task not found: {task_id}");
+        };
+        let _lock = self.acquire_run_admission_lock(&initial_record.run_id)?;
+        let Some(mut record) = self.get_task(task_id)? else {
+            bail!("task not found after admission lock: {task_id}");
+        };
+        if record.run_id != initial_record.run_id {
+            bail!("task run id changed during parent join admission: {task_id}");
+        }
+        if record.status != TaskStatus::Completed {
+            return Ok(None);
+        }
+        let events = self.read_ledger_events(&record.run_id)?;
+        if parent_join_continuation_fingerprint_consumed_in_events(
+            &events,
+            &admission.child_completion_fingerprint,
+        ) {
+            return Ok(None);
+        }
+
+        let admission_id = format!("parent_join_admission_{}", Uuid::new_v4().simple());
+        record.status = TaskStatus::Running;
+        record.updated_at = timestamp()?;
+        self.write_task_state(&record)?;
+        self.append_task_events_with_payloads(
+            &record,
+            vec![
+                (
+                    LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
+                    Some(serde_json::json!({
+                        "parent_join_continuation_status": "Consumed",
+                        "admission_id": admission_id.clone(),
+                        "child_completion_fingerprint": admission.child_completion_fingerprint,
+                        "child_completion_child_count": admission.child_completion_child_count,
+                        "fingerprint_input_count": admission.child_completion_fingerprint_input_count,
+                        "reason": "Parent join continuation admitted atomically for this completed controlled child result fingerprint."
+                    })),
+                ),
+                (
+                    LedgerEventKind::TaskRunning,
+                    Some(serde_json::json!({
+                        "admission_id": admission_id.clone(),
+                        "admission_kind": "parent_join_continuation",
+                        "reason": "Parent join continuation running after atomic fingerprint consumption."
+                    })),
+                ),
+            ],
+        )?;
+        Ok(Some(record))
     }
 
     pub fn get_task(&self, task_id: &str) -> Result<Option<TaskRecord>> {
@@ -255,7 +323,15 @@ impl TaskStore {
             .with_context(|| format!("failed to create {}", run_dir.display()))?;
         let state =
             serde_json::to_string_pretty(record).context("failed to serialize task state")?;
-        fs::write(run_dir.join("state.json"), state).context("failed to write task state")
+        let state_path = run_dir.join("state.json");
+        let tmp_path = run_dir.join(format!("state.json.tmp-{}", Uuid::new_v4().simple()));
+        fs::write(&tmp_path, state).context("failed to write temporary task state")?;
+        fs::rename(&tmp_path, &state_path).with_context(|| {
+            format!(
+                "failed to atomically replace task state {}",
+                state_path.display()
+            )
+        })
     }
 
     pub fn append_task_event(&self, record: &TaskRecord, kind: LedgerEventKind) -> Result<()> {
@@ -268,18 +344,64 @@ impl TaskStore {
         kind: LedgerEventKind,
         payload: Option<serde_json::Value>,
     ) -> Result<()> {
-        RunLedger::new(self.run_dir(&record.run_id)).append(&LedgerEvent {
-            event_id: format!("event_{}", Uuid::new_v4()),
-            task_id: record.task_id.clone(),
-            run_id: record.run_id.clone(),
-            kind,
-            timestamp: timestamp()?,
-            payload,
-        })
+        self.append_task_events_with_payloads(record, vec![(kind, payload)])
     }
 
     pub fn read_ledger_events(&self, run_id: &str) -> Result<Vec<LedgerEvent>> {
         RunLedger::new(self.run_dir(run_id)).read_events()
+    }
+
+    fn append_task_events_with_payloads(
+        &self,
+        record: &TaskRecord,
+        events: Vec<(LedgerEventKind, Option<serde_json::Value>)>,
+    ) -> Result<()> {
+        let ledger_events = events
+            .into_iter()
+            .map(|(kind, payload)| {
+                Ok(LedgerEvent {
+                    event_id: format!("event_{}", Uuid::new_v4()),
+                    task_id: record.task_id.clone(),
+                    run_id: record.run_id.clone(),
+                    kind,
+                    timestamp: timestamp()?,
+                    payload,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        RunLedger::new(self.run_dir(&record.run_id)).append_many(&ledger_events)
+    }
+
+    fn acquire_run_admission_lock(&self, run_id: &str) -> Result<RunAdmissionLock> {
+        let run_dir = self.run_dir(run_id);
+        fs::create_dir_all(&run_dir)
+            .with_context(|| format!("failed to create {}", run_dir.display()))?;
+        let lock_path = run_dir.join("parent-join-admission.lock");
+        for _ in 0..RUN_ADMISSION_LOCK_RETRIES {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&lock_path)
+            {
+                Ok(mut file) => {
+                    writeln!(file, "{}", timestamp()?)
+                        .context("failed to write run admission lock heartbeat")?;
+                    return Ok(RunAdmissionLock { path: lock_path });
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    thread::sleep(RUN_ADMISSION_LOCK_SLEEP);
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("failed to acquire {}", lock_path.display()));
+                }
+            }
+        }
+        bail!(
+            "run admission lock remained busy after {} attempts: {}",
+            RUN_ADMISSION_LOCK_RETRIES,
+            lock_path.display()
+        )
     }
 
     fn runs_dir(&self) -> PathBuf {
@@ -288,6 +410,17 @@ impl TaskStore {
 
     pub fn workspace_root(&self) -> &std::path::Path {
         &self.workspace_root
+    }
+}
+
+#[derive(Debug)]
+struct RunAdmissionLock {
+    path: PathBuf,
+}
+
+impl Drop for RunAdmissionLock {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.path);
     }
 }
 
@@ -304,15 +437,25 @@ impl RunLedger {
     }
 
     pub fn append(&self, event: &LedgerEvent) -> Result<()> {
+        self.append_many(std::slice::from_ref(event))
+    }
+
+    pub fn append_many(&self, events: &[LedgerEvent]) -> Result<()> {
         fs::create_dir_all(&self.run_dir)
             .with_context(|| format!("failed to create {}", self.run_dir.display()))?;
+        let mut buffer = Vec::new();
+        for event in events {
+            serde_json::to_writer(&mut buffer, event)
+                .context("failed to serialize ledger event")?;
+            writeln!(&mut buffer).context("failed to write ledger newline")?;
+        }
         let mut file = OpenOptions::new()
             .create(true)
             .append(true)
             .open(self.run_dir.join("ledger.jsonl"))
             .context("failed to open run ledger")?;
-        serde_json::to_writer(&mut file, event).context("failed to serialize ledger event")?;
-        writeln!(file).context("failed to write ledger newline")?;
+        file.write_all(&buffer)
+            .context("failed to append run ledger events")?;
         Ok(())
     }
 
@@ -338,6 +481,42 @@ impl RunLedger {
         }
         Ok(events)
     }
+}
+
+fn parent_join_continuation_fingerprint_consumed_in_events(
+    events: &[LedgerEvent],
+    child_completion_fingerprint: &str,
+) -> bool {
+    events.iter().any(|event| {
+        if event.kind != LedgerEventKind::ParentJoinContinuationFingerprintConsumed {
+            return false;
+        }
+        let Some(payload) = event.payload.as_ref() else {
+            return false;
+        };
+        if payload
+            .get("child_completion_fingerprint")
+            .and_then(serde_json::Value::as_str)
+            != Some(child_completion_fingerprint)
+        {
+            return false;
+        }
+        let Some(admission_id) = payload
+            .get("admission_id")
+            .and_then(serde_json::Value::as_str)
+        else {
+            return true;
+        };
+        events.iter().any(|candidate| {
+            candidate.kind == LedgerEventKind::TaskRunning
+                && candidate
+                    .payload
+                    .as_ref()
+                    .and_then(|payload| payload.get("admission_id"))
+                    .and_then(serde_json::Value::as_str)
+                    == Some(admission_id)
+        })
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -194,9 +194,6 @@ impl TaskStore {
         }
 
         let admission_id = format!("parent_join_admission_{}", Uuid::new_v4().simple());
-        record.status = TaskStatus::Running;
-        record.updated_at = timestamp()?;
-        self.write_task_state(&record)?;
         self.append_task_events_with_payloads(
             &record,
             vec![
@@ -221,6 +218,9 @@ impl TaskStore {
                 ),
             ],
         )?;
+        record.status = TaskStatus::Running;
+        record.updated_at = timestamp()?;
+        self.write_task_state(&record)?;
         Ok(Some(record))
     }
 
@@ -507,7 +507,7 @@ fn parent_join_continuation_fingerprint_consumed_in_events(
         else {
             return true;
         };
-        events.iter().any(|candidate| {
+        let Some(running_index) = events.iter().position(|candidate| {
             candidate.kind == LedgerEventKind::TaskRunning
                 && candidate
                     .payload
@@ -515,7 +515,23 @@ fn parent_join_continuation_fingerprint_consumed_in_events(
                     .and_then(|payload| payload.get("admission_id"))
                     .and_then(serde_json::Value::as_str)
                     == Some(admission_id)
-        })
+        }) else {
+            return false;
+        };
+        for candidate in events.iter().skip(running_index + 1) {
+            if candidate.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed {
+                return false;
+            }
+            if matches!(
+                candidate.kind,
+                LedgerEventKind::TaskCompleted
+                    | LedgerEventKind::TaskFailed
+                    | LedgerEventKind::TaskCancelled
+            ) {
+                return true;
+            }
+        }
+        false
     })
 }
 

--- a/docs/architecture/phase-value-manifest.m5.19.json
+++ b/docs/architecture/phase-value-manifest.m5.19.json
@@ -39,7 +39,7 @@
       },
       {
         "id": "failure_recovery",
-        "prompt": "Can orphaned consumption without TaskRunning be distinguished from committed admission?"
+        "prompt": "Can orphaned consumption without terminal completion be distinguished from committed admission?"
       },
       {
         "id": "safety_boundary",
@@ -51,7 +51,7 @@
       "preview_not_replay_identity": "Yes. Parent join fingerprint inputs use child/run/source/envelope identity, completion_final_state, and completion_result_fingerprint; previews remain display/context fields.",
       "atomic_parent_join_admission": "Yes. TaskStore::admit_parent_join_continuation acquires a run-scoped lock, rereads state/ledger, checks consumption, writes Running state, and appends consumption plus TaskRunning together.",
       "concurrent_replay_guard": "Yes. The run admission lock and reread prevent two concurrent task.run calls from consuming the same parent join fingerprint.",
-      "failure_recovery": "Yes. New consumed events carry admission_id and count as committed only when a matching TaskRunning exists; orphaned consumption can be retried.",
+      "failure_recovery": "Yes. New consumed events carry admission_id and count as committed only when a matching TaskRunning and later terminal event exist; orphaned admission can be retried.",
       "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, process execution expansion, or continuation child materialization."
     }
   },
@@ -62,7 +62,7 @@
     "Repeated parent continuation for the same child completion fingerprint is rejected before another parent agent-loop pass starts.",
     "Parent continuation admission is protected by run/task-scoped exclusion or an equivalent atomic TaskStore operation.",
     "Concurrent task.run admits at most one parent continuation for the same fingerprint.",
-    "Orphaned consumption without matching TaskRunning has defined recovery behavior.",
+    "Orphaned consumption without matching terminal completion has defined recovery behavior.",
     "Existing child materialization, explicit child task.run, multi-candidate materialization, child inspection, parent join continuation, and replay rejection remain compatible.",
     "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, or serialized request bodies are persisted or exposed.",
     "No scheduler handoff, external worker, child auto-run, continuation child materialization, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
@@ -81,7 +81,7 @@
       "completion_result_fingerprint",
       "parent_join_child_completion_fingerprint_v2",
       "task_run_parent_join_fingerprint_uses_result_fingerprint_not_preview",
-      "task_run_parent_join_recovers_orphaned_consumption_without_running",
+      "task_run_parent_join_recovers_orphaned_admission_without_terminal",
       "task_run_parent_join_concurrent_admission_consumes_once"
     ],
     "vsix_protocol_tokens": [

--- a/docs/architecture/phase-value-manifest.m5.19.json
+++ b/docs/architecture/phase-value-manifest.m5.19.json
@@ -1,0 +1,91 @@
+{
+  "phase": "M5.19",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "atomic_parent_continuation_admission_with_completion_result_fingerprint",
+  "forbidden_pattern": "continuation_child_materialization_or_new_wrapper_before_atomic_admission_hardening",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Hardens parent join continuation so replay identity uses child completion result fingerprints instead of bounded display previews."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Makes parent continuation admission an atomic state transition before another parent agent-loop pass starts."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Removes a persistence and concurrency blocker before scheduler handoff or controlled automatic child dispatch can be designed safely."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "completion_result_fingerprint",
+        "prompt": "Does child completion record a canonical sanitized result fingerprint?"
+      },
+      {
+        "id": "preview_not_replay_identity",
+        "prompt": "Does parent join replay identity avoid bounded completion/final-response previews?"
+      },
+      {
+        "id": "atomic_parent_join_admission",
+        "prompt": "Does parent join admission atomically consume the fingerprint while transitioning to Running?"
+      },
+      {
+        "id": "concurrent_replay_guard",
+        "prompt": "Does concurrent parent continuation admit at most one run for the same fingerprint?"
+      },
+      {
+        "id": "failure_recovery",
+        "prompt": "Can orphaned consumption without TaskRunning be distinguished from committed admission?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "completion_result_fingerprint": "Yes. AgentLoopCompleted records completion_result_fingerprint as a SHA-256 over canonical result hashes without persisting raw provider response content.",
+      "preview_not_replay_identity": "Yes. Parent join fingerprint inputs use child/run/source/envelope identity, completion_final_state, and completion_result_fingerprint; previews remain display/context fields.",
+      "atomic_parent_join_admission": "Yes. TaskStore::admit_parent_join_continuation acquires a run-scoped lock, rereads state/ledger, checks consumption, writes Running state, and appends consumption plus TaskRunning together.",
+      "concurrent_replay_guard": "Yes. The run admission lock and reread prevent two concurrent task.run calls from consuming the same parent join fingerprint.",
+      "failure_recovery": "Yes. New consumed events carry admission_id and count as committed only when a matching TaskRunning exists; orphaned consumption can be retried.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, process execution expansion, or continuation child materialization."
+    }
+  },
+  "exit_criteria": [
+    "Child completion records completion_result_fingerprint.",
+    "Parent join replay identity does not use bounded previews.",
+    "Materially different child completion results with identical bounded previews produce distinct parent join fingerprints.",
+    "Repeated parent continuation for the same child completion fingerprint is rejected before another parent agent-loop pass starts.",
+    "Parent continuation admission is protected by run/task-scoped exclusion or an equivalent atomic TaskStore operation.",
+    "Concurrent task.run admits at most one parent continuation for the same fingerprint.",
+    "Orphaned consumption without matching TaskRunning has defined recovery behavior.",
+    "Existing child materialization, explicit child task.run, multi-candidate materialization, child inspection, parent join continuation, and replay rejection remain compatible.",
+    "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, or serialized request bodies are persisted or exposed.",
+    "No scheduler handoff, external worker, child auto-run, continuation child materialization, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_store_tokens": [
+      "ParentJoinContinuationRunAdmission",
+      "admit_parent_join_continuation",
+      "acquire_run_admission_lock",
+      "parent_join_continuation_fingerprint_consumed_in_events"
+    ],
+    "rust_protocol_tokens": [
+      "completion_result_fingerprint"
+    ],
+    "rust_runtime_tokens": [
+      "completion_result_fingerprint",
+      "parent_join_child_completion_fingerprint_v2",
+      "task_run_parent_join_fingerprint_uses_result_fingerprint_not_preview",
+      "task_run_parent_join_recovers_orphaned_consumption_without_running",
+      "task_run_parent_join_concurrent_admission_consumes_once"
+    ],
+    "vsix_protocol_tokens": [
+      "completion_result_fingerprint"
+    ]
+  }
+}

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -291,6 +291,7 @@ export interface ChildTaskInspectSummary {
   event_count: number;
   has_agent_loop_completed: boolean;
   completion_final_state?: string | null;
+  completion_result_fingerprint?: string | null;
   completion_summary_preview?: string | null;
   final_response_preview?: string | null;
 }
@@ -2610,6 +2611,7 @@ export function isChildTaskInspectSummary(value: unknown): value is ChildTaskIns
     isNonNegativeInteger(value.event_count) &&
     typeof value.has_agent_loop_completed === 'boolean' &&
     (value.completion_final_state === undefined || value.completion_final_state === null || typeof value.completion_final_state === 'string') &&
+    (value.completion_result_fingerprint === undefined || value.completion_result_fingerprint === null || typeof value.completion_result_fingerprint === 'string') &&
     (value.completion_summary_preview === undefined || value.completion_summary_preview === null || typeof value.completion_summary_preview === 'string') &&
     (value.final_response_preview === undefined || value.final_response_preview === null || typeof value.final_response_preview === 'string')
   );

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -80,7 +80,7 @@ function validateManifest(manifest) {
     'identical bounded previews',
     'run/task-scoped exclusion',
     'Concurrent task.run',
-    'Orphaned consumption',
+    'Orphaned consumption without matching terminal completion',
     'No raw child prompts',
     'No scheduler handoff'
   ]) {
@@ -127,7 +127,7 @@ function validateSourceEvidence(manifest) {
     'admit_parent_join_continuation',
     'parent_join_child_completion_fingerprint_v2',
     'task_run_parent_join_fingerprint_uses_result_fingerprint_not_preview',
-    'task_run_parent_join_recovers_orphaned_consumption_without_running',
+    'task_run_parent_join_recovers_orphaned_admission_without_terminal',
     'task_run_parent_join_concurrent_admission_consumes_once'
   ]) {
     if (!runtimeText.includes(token) && !storeText.includes(token)) {

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.18';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.18.json';
+const phase = 'M5.19';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.19.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'replay_safe_parent_join_continuation',
-    `${phase} must declare the replay-safe parent join continuation transition.`
+    manifest.concrete_capability_transition === 'atomic_parent_continuation_admission_with_completion_result_fingerprint',
+    `${phase} must declare the atomic parent continuation admission transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_without_parent_join_replay_guard',
-    `${phase} must forbid adding another blocked summary wrapper without parent join replay protection.`
+    manifest.forbidden_pattern === 'continuation_child_materialization_or_new_wrapper_before_atomic_admission_hardening',
+    `${phase} must forbid continuation child materialization or wrapper-only work before atomic admission hardening.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,12 +75,12 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'deterministic summary-safe child completion fingerprint',
-    'first continuation',
-    'same child completion fingerprint',
-    'materially different controlled completed child result set',
-    'Incomplete or non-controlled child tasks',
-    'Parent continuation does not auto-run child tasks',
+    'completion_result_fingerprint',
+    'does not use bounded previews',
+    'identical bounded previews',
+    'run/task-scoped exclusion',
+    'Concurrent task.run',
+    'Orphaned consumption',
     'No raw child prompts',
     'No scheduler handoff'
   ]) {
@@ -122,11 +122,13 @@ function validateSourceEvidence(manifest) {
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   const storeText = readText('crates/brownie-store/src/lib.rs');
   for (const token of [
-    'parent_join_child_completion_fingerprint',
-    'parent_join_child_completion_fingerprint_consumed',
-    'ParentJoinContinuationFingerprintConsumed',
-    'task_run_rejects_repeated_parent_join_for_same_child_completion_fingerprint',
-    'task_run_admits_parent_join_when_child_completion_fingerprint_changes'
+    'completion_result_fingerprint',
+    'ParentJoinContinuationRunAdmission',
+    'admit_parent_join_continuation',
+    'parent_join_child_completion_fingerprint_v2',
+    'task_run_parent_join_fingerprint_uses_result_fingerprint_not_preview',
+    'task_run_parent_join_recovers_orphaned_consumption_without_running',
+    'task_run_parent_join_concurrent_admission_consumes_once'
   ]) {
     if (!runtimeText.includes(token) && !storeText.includes(token)) {
       errors.push(`${phase} source must include ${token}.`);
@@ -138,7 +140,8 @@ function validateSourceEvidence(manifest) {
     'SubtaskSchedulerPacketRecorded',
     'SubtaskHandoffReceiptRecorded',
     'SubtaskChildRunAdmissionSummaryRecorded',
-    'SubtaskChildRunResultSummaryRecorded'
+    'SubtaskChildRunResultSummaryRecorded',
+    'SubtaskContinuationChildMaterialized'
   ];
   for (const token of forbiddenWrapperEvents) {
     if (runtimeText.includes(token) || storeText.includes(token)) {


### PR DESCRIPTION
## Summary

M5.19 は PR #109 / M5.18 の parent join replay guard を harden します。今回の実体的な capability gain は、parent continuation admission を preview 依存から外し、TaskStore 側で atomic に fingerprint consume と `Running` transition を扱えるようにすることです。

## What changed

- child completion の `AgentLoopCompleted` payload に `completion_result_fingerprint` を記録しました。raw provider response は保存せず、completion summary / final response の hash と長さから作る canonical hash のみを保存します。
- parent join fingerprint input を `completion_summary_preview` / `final_response_preview` から切り離し、child/run/source/envelope identity、`completion_final_state`、`completion_result_fingerprint` に変更しました。
- `TaskStore::admit_parent_join_continuation` を追加し、run-scoped lock の下で最新 state/ledger を再読込し、未消費確認、`Running` state 書き込み、`ParentJoinContinuationFingerprintConsumed` + `TaskRunning` append を一体化しました。
- `admission_id` を consumption と `TaskRunning` に記録し、`TaskRunning` に対応しない orphan consumption は committed consumption と見なさない recovery behavior を追加しました。
- `run.inspect` の child summary protocol に `completion_result_fingerprint` を追加しました。
- M5.19 固有の phase value manifest / guard を追加し、wrapper-only work や continuation child materialization への逸脱を拒否します。

## Safety boundary

追加していません。

- scheduler handoff
- child auto-run
- external worker
- process exec expansion
- network bypass
- service control
- patch apply
- direct workspace mutation
- diagnostics wrapper RPC
- raw child prompt / provider response / file content / command output persistence
- continuation-produced child materialization
- new `Blocked` summary wrapper

## Validation

- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test -p brownie-runtime parent_join -- --nocapture`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
