### PR TITLE
M5.21: harden multi-cycle parent joins

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -12075,6 +12075,43 @@ fn queued_subtask_id_from_event(event: &LedgerEvent) -> Option<String> {
         .map(ToString::to_string)
 }
 
+fn parent_join_continuation_window(
+    events: &[LedgerEvent],
+    consumption_index: usize,
+) -> &[LedgerEvent] {
+    let start_index = consumption_index + 1;
+    let end_index = events
+        .iter()
+        .enumerate()
+        .skip(start_index)
+        .find_map(|(index, event)| {
+            if event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+                || matches!(
+                    event.kind,
+                    LedgerEventKind::TaskCompleted
+                        | LedgerEventKind::TaskFailed
+                        | LedgerEventKind::TaskCancelled
+                )
+            {
+                Some(index)
+            } else {
+                None
+            }
+        })
+        .unwrap_or(events.len());
+    &events[start_index..end_index]
+}
+
+fn queued_subtask_ids_from_events(events: &[LedgerEvent]) -> Vec<String> {
+    let mut candidate_ids = events
+        .iter()
+        .filter_map(queued_subtask_id_from_event)
+        .collect::<Vec<_>>();
+    candidate_ids.sort();
+    candidate_ids.dedup();
+    candidate_ids
+}
+
 fn source_intent_summary_fingerprint_inputs(
     source_candidate_id: &str,
     source_intent_summary: Option<&ChildTaskSourceIntentSummary>,
@@ -12143,13 +12180,8 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
         return Ok(());
     };
 
-    let mut candidate_ids = events
-        .iter()
-        .skip(consumption_index + 1)
-        .filter_map(queued_subtask_id_from_event)
-        .collect::<Vec<_>>();
-    candidate_ids.sort();
-    candidate_ids.dedup();
+    let continuation_events = parent_join_continuation_window(&events, consumption_index);
+    let candidate_ids = queued_subtask_ids_from_events(continuation_events);
     if candidate_ids.is_empty() {
         return Ok(());
     }
@@ -12170,7 +12202,8 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
         format!("candidate_count={}", candidate_ids.len()),
     ];
     for candidate_id in &candidate_ids {
-        let source_intent_summary = queued_subtask_source_intent_summary(&events, candidate_id);
+        let source_intent_summary =
+            queued_subtask_source_intent_summary(continuation_events, candidate_id);
         fingerprint_inputs.extend(source_intent_summary_fingerprint_inputs(
             candidate_id,
             source_intent_summary.as_ref(),
@@ -15628,6 +15661,260 @@ mod tests {
             .expect("get completed continuation child")
             .expect("completed continuation child");
         assert_eq!(completed_continuation_child.status, TaskStatus::Completed);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_parent_join_materializes_second_continuation_cycle_without_stale_candidates() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, initial_child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        let initial_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            initial_child.task_id
+        ));
+        assert!(initial_child_run.error.is_none());
+        assert_eq!(
+            initial_child_run.result.expect("initial child run result")["status"],
+            "Completed"
+        );
+
+        let first_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(first_parent_join.error.is_none());
+        assert_eq!(
+            first_parent_join.result.expect("first parent join result")["status"],
+            "Completed"
+        );
+
+        let store = BrownieStore::new(temp.path());
+        let first_continuation_child = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after first join")
+            .into_iter()
+            .find(|record| {
+                record.parent_run_id.as_deref() == Some(parent_run_id.as_str())
+                    && record.task_id != initial_child.task_id
+            })
+            .expect("first continuation child");
+        assert_eq!(first_continuation_child.status, TaskStatus::Queued);
+
+        let parent_events_after_first_join = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after first join");
+        let parent_event_count_after_first_join = parent_events_after_first_join.len();
+        let repeat_before_new_child_completion = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(repeat_before_new_child_completion.result.is_none());
+        assert_eq!(
+            repeat_before_new_child_completion
+                .error
+                .expect("repeat before child completion error")
+                .code,
+            -32602
+        );
+        assert_eq!(
+            store
+                .tasks()
+                .read_ledger_events(&parent_run_id)
+                .expect("parent events after rejected repeat")
+                .len(),
+            parent_event_count_after_first_join
+        );
+
+        let first_continuation_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":6,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            first_continuation_child.task_id
+        ));
+        assert!(first_continuation_child_run.error.is_none());
+        assert_eq!(
+            first_continuation_child_run
+                .result
+                .expect("first continuation child run result")["status"],
+            "Completed"
+        );
+
+        let second_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":7,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(second_parent_join.error.is_none());
+        assert_eq!(
+            second_parent_join
+                .result
+                .expect("second parent join result")["status"],
+            "Completed"
+        );
+
+        let second_continuation_child = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after second join")
+            .into_iter()
+            .find(|record| {
+                record.parent_run_id.as_deref() == Some(parent_run_id.as_str())
+                    && record.task_id != initial_child.task_id
+                    && record.task_id != first_continuation_child.task_id
+            })
+            .expect("second continuation child");
+        assert_eq!(second_continuation_child.status, TaskStatus::Queued);
+        assert_eq!(
+            second_continuation_child.parent_task_id.as_deref(),
+            Some(parent_task_id.as_str())
+        );
+        assert_eq!(
+            second_continuation_child.parent_run_id.as_deref(),
+            Some(parent_run_id.as_str())
+        );
+        assert_ne!(
+            second_continuation_child.source_candidate_id,
+            first_continuation_child.source_candidate_id
+        );
+        assert!(validate_controlled_queued_child_task_provenance(
+            &second_continuation_child,
+            &store
+        )
+        .is_ok());
+
+        let second_child_events = store
+            .tasks()
+            .read_ledger_events(&second_continuation_child.run_id)
+            .expect("second continuation child ledger");
+        assert_eq!(second_child_events.len(), 1);
+        assert_eq!(second_child_events[0].kind, LedgerEventKind::TaskStarted);
+        let second_child_started_payload = second_child_events[0]
+            .payload
+            .as_ref()
+            .expect("second child started payload");
+        assert_eq!(second_child_started_payload["status"], "Queued");
+        assert_eq!(second_child_started_payload["execution_enabled"], false);
+        assert_eq!(
+            second_child_started_payload["scheduler_handoff_enabled"],
+            false
+        );
+        assert!(second_child_started_payload["source_intent_summary"]
+            .get("input")
+            .is_none());
+        assert!(!second_child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+
+        let parent_events = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after second join");
+        let continuation_consumptions = parent_events
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| event.payload.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(continuation_consumptions.len(), 2);
+        let admission_ids = continuation_consumptions
+            .iter()
+            .map(|payload| {
+                payload["admission_id"]
+                    .as_str()
+                    .expect("admission id")
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+        assert_ne!(admission_ids[0], admission_ids[1]);
+        assert_eq!(
+            continuation_consumptions[0]["child_completion_child_count"],
+            1
+        );
+        assert_eq!(
+            continuation_consumptions[1]["child_completion_child_count"],
+            2
+        );
+        assert_ne!(
+            continuation_consumptions[0]["child_completion_fingerprint"],
+            continuation_consumptions[1]["child_completion_fingerprint"]
+        );
+
+        let continuation_envelopes = parent_events
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded)
+            .filter_map(|event| event.payload.as_ref())
+            .filter(|payload| {
+                payload
+                    .get("continuation_materialization")
+                    .and_then(Value::as_bool)
+                    == Some(true)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(continuation_envelopes.len(), 2);
+        let first_envelope = continuation_envelopes
+            .iter()
+            .find(|payload| {
+                payload
+                    .get("parent_join_admission_id")
+                    .and_then(Value::as_str)
+                    == Some(admission_ids[0].as_str())
+            })
+            .expect("first continuation envelope");
+        let second_envelope = continuation_envelopes
+            .iter()
+            .find(|payload| {
+                payload
+                    .get("parent_join_admission_id")
+                    .and_then(Value::as_str)
+                    == Some(admission_ids[1].as_str())
+            })
+            .expect("second continuation envelope");
+        assert_eq!(
+            first_envelope["parent_join_child_completion_child_count"],
+            1
+        );
+        assert_eq!(
+            second_envelope["parent_join_child_completion_child_count"],
+            2
+        );
+
+        let first_candidate = first_continuation_child
+            .source_candidate_id
+            .as_deref()
+            .expect("first continuation candidate id");
+        let second_candidate = second_continuation_child
+            .source_candidate_id
+            .as_deref()
+            .expect("second continuation candidate id");
+        let first_envelope_candidates = payload_string_array(first_envelope, "candidate_ids");
+        let second_envelope_candidates = payload_string_array(second_envelope, "candidate_ids");
+        assert_eq!(first_envelope_candidates, vec![first_candidate.to_string()]);
+        assert_eq!(
+            second_envelope_candidates,
+            vec![second_candidate.to_string()]
+        );
+        assert!(!second_envelope_candidates.contains(&first_candidate.to_string()));
+
+        let parent = store
+            .tasks()
+            .get_task(&parent_task_id)
+            .expect("get parent")
+            .expect("parent");
+        materialize_controlled_child_task_from_handoff_envelope(&store, &parent)
+            .expect("multi-envelope idempotent materialization");
+        assert_eq!(
+            store
+                .tasks()
+                .list_tasks()
+                .expect("list tasks after idempotency")
+                .iter()
+                .filter(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+                .count(),
+            3
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/docs/architecture/phase-value-manifest.m5.21.json
+++ b/docs/architecture/phase-value-manifest.m5.21.json
@@ -1,0 +1,88 @@
+{
+  "phase": "M5.21",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "multi_cycle_parent_child_orchestration",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_multi_cycle_parent_child_runtime_progress",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Hardens parent/child orchestration across multiple explicit continuation cycles over real controlled child TaskRecords."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Keeps parent continuation progress inside the Rust-owned agent loop and task ledger instead of stopping after one child materialization."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Moves long-running work loops closer to sustained bounded parent/child iteration without scheduler auto-dispatch or child auto-run."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "multi_cycle_parent_child_orchestration",
+        "prompt": "Can a parent complete two explicit continuation cycles over controlled child TaskRecords?"
+      },
+      {
+        "id": "new_child_changes_fingerprint",
+        "prompt": "Does completing a continuation-produced child change the parent join fingerprint and admit the next continuation?"
+      },
+      {
+        "id": "same_result_replay_rejected",
+        "prompt": "Does the same completed child result set remain replay-rejected before a new child completes?"
+      },
+      {
+        "id": "admission_scoped_envelopes",
+        "prompt": "Are continuation handoff envelopes scoped by parent_join_admission_id without stale candidate capture?"
+      },
+      {
+        "id": "multi_envelope_idempotency",
+        "prompt": "Does re-running materialization avoid duplicate children across multiple accepted envelopes?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "multi_cycle_parent_child_orchestration": "Yes. Tests cover initial child completion, first parent continuation child materialization, explicit continuation child run, second parent continuation, and second continuation child materialization.",
+      "new_child_changes_fingerprint": "Yes. The second parent continuation consumes an expanded child result set with a distinct preview-independent parent join fingerprint.",
+      "same_result_replay_rejected": "Yes. Repeating parent task.run before the continuation child completes is rejected and does not append parent ledger events.",
+      "admission_scoped_envelopes": "Yes. Continuation envelope candidate collection is bounded to the event window for the matching parent_join_admission_id and stops at terminal or later admission boundaries.",
+      "multi_envelope_idempotency": "Yes. Materialization remains keyed by parent_run_id, source candidate id, and handoff envelope fingerprint, so re-running over multiple accepted envelopes does not duplicate children.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "A parent can perform two explicit continuation cycles over controlled child TaskRecords.",
+    "Completing a continuation-produced child changes the parent join fingerprint and admits the next parent continuation.",
+    "The same completed child result set remains rejected before any new child completion.",
+    "The second continuation cycle can materialize a new controlled queued child TaskRecord.",
+    "Continuation handoff envelopes are scoped by parent_join_admission_id and do not capture stale candidates from previous admissions.",
+    "Re-running materialization does not duplicate children from any accepted envelope.",
+    "Every child execution remains explicit task.run; No child auto-run occurs.",
+    "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, or serialized request bodies are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "parent_join_continuation_window",
+      "queued_subtask_ids_from_events",
+      "append_parent_join_continuation_handoff_envelope_recorded",
+      "parent_join_admission_id",
+      "multi-envelope idempotent materialization",
+      "task_run_parent_join_materializes_second_continuation_cycle_without_stale_candidates",
+      "materialize_controlled_child_task_from_handoff_envelope",
+      "validate_controlled_queued_child_task_provenance"
+    ],
+    "rust_store_tokens": [
+      "ParentJoinContinuationRunAdmitted",
+      "admit_parent_join_continuation"
+    ],
+    "rust_llm_tokens": [
+      "Fake LLM parent continuation request"
+    ]
+  }
+}

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.20';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.20.json';
+const phase = 'M5.21';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.21.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'continuation_subtask_materialization',
-    `${phase} must declare the continuation subtask materialization transition.`
+    manifest.concrete_capability_transition === 'multi_cycle_parent_child_orchestration',
+    `${phase} must declare the multi-cycle parent/child orchestration transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_continuation_child_materialization',
-    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without continuation child materialization.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_multi_cycle_parent_child_runtime_progress',
+    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without multi-cycle runtime progress.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,10 +75,13 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'controlled queued child TaskRecord',
-    'Existing earlier parent-run handoff/materialization events do not suppress',
-    'Repeating the same continuation/source intent does not create duplicate children',
-    'explicit child task.run',
+    'two explicit continuation cycles',
+    'Completing a continuation-produced child changes the parent join fingerprint',
+    'same completed child result set remains rejected',
+    'second continuation cycle can materialize',
+    'parent_join_admission_id',
+    'Re-running materialization does not duplicate',
+    'explicit task.run',
     'No child auto-run',
     'No raw child prompts',
     'No scheduler handoff'
@@ -124,12 +127,12 @@ function validateSourceEvidence(manifest) {
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   const storeText = readText('crates/brownie-store/src/lib.rs');
   for (const token of [
-    'ParentJoinContinuationRunAdmitted',
-    'admit_parent_join_continuation',
+    'parent_join_continuation_window',
+    'queued_subtask_ids_from_events',
     'append_parent_join_continuation_handoff_envelope_recorded',
-    'm5.20_parent_join_continuation_handoff_envelope_v1',
-    'continuation_subtask_materialization',
-    'task_run_parent_join_materializes_continuation_subtask_without_auto_run',
+    'parent_join_admission_id',
+    'multi-envelope idempotent materialization',
+    'task_run_parent_join_materializes_second_continuation_cycle_without_stale_candidates',
     'materialize_controlled_child_task_from_handoff_envelope',
     'validate_controlled_queued_child_task_provenance'
   ]) {


### PR DESCRIPTION
## 概要

M5.21 として、M5.20 の continuation-produced child materialization を複数サイクルの parent/child orchestration に進めます。

主な変更:

- `parent_join_continuation_window` を追加し、continuation handoff envelope の candidate collection を該当 `parent_join_admission_id` の event window に限定しました。
- `queued_subtask_ids_from_events` で continuation window 内の candidate IDs のみを sort/dedup し、前後の admission candidate を巻き込まないようにしました。
- `task_run_parent_join_materializes_second_continuation_cycle_without_stale_candidates` を追加し、初回 child completion、first parent continuation、continuation child の明示 `task.run`、second parent continuation、second continuation child materialization を検証しました。
- M5.21 用 `phase-value-manifest.m5.21.json` と `guard:phase-value` 更新を追加しました。

## Capability gain

Brownie は一回だけ continuation child を作る状態から、明示的な child completion を挟んだ複数サイクルの parent continuation を安全に進められるようになります。同じ completed child result set の replay は拒否され、新しい continuation child completion によって parent join fingerprint が変わった場合だけ次の continuation が admit されます。

## Safety boundary

この PR は scheduler auto-dispatch、child auto-run、external worker、process exec expansion、network bypass、service control、patch apply、direct workspace mutation、diagnostics wrapper RPC、raw child data persistence、新しい `Blocked` summary wrapper を追加しません。

## Checks

- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
