### PR TITLE
M5.23: close recovery child join cycle

### DIFF
--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -277,6 +277,24 @@ impl FakeLlm {
             .collect::<Vec<_>>()
             .join("\n")
             .to_lowercase();
+        if prompt.contains("failed_child")
+            && prompt.contains("completed_child")
+            && prompt.contains("orchestrator")
+        {
+            let intent = serde_json::json!({
+                "tool_requests": [{
+                    "tool_id": "subtask.spawn",
+                    "reason": "Continue recovery after explicit recovery child completion."
+                }]
+            });
+            return LlmResponse {
+                content: format!(
+                    "Fake LLM recovery-child completion continuation request with {} messages.\n\n```brownie-tool-intent\n{}\n```",
+                    request.messages.len(),
+                    serde_json::to_string_pretty(&intent).expect("fake intent serializes")
+                ),
+            };
+        }
         if prompt.contains("failed_child") && prompt.contains("orchestrator") {
             let intent = serde_json::json!({
                 "tool_requests": [{

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1776,6 +1776,8 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                 child_completion_child_count: consumption.child_completion_child_count,
                 child_completion_fingerprint_input_count: consumption
                     .child_completion_fingerprint_input_count,
+                child_terminal_completed_count: consumption.child_terminal_completed_count,
+                child_terminal_failed_count: consumption.child_terminal_failed_count,
             },
         ) {
             Ok(Some(admitted)) => {
@@ -2197,6 +2199,8 @@ struct ParentJoinContinuationAdmission {
     child_completion_fingerprint: String,
     child_completion_fingerprint_input_count: usize,
     child_completion_child_count: usize,
+    child_terminal_completed_count: usize,
+    child_terminal_failed_count: usize,
 }
 
 impl TaskRunAdmission {
@@ -2215,6 +2219,8 @@ impl TaskRunAdmission {
                 child_completion_fingerprint_input_count: admission
                     .child_completion_fingerprint_input_count,
                 child_completion_child_count: admission.child_completion_child_count,
+                child_terminal_completed_count: admission.child_terminal_completed_count,
+                child_terminal_failed_count: admission.child_terminal_failed_count,
             }),
         }
     }
@@ -2231,6 +2237,8 @@ impl TaskRunAdmission {
                     child_completion_fingerprint_input_count: admission
                         .child_completion_fingerprint_input_count,
                     child_completion_child_count: admission.child_completion_child_count,
+                    child_terminal_completed_count: admission.child_terminal_completed_count,
+                    child_terminal_failed_count: admission.child_terminal_failed_count,
                 })
             }
         }
@@ -2241,6 +2249,8 @@ struct ParentJoinContinuationConsumption {
     child_completion_fingerprint: String,
     child_completion_fingerprint_input_count: usize,
     child_completion_child_count: usize,
+    child_terminal_completed_count: usize,
+    child_terminal_failed_count: usize,
 }
 
 #[derive(Clone)]
@@ -2249,6 +2259,8 @@ struct ParentJoinContinuationMaterialization {
     child_completion_fingerprint: String,
     child_completion_fingerprint_input_count: usize,
     child_completion_child_count: usize,
+    child_terminal_completed_count: usize,
+    child_terminal_failed_count: usize,
 }
 
 fn validate_task_run_admission(
@@ -2319,6 +2331,14 @@ fn validate_completed_parent_join_continuation_admission(
         .iter()
         .map(|child| parent_join_child_completion_evidence(store, child))
         .collect::<Result<Vec<_>, _>>()?;
+    let child_terminal_completed_count = child_tasks
+        .iter()
+        .filter(|child| child.status == TaskStatus::Completed)
+        .count();
+    let child_terminal_failed_count = child_tasks
+        .iter()
+        .filter(|child| child.status == TaskStatus::Failed)
+        .count();
     let (child_completion_fingerprint, child_completion_fingerprint_input_count) =
         parent_join_child_completion_fingerprint(&child_evidence);
     if parent_join_child_completion_fingerprint_consumed(
@@ -2347,6 +2367,8 @@ fn validate_completed_parent_join_continuation_admission(
         child_completion_fingerprint,
         child_completion_fingerprint_input_count,
         child_completion_child_count: child_tasks.len(),
+        child_terminal_completed_count,
+        child_terminal_failed_count,
     })
 }
 
@@ -12372,6 +12394,14 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
             "parent_join_child_completion_child_count={}",
             continuation.child_completion_child_count
         ),
+        format!(
+            "parent_join_terminal_completed_child_count={}",
+            continuation.child_terminal_completed_count
+        ),
+        format!(
+            "parent_join_terminal_failed_child_count={}",
+            continuation.child_terminal_failed_count
+        ),
         format!("candidate_count={}", candidate_ids.len()),
     ];
     for candidate_id in &candidate_ids {
@@ -12402,7 +12432,10 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
             "parent_join_admission_id": continuation.admission_id,
             "parent_join_child_completion_fingerprint": continuation.child_completion_fingerprint,
             "parent_join_child_completion_child_count": continuation.child_completion_child_count,
+            "parent_join_terminal_completed_child_count": continuation.child_terminal_completed_count,
+            "parent_join_terminal_failed_child_count": continuation.child_terminal_failed_count,
             "parent_join_fingerprint_input_count": continuation.child_completion_fingerprint_input_count,
+            "parent_join_recovery_cycle": continuation.child_terminal_failed_count > 0 && continuation.child_terminal_completed_count > 0,
             "queued_count": candidate_count,
             "source_event_count": candidate_count,
             "status": "Accepted",
@@ -16153,6 +16186,363 @@ mod tests {
             parent_join_child_completion_evidence(&store, &failed_child).expect("second evidence");
         let (second_fingerprint, _) = parent_join_child_completion_fingerprint(&[second_evidence]);
         assert_ne!(first_fingerprint, second_fingerprint);
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_parent_join_recovery_child_completion_materializes_next_cycle_without_auto_run() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, initial_child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        configure_strict_missing_openai_for_test();
+        let failed_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            initial_child.task_id
+        ));
+        assert!(failed_child_run.result.is_none());
+        assert_eq!(
+            failed_child_run.error.expect("failed child run error").code,
+            -32603
+        );
+        clear_llm_env_for_test();
+
+        let store = BrownieStore::new(temp.path());
+        let failed_child = store
+            .tasks()
+            .get_task(&initial_child.task_id)
+            .expect("get failed child")
+            .expect("failed child");
+        assert_eq!(failed_child.status, TaskStatus::Failed);
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &failed_child,
+                LedgerEventKind::PromptBuilt,
+                Some(json!({
+                    "prompt_preview": "RAW_M5_23_FAILED_CHILD_PROMPT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append failed child raw prompt marker");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &failed_child,
+                LedgerEventKind::ToolExecutionCompleted,
+                Some(json!({
+                    "tool_id": "workspace.read",
+                    "status": "Completed",
+                    "output_preview": "RAW_M5_23_FAILED_CHILD_OUTPUT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append failed child raw output marker");
+
+        let first_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(first_parent_join.error.is_none());
+        assert_eq!(
+            first_parent_join.result.expect("first parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_children_after_first_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after first failed-child join")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(parent_children_after_first_join.len(), 2);
+        let recovery_child = parent_children_after_first_join
+            .iter()
+            .find(|record| record.task_id != failed_child.task_id)
+            .expect("recovery child")
+            .clone();
+        assert_eq!(recovery_child.status, TaskStatus::Queued);
+        assert_eq!(
+            recovery_child
+                .source_intent_summary
+                .as_ref()
+                .expect("recovery source intent")
+                .request_reason,
+            "Recover failed controlled child task."
+        );
+        let recovery_events_before_run = store
+            .tasks()
+            .read_ledger_events(&recovery_child.run_id)
+            .expect("recovery child events before explicit run");
+        assert_eq!(recovery_events_before_run.len(), 1);
+        assert_eq!(
+            recovery_events_before_run[0].kind,
+            LedgerEventKind::TaskStarted
+        );
+        assert!(!recovery_events_before_run
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+
+        let parent_events_after_first_join = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after first failed-child join");
+        let first_event_count = parent_events_after_first_join.len();
+        let first_consumption = parent_events_after_first_join
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| event.payload.as_ref())
+            .next()
+            .expect("first parent join consumption payload");
+        let first_fingerprint = first_consumption["child_completion_fingerprint"]
+            .as_str()
+            .expect("first fingerprint")
+            .to_string();
+        assert_eq!(first_consumption["child_completion_child_count"], 1);
+        assert_eq!(first_consumption["child_terminal_failed_count"], 1);
+        assert_eq!(first_consumption["child_terminal_completed_count"], 0);
+
+        let repeat_before_recovery_terminal = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(repeat_before_recovery_terminal.result.is_none());
+        assert_eq!(
+            repeat_before_recovery_terminal
+                .error
+                .expect("repeat before recovery terminal error")
+                .code,
+            -32602
+        );
+        assert_eq!(
+            store
+                .tasks()
+                .read_ledger_events(&parent_run_id)
+                .expect("parent events after rejected recovery replay")
+                .len(),
+            first_event_count
+        );
+
+        let recovery_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":6,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            recovery_child.task_id
+        ));
+        assert!(recovery_child_run.error.is_none());
+        assert_eq!(
+            recovery_child_run
+                .result
+                .expect("recovery child run result")["status"],
+            "Completed"
+        );
+        let completed_recovery_child = store
+            .tasks()
+            .get_task(&recovery_child.task_id)
+            .expect("get completed recovery child")
+            .expect("completed recovery child");
+        assert_eq!(completed_recovery_child.status, TaskStatus::Completed);
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_recovery_child,
+                LedgerEventKind::PromptBuilt,
+                Some(json!({
+                    "prompt_preview": "RAW_M5_23_RECOVERY_CHILD_PROMPT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append recovery child raw prompt marker");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_recovery_child,
+                LedgerEventKind::ToolExecutionCompleted,
+                Some(json!({
+                    "tool_id": "workspace.read",
+                    "status": "Completed",
+                    "output_preview": "RAW_M5_23_RECOVERY_CHILD_OUTPUT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append recovery child raw output marker");
+        let recovery_child_evidence =
+            parent_join_child_completion_evidence(&store, &completed_recovery_child)
+                .expect("recovery child completion evidence");
+        assert!(recovery_child_evidence
+            .summary
+            .contains("completed_child task_id="));
+        assert!(recovery_child_evidence
+            .summary
+            .contains("completion_result_fingerprint="));
+
+        let second_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":7,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(second_parent_join.error.is_none());
+        assert_eq!(
+            second_parent_join
+                .result
+                .expect("second parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_children_after_second_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after recovery cycle join")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(parent_children_after_second_join.len(), 3);
+        let second_recovery_cycle_child = parent_children_after_second_join
+            .iter()
+            .find(|record| {
+                record.task_id != failed_child.task_id
+                    && record.task_id != completed_recovery_child.task_id
+            })
+            .expect("second recovery-cycle child");
+        assert_eq!(second_recovery_cycle_child.status, TaskStatus::Queued);
+        assert_eq!(
+            second_recovery_cycle_child
+                .source_intent_summary
+                .as_ref()
+                .expect("second recovery-cycle source intent")
+                .request_reason,
+            "Continue recovery after explicit recovery child completion."
+        );
+        assert!(validate_controlled_queued_child_task_provenance(
+            second_recovery_cycle_child,
+            &store
+        )
+        .is_ok());
+        let second_recovery_cycle_child_events = store
+            .tasks()
+            .read_ledger_events(&second_recovery_cycle_child.run_id)
+            .expect("second recovery-cycle child events");
+        assert_eq!(second_recovery_cycle_child_events.len(), 1);
+        assert_eq!(
+            second_recovery_cycle_child_events[0].kind,
+            LedgerEventKind::TaskStarted
+        );
+        assert!(!second_recovery_cycle_child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+
+        let parent_events_after_second_join = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after recovery cycle join");
+        let continuation_consumptions = parent_events_after_second_join
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| event.payload.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(continuation_consumptions.len(), 2);
+        assert_eq!(
+            continuation_consumptions[1]["child_completion_child_count"],
+            2
+        );
+        assert_eq!(
+            continuation_consumptions[1]["child_terminal_failed_count"],
+            1
+        );
+        assert_eq!(
+            continuation_consumptions[1]["child_terminal_completed_count"],
+            1
+        );
+        let second_fingerprint = continuation_consumptions[1]["child_completion_fingerprint"]
+            .as_str()
+            .expect("second fingerprint");
+        assert_ne!(first_fingerprint, second_fingerprint);
+
+        let continuation_prompt_preview = parent_events_after_second_join
+            .iter()
+            .rev()
+            .find(|event| event.kind == LedgerEventKind::PromptBuilt)
+            .and_then(|event| event.payload.as_ref())
+            .and_then(|payload| payload.get("prompt_preview"))
+            .and_then(Value::as_str)
+            .expect("recovery-cycle continuation prompt preview");
+        assert!(continuation_prompt_preview.contains("failed_child task_id="));
+        assert!(continuation_prompt_preview.contains(&failed_child.task_id));
+        assert!(continuation_prompt_preview.contains("completed_child task_id="));
+        assert!(continuation_prompt_preview.contains(&completed_recovery_child.task_id));
+        assert!(continuation_prompt_preview.contains("failure_result_fingerprint=sha256:"));
+        assert!(!continuation_prompt_preview
+            .contains("RAW_M5_23_FAILED_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!continuation_prompt_preview
+            .contains("RAW_M5_23_FAILED_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+        assert!(!continuation_prompt_preview
+            .contains("RAW_M5_23_RECOVERY_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!continuation_prompt_preview
+            .contains("RAW_M5_23_RECOVERY_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+
+        let second_admission_id = continuation_consumptions[1]["admission_id"]
+            .as_str()
+            .expect("second admission id");
+        let continuation_envelope = parent_events_after_second_join
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded)
+            .filter_map(|event| event.payload.as_ref())
+            .find(|payload| {
+                payload
+                    .get("parent_join_admission_id")
+                    .and_then(Value::as_str)
+                    == Some(second_admission_id)
+            })
+            .expect("recovery-cycle continuation envelope");
+        assert_eq!(
+            continuation_envelope["parent_join_child_completion_child_count"],
+            2
+        );
+        assert_eq!(
+            continuation_envelope["parent_join_terminal_failed_child_count"],
+            1
+        );
+        assert_eq!(
+            continuation_envelope["parent_join_terminal_completed_child_count"],
+            1
+        );
+        assert_eq!(continuation_envelope["parent_join_recovery_cycle"], true);
+        assert_eq!(
+            second_recovery_cycle_child
+                .source_handoff_envelope_fingerprint
+                .as_deref(),
+            continuation_envelope["handoff_envelope_fingerprint"].as_str()
+        );
+        assert_eq!(
+            payload_string_array(continuation_envelope, "candidate_ids"),
+            vec![second_recovery_cycle_child
+                .source_candidate_id
+                .as_deref()
+                .expect("second recovery-cycle candidate")
+                .to_string()]
+        );
+
+        let parent_event_count_after_second_join = parent_events_after_second_join.len();
+        let repeat_expanded_terminal_set = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":8,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(repeat_expanded_terminal_set.result.is_none());
+        assert_eq!(
+            repeat_expanded_terminal_set
+                .error
+                .expect("repeat expanded terminal set error")
+                .code,
+            -32602
+        );
+        assert_eq!(
+            store
+                .tasks()
+                .read_ledger_events(&parent_run_id)
+                .expect("parent events after rejected expanded replay")
+                .len(),
+            parent_event_count_after_second_join
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
         clear_llm_env_for_test();

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -68,6 +68,8 @@ pub struct ParentJoinContinuationRunAdmission {
     pub child_completion_fingerprint: String,
     pub child_completion_child_count: usize,
     pub child_completion_fingerprint_input_count: usize,
+    pub child_terminal_completed_count: usize,
+    pub child_terminal_failed_count: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -210,6 +212,8 @@ impl TaskStore {
                         "admission_id": admission_id.clone(),
                         "child_completion_fingerprint": admission.child_completion_fingerprint,
                         "child_completion_child_count": admission.child_completion_child_count,
+                        "child_terminal_completed_count": admission.child_terminal_completed_count,
+                        "child_terminal_failed_count": admission.child_terminal_failed_count,
                         "fingerprint_input_count": admission.child_completion_fingerprint_input_count,
                         "reason": "Parent join continuation admitted atomically for this controlled terminal child result fingerprint."
                     })),

--- a/docs/architecture/phase-value-manifest.m5.23.json
+++ b/docs/architecture/phase-value-manifest.m5.23.json
@@ -1,0 +1,103 @@
+{
+  "phase": "M5.23",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "recovery_child_completion_join_cycle",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_recovery_child_completion_runtime_progress",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Makes failed-child recovery repeatable by admitting a parent join after the explicitly-run recovery child reaches a terminal outcome."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Feeds the expanded failed_child plus completed_child terminal result set back through the Rust-owned parent agent loop without auto-running children."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Removes the recovery-loop wedge where Brownie could create a recovery child but could not continue bounded parent orchestration after that child completed."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "recovery_child_explicit_run_only",
+        "prompt": "Does a recovery child produced from failed_child evidence remain queued until explicit task.run?"
+      },
+      {
+        "id": "expanded_terminal_join",
+        "prompt": "Can the parent explicitly join after the recovery child reaches a terminal outcome?"
+      },
+      {
+        "id": "expanded_terminal_fingerprint_change",
+        "prompt": "Does the failed_child plus completed_child terminal result set change the parent join fingerprint?"
+      },
+      {
+        "id": "expanded_terminal_replay_rejection",
+        "prompt": "Does the same expanded terminal child result set remain replay-rejected?"
+      },
+      {
+        "id": "second_recovery_cycle_materialization",
+        "prompt": "Does an approved recovery-cycle subtask.spawn materialize a second controlled queued child TaskRecord?"
+      },
+      {
+        "id": "bounded_recovery_provenance",
+        "prompt": "Do continuation records distinguish failed and completed terminal child counts without raw child data?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "recovery_child_explicit_run_only": "Yes. A recovery child materialized from failed_child evidence remains Queued with only TaskStarted until an explicit task.run runs it.",
+      "expanded_terminal_join": "Yes. After the recovery child reaches Completed, the parent can run another explicit continuation over the expanded terminal child result set.",
+      "expanded_terminal_fingerprint_change": "Yes. The second continuation consumes a distinct child_completion_fingerprint for the failed_child plus completed_child evidence set.",
+      "expanded_terminal_replay_rejection": "Yes. Repeating parent task.run after the second recovery-cycle child is queued is rejected because the same expanded terminal result set is either already consumed or not all children are terminal.",
+      "second_recovery_cycle_materialization": "Yes. The fake LLM emits an approved recovery-cycle subtask.spawn, and Brownie materializes it into a new controlled queued child TaskRecord.",
+      "bounded_recovery_provenance": "Yes. Parent join consumption and continuation handoff envelope records include child_terminal_failed_count, child_terminal_completed_count, parent_join_terminal_failed_child_count, and parent_join_terminal_completed_child_count while excluding raw child prompts and outputs.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "A failed controlled child can create a recovery child that remains queued until explicit task.run.",
+    "After explicit task.run completes the recovery child, the parent can continue over the expanded terminal child result set.",
+    "The expanded terminal child result set includes failed_child evidence with failure_result_fingerprint and completed_child evidence with completion_result_fingerprint.",
+    "The expanded terminal child result set changes the parent join fingerprint from the first failed-child continuation.",
+    "The same expanded terminal result set remains rejected before new terminal child progress exists.",
+    "An approved recovery-cycle continuation materializes a second recovery-cycle child as a controlled queued TaskRecord.",
+    "The second recovery-cycle child has bounded parent/source/failure/recovery provenance including parent_join_admission_id, parent_join_terminal_failed_child_count, and parent_join_terminal_completed_child_count.",
+    "Every child execution remains explicit task.run; No child auto-run occurs.",
+    "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, serialized request bodies, raw failure payloads, or unbounded error text are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "task_run_parent_join_recovery_child_completion_materializes_next_cycle_without_auto_run",
+      "task_run_parent_join_recovers_failed_controlled_child_without_auto_run",
+      "task_run_parent_join_materializes_second_continuation_cycle_without_stale_candidates",
+      "child_has_terminal_parent_join_outcome",
+      "failed_child task_id=",
+      "completed_child task_id=",
+      "failure_result_fingerprint",
+      "completion_result_fingerprint",
+      "parent_join_terminal_failed_child_count",
+      "parent_join_terminal_completed_child_count",
+      "parent_join_recovery_cycle",
+      "append_parent_join_continuation_handoff_envelope_recorded",
+      "materialize_controlled_child_task_from_handoff_envelope",
+      "validate_controlled_queued_child_task_provenance"
+    ],
+    "rust_store_tokens": [
+      "ParentJoinContinuationRunAdmitted",
+      "admit_parent_join_continuation",
+      "child_terminal_failed_count",
+      "child_terminal_completed_count"
+    ],
+    "rust_llm_tokens": [
+      "Fake LLM recovery-child completion continuation request",
+      "Continue recovery after explicit recovery child completion."
+    ]
+  }
+}

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.22';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.22.json';
+const phase = 'M5.23';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.23.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'terminal_child_failure_recovery_continuation',
-    `${phase} must declare the terminal child failure recovery continuation transition.`
+    manifest.concrete_capability_transition === 'recovery_child_completion_join_cycle',
+    `${phase} must declare the recovery child completion join cycle transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_failed_child_recovery_runtime_progress',
-    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without failed-child recovery runtime progress.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_recovery_child_completion_runtime_progress',
+    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without recovery-child completion runtime progress.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -77,12 +77,17 @@ function validateManifest(manifest) {
   for (const token of [
     'failed controlled child',
     'failed_child',
-    'same failed child result set remains rejected',
     'recovery child',
-    'failure_result_fingerprint',
-    'bounded before persistence',
-    'parent_join_admission_id',
     'explicit task.run',
+    'expanded terminal child result set',
+    'same expanded terminal result set remains rejected',
+    'second recovery-cycle child',
+    'completed_child',
+    'failure_result_fingerprint',
+    'completion_result_fingerprint',
+    'parent_join_terminal_failed_child_count',
+    'parent_join_terminal_completed_child_count',
+    'parent_join_admission_id',
     'No child auto-run',
     'No raw child prompts',
     'No scheduler handoff'
@@ -127,14 +132,21 @@ function validateSourceEvidence(manifest) {
 
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   const storeText = readText('crates/brownie-store/src/lib.rs');
+  const llmText = readText('crates/brownie-llm/src/lib.rs');
   for (const token of [
     'child_has_terminal_parent_join_outcome',
     'child_failure_result_fingerprint',
     'LLM_FAILURE_REASON_PREVIEW_CHARS',
     'llm_failure_reason_is_bounded_before_persistence',
     'failed_child task_id=',
+    'completed_child task_id=',
     'failure_result_fingerprint',
+    'completion_result_fingerprint',
+    'parent_join_terminal_failed_child_count',
+    'parent_join_terminal_completed_child_count',
+    'parent_join_recovery_cycle',
     'task_run_parent_join_recovers_failed_controlled_child_without_auto_run',
+    'task_run_parent_join_recovery_child_completion_materializes_next_cycle_without_auto_run',
     'failed_child_terminal_outcome_fingerprint_changes_with_failure_reason',
     'parent_join_admission_id',
     'append_parent_join_continuation_handoff_envelope_recorded',
@@ -143,6 +155,14 @@ function validateSourceEvidence(manifest) {
   ]) {
     if (!runtimeText.includes(token) && !storeText.includes(token)) {
       errors.push(`${phase} source must include ${token}.`);
+    }
+  }
+  for (const token of [
+    'Fake LLM recovery-child completion continuation request',
+    'Continue recovery after explicit recovery child completion.'
+  ]) {
+    if (!llmText.includes(token)) {
+      errors.push(`${phase} LLM source must include ${token}.`);
     }
   }
   const forbiddenWrapperEvents = [


### PR DESCRIPTION
## 概要
- M5.23 の recovery child completion join cycle を実装しました。
- `failed_child` continuation で作られた recovery child は `Queued` のまま保持され、明示的な `task.run` 後に parent が `failed_child` + `completed_child` の拡張 terminal child result set で再 join できることを固定しました。
- parent join consumption と continuation handoff envelope に `child_terminal_failed_count` / `child_terminal_completed_count` と `parent_join_terminal_failed_child_count` / `parent_join_terminal_completed_child_count` を追加し、raw child data なしで bounded recovery provenance を残します。

## Capability gain
M5.22 は failed child から recovery child を materialize するところまででした。M5.23 では、その recovery child を明示 `task.run` で terminal にした後、parent が拡張 terminal set を消費して次の controlled queued child を materialize できるようにしています。同じ拡張 terminal set の replay は引き続き拒否され、child の自動実行や scheduler handoff は追加していません。

## Safety
- patch apply、workspace mutation、process exec expansion、service control、network bypass は追加していません。
- recovery-cycle child は `TaskStarted` のみで `Queued` として作成され、`TaskRunning` は明示 `task.run` まで発生しません。
- prompt / provider response / file content / raw failure payload は parent continuation context に露出しません。

## Checks
- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`