### PR TITLE
M5.24: repeat recovery join cycles

### DIFF
--- a/crates/brownie-llm/src/lib.rs
+++ b/crates/brownie-llm/src/lib.rs
@@ -278,6 +278,24 @@ impl FakeLlm {
             .join("\n")
             .to_lowercase();
         if prompt.contains("failed_child")
+            && prompt.matches("completed_child").count() >= 2
+            && prompt.contains("orchestrator")
+        {
+            let intent = serde_json::json!({
+                "tool_requests": [{
+                    "tool_id": "subtask.spawn",
+                    "reason": "Continue repeated recovery cycle after second explicit recovery child completion."
+                }]
+            });
+            return LlmResponse {
+                content: format!(
+                    "Fake LLM repeated recovery-cycle continuation request with {} messages.\n\n```brownie-tool-intent\n{}\n```",
+                    request.messages.len(),
+                    serde_json::to_string_pretty(&intent).expect("fake intent serializes")
+                ),
+            };
+        }
+        if prompt.contains("failed_child")
             && prompt.contains("completed_child")
             && prompt.contains("orchestrator")
         {

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1778,6 +1778,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                     .child_completion_fingerprint_input_count,
                 child_terminal_completed_count: consumption.child_terminal_completed_count,
                 child_terminal_failed_count: consumption.child_terminal_failed_count,
+                child_recovery_cycle_depth: consumption.child_recovery_cycle_depth,
             },
         ) {
             Ok(Some(admitted)) => {
@@ -2201,6 +2202,7 @@ struct ParentJoinContinuationAdmission {
     child_completion_child_count: usize,
     child_terminal_completed_count: usize,
     child_terminal_failed_count: usize,
+    child_recovery_cycle_depth: usize,
 }
 
 impl TaskRunAdmission {
@@ -2221,6 +2223,7 @@ impl TaskRunAdmission {
                 child_completion_child_count: admission.child_completion_child_count,
                 child_terminal_completed_count: admission.child_terminal_completed_count,
                 child_terminal_failed_count: admission.child_terminal_failed_count,
+                child_recovery_cycle_depth: admission.child_recovery_cycle_depth,
             }),
         }
     }
@@ -2239,6 +2242,7 @@ impl TaskRunAdmission {
                     child_completion_child_count: admission.child_completion_child_count,
                     child_terminal_completed_count: admission.child_terminal_completed_count,
                     child_terminal_failed_count: admission.child_terminal_failed_count,
+                    child_recovery_cycle_depth: admission.child_recovery_cycle_depth,
                 })
             }
         }
@@ -2251,6 +2255,7 @@ struct ParentJoinContinuationConsumption {
     child_completion_child_count: usize,
     child_terminal_completed_count: usize,
     child_terminal_failed_count: usize,
+    child_recovery_cycle_depth: usize,
 }
 
 #[derive(Clone)]
@@ -2261,6 +2266,7 @@ struct ParentJoinContinuationMaterialization {
     child_completion_child_count: usize,
     child_terminal_completed_count: usize,
     child_terminal_failed_count: usize,
+    child_recovery_cycle_depth: usize,
 }
 
 fn validate_task_run_admission(
@@ -2339,6 +2345,11 @@ fn validate_completed_parent_join_continuation_admission(
         .iter()
         .filter(|child| child.status == TaskStatus::Failed)
         .count();
+    let child_recovery_cycle_depth = if child_terminal_failed_count > 0 {
+        child_terminal_completed_count
+    } else {
+        0
+    };
     let (child_completion_fingerprint, child_completion_fingerprint_input_count) =
         parent_join_child_completion_fingerprint(&child_evidence);
     if parent_join_child_completion_fingerprint_consumed(
@@ -2369,6 +2380,7 @@ fn validate_completed_parent_join_continuation_admission(
         child_completion_child_count: child_tasks.len(),
         child_terminal_completed_count,
         child_terminal_failed_count,
+        child_recovery_cycle_depth,
     })
 }
 
@@ -12402,6 +12414,10 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
             "parent_join_terminal_failed_child_count={}",
             continuation.child_terminal_failed_count
         ),
+        format!(
+            "parent_join_recovery_cycle_depth={}",
+            continuation.child_recovery_cycle_depth
+        ),
         format!("candidate_count={}", candidate_ids.len()),
     ];
     for candidate_id in &candidate_ids {
@@ -12421,56 +12437,63 @@ fn append_parent_join_continuation_handoff_envelope_recorded(
     let admission_fragment = fragment_for_identifier(&continuation.admission_id);
     let candidate_count = candidate_ids.len();
     let eligible_candidate_ids = candidate_ids.clone();
+    let mut payload = json!({
+        "handoff_envelope_id": format!("subtask_dispatch_handoff_envelope_{run_fragment}_{admission_fragment}"),
+        "parent_task_id": record.task_id,
+        "parent_run_id": record.run_id,
+        "parent_join_admission_id": continuation.admission_id,
+        "parent_join_child_completion_fingerprint": continuation.child_completion_fingerprint,
+        "parent_join_child_completion_child_count": continuation.child_completion_child_count,
+        "parent_join_terminal_completed_child_count": continuation.child_terminal_completed_count,
+        "parent_join_terminal_failed_child_count": continuation.child_terminal_failed_count,
+        "parent_join_fingerprint_input_count": continuation.child_completion_fingerprint_input_count,
+        "parent_join_recovery_cycle": continuation.child_terminal_failed_count > 0 && continuation.child_terminal_completed_count > 0,
+        "queued_count": candidate_count,
+        "source_event_count": candidate_count,
+        "status": "Accepted",
+        "handoff_envelope_status": "Accepted",
+        "handoff_ticket_status": "Blocked",
+        "replay_guard_status": "Accepted",
+        "scheduler_handoff_status": "Blocked",
+        "candidate_status": "Accepted",
+        "dispatch_decision": "MaterializeControlledChildTask",
+        "candidate_count": candidate_count,
+        "dispatch_candidate_count": candidate_count,
+        "eligible_candidate_count": candidate_count,
+        "blocked_candidate_count": 0,
+        "handoff_ticket_count": 0,
+        "candidate_ids": candidate_ids,
+        "eligible_candidate_ids": eligible_candidate_ids,
+        "blocked_candidate_ids": [],
+        "handoff_envelope_fingerprint": handoff_envelope_fingerprint,
+        "fingerprint_input_count": fingerprint_input_count,
+        "required_capability": "continuation_subtask_materialization",
+        "precondition_count": 0,
+        "satisfied_precondition_count": 0,
+        "blocked_preconditions": [],
+        "check_count": 2,
+        "blocked_checks": [
+            "scheduler_handoff_not_available",
+            "child_task_auto_run_disabled"
+        ],
+        "execution_enabled": false,
+        "dispatch_enabled": false,
+        "continuation_materialization": true,
+        "continuation_source": "parent_join_continuation",
+        "next_action": "explicit_child_task_run",
+        "reason": "Approved subtask intents emitted during an atomic parent join continuation were accepted for controlled queued child TaskRecord materialization; child execution remains explicit."
+    });
+    if let Some(payload) = payload.as_object_mut() {
+        payload.insert(
+            "parent_join_recovery_cycle_depth".to_string(),
+            json!(continuation.child_recovery_cycle_depth),
+        );
+    }
 
     store.tasks().append_task_event_with_payload(
         record,
         LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded,
-        Some(json!({
-            "handoff_envelope_id": format!("subtask_dispatch_handoff_envelope_{run_fragment}_{admission_fragment}"),
-            "parent_task_id": record.task_id,
-            "parent_run_id": record.run_id,
-            "parent_join_admission_id": continuation.admission_id,
-            "parent_join_child_completion_fingerprint": continuation.child_completion_fingerprint,
-            "parent_join_child_completion_child_count": continuation.child_completion_child_count,
-            "parent_join_terminal_completed_child_count": continuation.child_terminal_completed_count,
-            "parent_join_terminal_failed_child_count": continuation.child_terminal_failed_count,
-            "parent_join_fingerprint_input_count": continuation.child_completion_fingerprint_input_count,
-            "parent_join_recovery_cycle": continuation.child_terminal_failed_count > 0 && continuation.child_terminal_completed_count > 0,
-            "queued_count": candidate_count,
-            "source_event_count": candidate_count,
-            "status": "Accepted",
-            "handoff_envelope_status": "Accepted",
-            "handoff_ticket_status": "Blocked",
-            "replay_guard_status": "Accepted",
-            "scheduler_handoff_status": "Blocked",
-            "candidate_status": "Accepted",
-            "dispatch_decision": "MaterializeControlledChildTask",
-            "candidate_count": candidate_count,
-            "dispatch_candidate_count": candidate_count,
-            "eligible_candidate_count": candidate_count,
-            "blocked_candidate_count": 0,
-            "handoff_ticket_count": 0,
-            "candidate_ids": candidate_ids,
-            "eligible_candidate_ids": eligible_candidate_ids,
-            "blocked_candidate_ids": [],
-            "handoff_envelope_fingerprint": handoff_envelope_fingerprint,
-            "fingerprint_input_count": fingerprint_input_count,
-            "required_capability": "continuation_subtask_materialization",
-            "precondition_count": 0,
-            "satisfied_precondition_count": 0,
-            "blocked_preconditions": [],
-            "check_count": 2,
-            "blocked_checks": [
-                "scheduler_handoff_not_available",
-                "child_task_auto_run_disabled"
-            ],
-            "execution_enabled": false,
-            "dispatch_enabled": false,
-            "continuation_materialization": true,
-            "continuation_source": "parent_join_continuation",
-            "next_action": "explicit_child_task_run",
-            "reason": "Approved subtask intents emitted during an atomic parent join continuation were accepted for controlled queued child TaskRecord materialization; child execution remains explicit."
-        })),
+        Some(payload),
     )
 }
 
@@ -16542,6 +16565,462 @@ mod tests {
                 .expect("parent events after rejected expanded replay")
                 .len(),
             parent_event_count_after_second_join
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_parent_join_repeated_recovery_cycle_materializes_next_child_without_auto_run() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (parent_task_id, parent_run_id, initial_child, _parent_event_count) =
+            start_parent_with_queued_child();
+
+        configure_strict_missing_openai_for_test();
+        let failed_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            initial_child.task_id
+        ));
+        assert!(failed_child_run.result.is_none());
+        assert_eq!(
+            failed_child_run.error.expect("failed child run error").code,
+            -32603
+        );
+        clear_llm_env_for_test();
+
+        let store = BrownieStore::new(temp.path());
+        let failed_child = store
+            .tasks()
+            .get_task(&initial_child.task_id)
+            .expect("get failed child")
+            .expect("failed child");
+        assert_eq!(failed_child.status, TaskStatus::Failed);
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &failed_child,
+                LedgerEventKind::PromptBuilt,
+                Some(json!({
+                    "prompt_preview": "RAW_M5_24_FAILED_CHILD_PROMPT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append M5.24 failed child raw prompt marker");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &failed_child,
+                LedgerEventKind::ToolExecutionCompleted,
+                Some(json!({
+                    "tool_id": "workspace.read",
+                    "status": "Completed",
+                    "output_preview": "RAW_M5_24_FAILED_CHILD_OUTPUT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append M5.24 failed child raw output marker");
+        let failed_child_evidence =
+            parent_join_child_completion_evidence(&store, &failed_child).expect("failed evidence");
+        assert!(failed_child_evidence
+            .summary
+            .contains("failed_child task_id="));
+        assert!(failed_child_evidence
+            .summary
+            .contains("failure_result_fingerprint="));
+        assert!(!failed_child_evidence
+            .summary
+            .contains("RAW_M5_24_FAILED_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!failed_child_evidence
+            .summary
+            .contains("RAW_M5_24_FAILED_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+
+        let first_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(first_parent_join.error.is_none());
+        assert_eq!(
+            first_parent_join.result.expect("first parent join result")["status"],
+            "Completed"
+        );
+
+        let first_recovery_child = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after first recovery join")
+            .into_iter()
+            .find(|record| {
+                record.parent_run_id.as_deref() == Some(parent_run_id.as_str())
+                    && record.task_id != failed_child.task_id
+            })
+            .expect("first recovery child");
+        assert_eq!(first_recovery_child.status, TaskStatus::Queued);
+        assert_eq!(
+            first_recovery_child
+                .source_intent_summary
+                .as_ref()
+                .expect("first recovery source intent")
+                .request_reason,
+            "Recover failed controlled child task."
+        );
+
+        let first_recovery_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":5,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            first_recovery_child.task_id
+        ));
+        assert!(first_recovery_child_run.error.is_none());
+        assert_eq!(
+            first_recovery_child_run
+                .result
+                .expect("first recovery child run result")["status"],
+            "Completed"
+        );
+        let completed_first_recovery_child = store
+            .tasks()
+            .get_task(&first_recovery_child.task_id)
+            .expect("get completed first recovery child")
+            .expect("completed first recovery child");
+        assert_eq!(completed_first_recovery_child.status, TaskStatus::Completed);
+
+        let second_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":6,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(second_parent_join.error.is_none());
+        assert_eq!(
+            second_parent_join
+                .result
+                .expect("second parent join result")["status"],
+            "Completed"
+        );
+
+        let second_recovery_cycle_child = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after second recovery-cycle join")
+            .into_iter()
+            .find(|record| {
+                record.parent_run_id.as_deref() == Some(parent_run_id.as_str())
+                    && record.task_id != failed_child.task_id
+                    && record.task_id != completed_first_recovery_child.task_id
+            })
+            .expect("second recovery-cycle child");
+        assert_eq!(second_recovery_cycle_child.status, TaskStatus::Queued);
+        assert_eq!(
+            second_recovery_cycle_child
+                .source_intent_summary
+                .as_ref()
+                .expect("second recovery source intent")
+                .request_reason,
+            "Continue recovery after explicit recovery child completion."
+        );
+        let second_recovery_events_before_run = store
+            .tasks()
+            .read_ledger_events(&second_recovery_cycle_child.run_id)
+            .expect("second recovery-cycle child events before run");
+        assert_eq!(second_recovery_events_before_run.len(), 1);
+        assert_eq!(
+            second_recovery_events_before_run[0].kind,
+            LedgerEventKind::TaskStarted
+        );
+        assert!(!second_recovery_events_before_run
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+
+        let parent_events_after_second_join = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after second join");
+        let continuation_consumptions_after_second_join = parent_events_after_second_join
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| event.payload.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(continuation_consumptions_after_second_join.len(), 2);
+        assert_eq!(
+            continuation_consumptions_after_second_join[1]["child_completion_child_count"],
+            2
+        );
+        assert_eq!(
+            continuation_consumptions_after_second_join[1]["child_terminal_failed_count"],
+            1
+        );
+        assert_eq!(
+            continuation_consumptions_after_second_join[1]["child_terminal_completed_count"],
+            1
+        );
+        assert_eq!(
+            continuation_consumptions_after_second_join[1]["child_recovery_cycle_depth"],
+            1
+        );
+        let second_terminal_set_fingerprint = continuation_consumptions_after_second_join[1]
+            ["child_completion_fingerprint"]
+            .as_str()
+            .expect("second terminal set fingerprint")
+            .to_string();
+
+        let second_recovery_cycle_child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":7,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            second_recovery_cycle_child.task_id
+        ));
+        assert!(second_recovery_cycle_child_run.error.is_none());
+        assert_eq!(
+            second_recovery_cycle_child_run
+                .result
+                .expect("second recovery-cycle child run result")["status"],
+            "Completed"
+        );
+        let completed_second_recovery_cycle_child = store
+            .tasks()
+            .get_task(&second_recovery_cycle_child.task_id)
+            .expect("get completed second recovery-cycle child")
+            .expect("completed second recovery-cycle child");
+        assert_eq!(
+            completed_second_recovery_cycle_child.status,
+            TaskStatus::Completed
+        );
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_second_recovery_cycle_child,
+                LedgerEventKind::PromptBuilt,
+                Some(json!({
+                    "prompt_preview": "RAW_M5_24_SECOND_RECOVERY_CHILD_PROMPT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append second recovery child raw prompt marker");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &completed_second_recovery_cycle_child,
+                LedgerEventKind::ToolExecutionCompleted,
+                Some(json!({
+                    "tool_id": "workspace.read",
+                    "status": "Completed",
+                    "output_preview": "RAW_M5_24_SECOND_RECOVERY_CHILD_OUTPUT_SHOULD_NOT_APPEAR"
+                })),
+            )
+            .expect("append second recovery child raw output marker");
+        let second_recovery_child_evidence =
+            parent_join_child_completion_evidence(&store, &completed_second_recovery_cycle_child)
+                .expect("second recovery child completion evidence");
+        assert!(second_recovery_child_evidence
+            .summary
+            .contains("completed_child task_id="));
+        assert!(second_recovery_child_evidence
+            .summary
+            .contains("completion_result_fingerprint="));
+        assert!(!second_recovery_child_evidence
+            .summary
+            .contains("RAW_M5_24_SECOND_RECOVERY_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!second_recovery_child_evidence
+            .summary
+            .contains("RAW_M5_24_SECOND_RECOVERY_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+
+        let third_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":8,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(third_parent_join.error.is_none());
+        assert_eq!(
+            third_parent_join.result.expect("third parent join result")["status"],
+            "Completed"
+        );
+
+        let parent_children_after_third_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list parent children after repeated recovery-cycle join")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+            .collect::<Vec<_>>();
+        assert_eq!(parent_children_after_third_join.len(), 4);
+        let third_recovery_cycle_child = parent_children_after_third_join
+            .iter()
+            .find(|record| {
+                record.task_id != failed_child.task_id
+                    && record.task_id != completed_first_recovery_child.task_id
+                    && record.task_id != completed_second_recovery_cycle_child.task_id
+            })
+            .expect("third recovery-cycle child");
+        assert_eq!(third_recovery_cycle_child.status, TaskStatus::Queued);
+        assert_eq!(
+            third_recovery_cycle_child
+                .source_intent_summary
+                .as_ref()
+                .expect("third recovery-cycle source intent")
+                .request_reason,
+            "Continue repeated recovery cycle after second explicit recovery child completion."
+        );
+        assert!(validate_controlled_queued_child_task_provenance(
+            third_recovery_cycle_child,
+            &store
+        )
+        .is_ok());
+        let third_recovery_cycle_child_events = store
+            .tasks()
+            .read_ledger_events(&third_recovery_cycle_child.run_id)
+            .expect("third recovery-cycle child events");
+        assert_eq!(third_recovery_cycle_child_events.len(), 1);
+        assert_eq!(
+            third_recovery_cycle_child_events[0].kind,
+            LedgerEventKind::TaskStarted
+        );
+        assert!(!third_recovery_cycle_child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+
+        let parent_events_after_third_join = store
+            .tasks()
+            .read_ledger_events(&parent_run_id)
+            .expect("parent events after repeated recovery-cycle join");
+        let continuation_consumptions = parent_events_after_third_join
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .filter_map(|event| event.payload.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(continuation_consumptions.len(), 3);
+        assert_eq!(
+            continuation_consumptions[2]["child_completion_child_count"],
+            3
+        );
+        assert_eq!(
+            continuation_consumptions[2]["child_terminal_failed_count"],
+            1
+        );
+        assert_eq!(
+            continuation_consumptions[2]["child_terminal_completed_count"],
+            2
+        );
+        assert_eq!(
+            continuation_consumptions[2]["child_recovery_cycle_depth"],
+            2
+        );
+        let third_terminal_set_fingerprint = continuation_consumptions[2]
+            ["child_completion_fingerprint"]
+            .as_str()
+            .expect("third terminal set fingerprint");
+        assert_ne!(
+            second_terminal_set_fingerprint,
+            third_terminal_set_fingerprint
+        );
+
+        let repeated_recovery_prompt_preview = parent_events_after_third_join
+            .iter()
+            .rev()
+            .find(|event| event.kind == LedgerEventKind::PromptBuilt)
+            .and_then(|event| event.payload.as_ref())
+            .and_then(|payload| payload.get("prompt_preview"))
+            .and_then(Value::as_str)
+            .expect("repeated recovery continuation prompt preview");
+        assert!(repeated_recovery_prompt_preview.contains("failed_child task_id="));
+        assert!(repeated_recovery_prompt_preview.contains(&failed_child.task_id));
+        assert!(!repeated_recovery_prompt_preview
+            .contains("RAW_M5_24_FAILED_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!repeated_recovery_prompt_preview
+            .contains("RAW_M5_24_FAILED_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+        assert!(!repeated_recovery_prompt_preview
+            .contains("RAW_M5_24_SECOND_RECOVERY_CHILD_PROMPT_SHOULD_NOT_APPEAR"));
+        assert!(!repeated_recovery_prompt_preview
+            .contains("RAW_M5_24_SECOND_RECOVERY_CHILD_OUTPUT_SHOULD_NOT_APPEAR"));
+
+        let third_admission_id = continuation_consumptions[2]["admission_id"]
+            .as_str()
+            .expect("third admission id");
+        let repeated_recovery_envelope = parent_events_after_third_join
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded)
+            .filter_map(|event| event.payload.as_ref())
+            .find(|payload| {
+                payload
+                    .get("parent_join_admission_id")
+                    .and_then(Value::as_str)
+                    == Some(third_admission_id)
+            })
+            .expect("repeated recovery-cycle continuation envelope");
+        assert_eq!(
+            repeated_recovery_envelope["parent_join_child_completion_child_count"],
+            3
+        );
+        assert_eq!(
+            repeated_recovery_envelope["parent_join_terminal_failed_child_count"],
+            1
+        );
+        assert_eq!(
+            repeated_recovery_envelope["parent_join_terminal_completed_child_count"],
+            2
+        );
+        assert_eq!(
+            repeated_recovery_envelope["parent_join_recovery_cycle_depth"],
+            2
+        );
+        assert_eq!(
+            repeated_recovery_envelope["parent_join_recovery_cycle"],
+            true
+        );
+        let second_candidate = second_recovery_cycle_child
+            .source_candidate_id
+            .as_deref()
+            .expect("second recovery candidate");
+        let third_candidate = third_recovery_cycle_child
+            .source_candidate_id
+            .as_deref()
+            .expect("third recovery candidate");
+        let repeated_envelope_candidates =
+            payload_string_array(repeated_recovery_envelope, "candidate_ids");
+        assert_eq!(
+            repeated_envelope_candidates,
+            vec![third_candidate.to_string()]
+        );
+        assert!(!repeated_envelope_candidates.contains(&second_candidate.to_string()));
+        assert_eq!(
+            third_recovery_cycle_child
+                .source_handoff_envelope_fingerprint
+                .as_deref(),
+            repeated_recovery_envelope["handoff_envelope_fingerprint"].as_str()
+        );
+
+        let parent = store
+            .tasks()
+            .get_task(&parent_task_id)
+            .expect("get parent")
+            .expect("parent");
+        materialize_controlled_child_task_from_handoff_envelope(&store, &parent)
+            .expect("repeated recovery envelope idempotent materialization");
+        assert_eq!(
+            store
+                .tasks()
+                .list_tasks()
+                .expect("list tasks after repeated recovery idempotency")
+                .iter()
+                .filter(|record| record.parent_run_id.as_deref() == Some(parent_run_id.as_str()))
+                .count(),
+            4
+        );
+
+        let parent_event_count_after_third_join = parent_events_after_third_join.len();
+        let repeat_larger_terminal_set = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":9,"method":"task.run","params":{{"task_id":"{parent_task_id}"}}}}"#
+        ));
+        assert!(repeat_larger_terminal_set.result.is_none());
+        assert_eq!(
+            repeat_larger_terminal_set
+                .error
+                .expect("repeat larger terminal set error")
+                .code,
+            -32602
+        );
+        assert_eq!(
+            store
+                .tasks()
+                .read_ledger_events(&parent_run_id)
+                .expect("parent events after rejected larger replay")
+                .len(),
+            parent_event_count_after_third_join
         );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -70,6 +70,7 @@ pub struct ParentJoinContinuationRunAdmission {
     pub child_completion_fingerprint_input_count: usize,
     pub child_terminal_completed_count: usize,
     pub child_terminal_failed_count: usize,
+    pub child_recovery_cycle_depth: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -214,6 +215,7 @@ impl TaskStore {
                         "child_completion_child_count": admission.child_completion_child_count,
                         "child_terminal_completed_count": admission.child_terminal_completed_count,
                         "child_terminal_failed_count": admission.child_terminal_failed_count,
+                        "child_recovery_cycle_depth": admission.child_recovery_cycle_depth,
                         "fingerprint_input_count": admission.child_completion_fingerprint_input_count,
                         "reason": "Parent join continuation admitted atomically for this controlled terminal child result fingerprint."
                     })),

--- a/docs/architecture/phase-value-manifest.m5.24.json
+++ b/docs/architecture/phase-value-manifest.m5.24.json
@@ -1,0 +1,109 @@
+{
+  "phase": "M5.24",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "repeated_recovery_cycle_join",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_repeated_recovery_cycle_runtime_progress",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Makes mixed-outcome recovery-cycle parent joins repeatable after another explicitly-run recovery child reaches a terminal outcome."
+    },
+    {
+      "capability": "agent_loop_integration",
+      "relationship": "Feeds a larger bounded failed_child plus completed_child terminal result set back through the Rust-owned parent agent loop without auto-running child tasks."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Removes the next recovery-loop wedge where Brownie could continue once after recovery completion but could not admit a subsequent bounded recovery cycle."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "second_recovery_child_explicit_run_only",
+        "prompt": "Does a second recovery-cycle child remain queued until explicit task.run?"
+      },
+      {
+        "id": "larger_terminal_join",
+        "prompt": "Can the parent explicitly join again after the second recovery-cycle child reaches a terminal outcome?"
+      },
+      {
+        "id": "larger_terminal_fingerprint_change",
+        "prompt": "Does the larger failed_child plus completed_child terminal result set change the parent join fingerprint?"
+      },
+      {
+        "id": "larger_terminal_replay_rejection",
+        "prompt": "Does the same larger terminal child result set remain replay-rejected?"
+      },
+      {
+        "id": "repeated_recovery_cycle_materialization",
+        "prompt": "Does an approved repeated recovery-cycle subtask.spawn materialize the next controlled queued child TaskRecord?"
+      },
+      {
+        "id": "bounded_recovery_cycle_depth",
+        "prompt": "Do continuation records distinguish repeated recovery-cycle depth and terminal child counts without raw child data?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "second_recovery_child_explicit_run_only": "Yes. The second recovery-cycle child remains Queued with only TaskStarted until an explicit task.run runs it.",
+      "larger_terminal_join": "Yes. After explicit task.run completes the second recovery-cycle child, the parent can run another explicit continuation over the larger terminal child result set.",
+      "larger_terminal_fingerprint_change": "Yes. The repeated continuation consumes a distinct child_completion_fingerprint for the failed_child plus two completed_child evidence set.",
+      "larger_terminal_replay_rejection": "Yes. Repeating parent task.run after the next recovery-cycle child is queued is rejected because the same larger terminal result set is already consumed or not all children are terminal.",
+      "repeated_recovery_cycle_materialization": "Yes. The fake LLM emits an approved repeated recovery-cycle subtask.spawn, and Brownie materializes it into the next controlled queued child TaskRecord.",
+      "bounded_recovery_cycle_depth": "Yes. Parent join consumption and continuation handoff envelope records include child_recovery_cycle_depth, parent_join_recovery_cycle_depth, failed/completed terminal child counts, and parent_join_admission_id while excluding raw child prompts and outputs.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "A failed controlled child can create a recovery child that remains queued until explicit task.run.",
+    "A second recovery-cycle child can be explicitly completed by task.run without child auto-run.",
+    "After explicit task.run completes the second recovery-cycle child, the parent can continue over the larger terminal child result set.",
+    "The larger terminal child result set includes failed_child evidence with failure_result_fingerprint and repeated completed_child evidence with completion_result_fingerprint.",
+    "The larger terminal child result set changes the parent join fingerprint from the previous recovery-cycle continuation.",
+    "The same larger terminal result set remains rejected before new terminal child progress exists.",
+    "An approved repeated recovery-cycle continuation materializes the next recovery child as a controlled queued TaskRecord.",
+    "The repeated recovery-cycle child has bounded parent/source/failure/recovery provenance including parent_join_admission_id, child_recovery_cycle_depth, parent_join_recovery_cycle_depth, parent_join_terminal_failed_child_count, and parent_join_terminal_completed_child_count.",
+    "Every child execution remains explicit task.run; No child auto-run occurs.",
+    "No raw child prompts, raw provider responses, raw file content, command strings, stdout, stderr, environment values, raw tool input objects, serialized request bodies, raw failure payloads, or unbounded error text are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "task_run_parent_join_repeated_recovery_cycle_materializes_next_child_without_auto_run",
+      "task_run_parent_join_recovery_child_completion_materializes_next_cycle_without_auto_run",
+      "task_run_parent_join_recovers_failed_controlled_child_without_auto_run",
+      "child_has_terminal_parent_join_outcome",
+      "failed_child task_id=",
+      "completed_child task_id=",
+      "failure_result_fingerprint",
+      "completion_result_fingerprint",
+      "parent_join_terminal_failed_child_count",
+      "parent_join_terminal_completed_child_count",
+      "parent_join_recovery_cycle_depth",
+      "child_recovery_cycle_depth",
+      "parent_join_recovery_cycle",
+      "append_parent_join_continuation_handoff_envelope_recorded",
+      "materialize_controlled_child_task_from_handoff_envelope",
+      "validate_controlled_queued_child_task_provenance"
+    ],
+    "rust_store_tokens": [
+      "ParentJoinContinuationRunAdmitted",
+      "admit_parent_join_continuation",
+      "child_terminal_failed_count",
+      "child_terminal_completed_count",
+      "child_recovery_cycle_depth"
+    ],
+    "rust_llm_tokens": [
+      "Fake LLM recovery-child completion continuation request",
+      "Continue recovery after explicit recovery child completion.",
+      "Fake LLM repeated recovery-cycle continuation request",
+      "Continue repeated recovery cycle after second explicit recovery child completion."
+    ]
+  }
+}

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.23';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.23.json';
+const phase = 'M5.24';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.24.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'recovery_child_completion_join_cycle',
-    `${phase} must declare the recovery child completion join cycle transition.`
+    manifest.concrete_capability_transition === 'repeated_recovery_cycle_join',
+    `${phase} must declare the repeated recovery-cycle join transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_recovery_child_completion_runtime_progress',
-    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without recovery-child completion runtime progress.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_scheduler_auto_dispatch_without_repeated_recovery_cycle_runtime_progress',
+    `${phase} must forbid wrapper-only work or scheduler auto-dispatch without repeated recovery-cycle runtime progress.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -78,13 +78,16 @@ function validateManifest(manifest) {
     'failed controlled child',
     'failed_child',
     'recovery child',
-    'explicit task.run',
-    'expanded terminal child result set',
-    'same expanded terminal result set remains rejected',
     'second recovery-cycle child',
+    'explicit task.run',
+    'larger terminal child result set',
+    'same larger terminal result set remains rejected',
+    'repeated recovery-cycle',
     'completed_child',
     'failure_result_fingerprint',
     'completion_result_fingerprint',
+    'parent_join_recovery_cycle_depth',
+    'child_recovery_cycle_depth',
     'parent_join_terminal_failed_child_count',
     'parent_join_terminal_completed_child_count',
     'parent_join_admission_id',
@@ -144,9 +147,12 @@ function validateSourceEvidence(manifest) {
     'completion_result_fingerprint',
     'parent_join_terminal_failed_child_count',
     'parent_join_terminal_completed_child_count',
+    'parent_join_recovery_cycle_depth',
+    'child_recovery_cycle_depth',
     'parent_join_recovery_cycle',
     'task_run_parent_join_recovers_failed_controlled_child_without_auto_run',
     'task_run_parent_join_recovery_child_completion_materializes_next_cycle_without_auto_run',
+    'task_run_parent_join_repeated_recovery_cycle_materializes_next_child_without_auto_run',
     'failed_child_terminal_outcome_fingerprint_changes_with_failure_reason',
     'parent_join_admission_id',
     'append_parent_join_continuation_handoff_envelope_recorded',
@@ -159,7 +165,9 @@ function validateSourceEvidence(manifest) {
   }
   for (const token of [
     'Fake LLM recovery-child completion continuation request',
-    'Continue recovery after explicit recovery child completion.'
+    'Continue recovery after explicit recovery child completion.',
+    'Fake LLM repeated recovery-cycle continuation request',
+    'Continue repeated recovery cycle after second explicit recovery child completion.'
   ]) {
     if (!llmText.includes(token)) {
       errors.push(`${phase} LLM source must include ${token}.`);


### PR DESCRIPTION
## 概要
- M5.24 として、混合 outcome の recovery-cycle parent join をさらに 1 サイクル繰り返せるようにしました。
- failed_child + completed_child の terminal set が大きくなった場合に、`child_recovery_cycle_depth` / `parent_join_recovery_cycle_depth` を記録し、fingerprint と handoff envelope に反映します。
- 2 回目 recovery-cycle child の明示的 `task.run` 後、次の controlled queued child を materialize し、child auto-run や scheduler handoff は追加していません。

## 検証
- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`