### PR TITLE
M5.26: guard recovery child run provenance

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -2776,8 +2776,169 @@ fn validate_controlled_queued_child_task_provenance(
             "invalid params: queued child task source provenance is invalid",
         ));
     }
+    validate_recovery_cycle_child_run_provenance(
+        record,
+        &parent_events,
+        source_handoff_envelope_id,
+        source_handoff_envelope_fingerprint,
+    )?;
 
     Ok(())
+}
+
+fn validate_recovery_cycle_child_run_provenance(
+    record: &TaskRecord,
+    parent_events: &[LedgerEvent],
+    source_handoff_envelope_id: &str,
+    source_handoff_envelope_fingerprint: &str,
+) -> Result<(), TaskRunAdmissionRejection> {
+    let Some(provenance) = record.recovery_cycle_provenance.as_ref() else {
+        return Ok(());
+    };
+    if !recovery_cycle_child_provenance_is_internally_valid(provenance) {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: recovery-cycle child task provenance is invalid",
+        ));
+    }
+
+    if !parent_events
+        .iter()
+        .any(|event| recovery_cycle_provenance_matches_parent_join(event, provenance))
+    {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: recovery-cycle child task provenance does not match parent join admission",
+        ));
+    }
+
+    if !parent_events.iter().any(|event| {
+        recovery_cycle_provenance_matches_handoff_envelope(
+            event,
+            provenance,
+            source_handoff_envelope_id,
+            source_handoff_envelope_fingerprint,
+        )
+    }) {
+        return Err(TaskRunAdmissionRejection::InvalidParams(
+            "invalid params: recovery-cycle child task provenance does not match parent handoff envelope",
+        ));
+    }
+
+    Ok(())
+}
+
+fn recovery_cycle_child_provenance_is_internally_valid(
+    provenance: &RecoveryCycleChildProvenance,
+) -> bool {
+    !provenance.parent_join_admission_id.trim().is_empty()
+        && is_sha256_fingerprint(&provenance.parent_join_child_completion_fingerprint)
+        && provenance
+            .parent_join_terminal_failed_child_count
+            .checked_add(provenance.parent_join_terminal_completed_child_count)
+            == Some(provenance.parent_join_child_completion_child_count)
+        && provenance.parent_join_recovery_cycle
+        && provenance.parent_join_recovery_cycle_depth >= 1
+}
+
+fn recovery_cycle_provenance_matches_parent_join(
+    event: &LedgerEvent,
+    provenance: &RecoveryCycleChildProvenance,
+) -> bool {
+    if event.kind != LedgerEventKind::ParentJoinContinuationFingerprintConsumed {
+        return false;
+    }
+    let Some(payload) = event.payload.as_ref() else {
+        return false;
+    };
+    payload.get("admission_id").and_then(Value::as_str)
+        == Some(provenance.parent_join_admission_id.as_str())
+        && payload
+            .get("child_completion_fingerprint")
+            .and_then(Value::as_str)
+            == Some(provenance.parent_join_child_completion_fingerprint.as_str())
+        && payload_usize_eq(
+            payload,
+            "child_completion_child_count",
+            provenance.parent_join_child_completion_child_count,
+        )
+        && payload_usize_eq(
+            payload,
+            "child_terminal_failed_count",
+            provenance.parent_join_terminal_failed_child_count,
+        )
+        && payload_usize_eq(
+            payload,
+            "child_terminal_completed_count",
+            provenance.parent_join_terminal_completed_child_count,
+        )
+        && payload_usize_eq(
+            payload,
+            "child_recovery_cycle_depth",
+            provenance.parent_join_recovery_cycle_depth,
+        )
+}
+
+fn recovery_cycle_provenance_matches_handoff_envelope(
+    event: &LedgerEvent,
+    provenance: &RecoveryCycleChildProvenance,
+    source_handoff_envelope_id: &str,
+    source_handoff_envelope_fingerprint: &str,
+) -> bool {
+    if event.kind != LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded {
+        return false;
+    }
+    let Some(payload) = event.payload.as_ref() else {
+        return false;
+    };
+    payload
+        .get("handoff_envelope_status")
+        .and_then(Value::as_str)
+        == Some("Accepted")
+        && payload.get("handoff_envelope_id").and_then(Value::as_str)
+            == Some(source_handoff_envelope_id)
+        && payload
+            .get("handoff_envelope_fingerprint")
+            .and_then(Value::as_str)
+            == Some(source_handoff_envelope_fingerprint)
+        && payload
+            .get("parent_join_admission_id")
+            .and_then(Value::as_str)
+            == Some(provenance.parent_join_admission_id.as_str())
+        && payload
+            .get("parent_join_child_completion_fingerprint")
+            .and_then(Value::as_str)
+            == Some(provenance.parent_join_child_completion_fingerprint.as_str())
+        && payload_usize_eq(
+            payload,
+            "parent_join_child_completion_child_count",
+            provenance.parent_join_child_completion_child_count,
+        )
+        && payload_usize_eq(
+            payload,
+            "parent_join_terminal_failed_child_count",
+            provenance.parent_join_terminal_failed_child_count,
+        )
+        && payload_usize_eq(
+            payload,
+            "parent_join_terminal_completed_child_count",
+            provenance.parent_join_terminal_completed_child_count,
+        )
+        && payload
+            .get("parent_join_recovery_cycle")
+            .and_then(Value::as_bool)
+            == Some(provenance.parent_join_recovery_cycle)
+        && payload_usize_eq(
+            payload,
+            "parent_join_recovery_cycle_depth",
+            provenance.parent_join_recovery_cycle_depth,
+        )
+}
+
+fn payload_usize_eq(payload: &Value, key: &str, expected: usize) -> bool {
+    payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
+        == Some(expected)
 }
 
 fn required_task_run_provenance(value: Option<&str>) -> Result<&str, TaskRunAdmissionRejection> {
@@ -15461,6 +15622,138 @@ mod tests {
         (parent_task_id, parent_run_id, child, parent_event_count)
     }
 
+    fn start_recovery_cycle_child_with_parent_evidence(
+        workspace_root: &std::path::Path,
+    ) -> (TaskRecord, TaskRecord, RecoveryCycleChildProvenance) {
+        let store = BrownieStore::new(workspace_root);
+        let parent = store
+            .tasks()
+            .start_task(TaskStartParams {
+                goal: "Parent recovery-cycle admission".into(),
+                mode_id: Some("orchestrator".into()),
+            })
+            .expect("start parent");
+        let provenance = RecoveryCycleChildProvenance {
+            parent_join_admission_id: "parent_join_admission_m5_26".into(),
+            parent_join_child_completion_fingerprint: format!("sha256:{}", "a".repeat(64)),
+            parent_join_child_completion_child_count: 3,
+            parent_join_terminal_failed_child_count: 1,
+            parent_join_terminal_completed_child_count: 2,
+            parent_join_recovery_cycle: true,
+            parent_join_recovery_cycle_depth: 2,
+        };
+        let source_handoff_envelope_id = "handoff_envelope_m5_26";
+        let source_handoff_envelope_fingerprint = format!("sha256:{}", "b".repeat(64));
+        let source_candidate_id = "candidate_m5_26_recovery_child";
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &parent,
+                LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
+                Some(json!({
+                    "parent_join_continuation_status": "Consumed",
+                    "admission_id": provenance.parent_join_admission_id,
+                    "child_completion_fingerprint": provenance.parent_join_child_completion_fingerprint,
+                    "child_completion_child_count": provenance.parent_join_child_completion_child_count,
+                    "child_terminal_failed_count": provenance.parent_join_terminal_failed_child_count,
+                    "child_terminal_completed_count": provenance.parent_join_terminal_completed_child_count,
+                    "child_recovery_cycle_depth": provenance.parent_join_recovery_cycle_depth,
+                    "fingerprint_input_count": 5,
+                    "reason": "Parent join continuation admitted for M5.26 recovery-cycle child run provenance guard."
+                })),
+            )
+            .expect("append parent join admission evidence");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &parent,
+                LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded,
+                Some(json!({
+                    "handoff_envelope_status": "Accepted",
+                    "handoff_envelope_id": source_handoff_envelope_id,
+                    "handoff_envelope_fingerprint": source_handoff_envelope_fingerprint,
+                    "candidate_ids": [source_candidate_id],
+                    "parent_join_admission_id": provenance.parent_join_admission_id,
+                    "parent_join_child_completion_fingerprint": provenance.parent_join_child_completion_fingerprint,
+                    "parent_join_child_completion_child_count": provenance.parent_join_child_completion_child_count,
+                    "parent_join_terminal_failed_child_count": provenance.parent_join_terminal_failed_child_count,
+                    "parent_join_terminal_completed_child_count": provenance.parent_join_terminal_completed_child_count,
+                    "parent_join_recovery_cycle": provenance.parent_join_recovery_cycle,
+                    "parent_join_recovery_cycle_depth": provenance.parent_join_recovery_cycle_depth,
+                    "scheduler_handoff_status": "Blocked",
+                    "execution_enabled": false,
+                    "reason": "Accepted parent join recovery-cycle handoff envelope for controlled child materialization."
+                })),
+            )
+            .expect("append accepted handoff envelope evidence");
+        let child = store
+            .tasks()
+            .start_child_task(ChildTaskStartParams {
+                goal: "Run recovery-cycle child after provenance admission guard".into(),
+                mode_id: Some("orchestrator".into()),
+                parent_task_id: parent.task_id.clone(),
+                parent_run_id: parent.run_id.clone(),
+                source_candidate_id: source_candidate_id.into(),
+                source_handoff_envelope_id: source_handoff_envelope_id.into(),
+                source_handoff_envelope_fingerprint,
+                source_intent_summary: None,
+                recovery_cycle_provenance: Some(provenance.clone()),
+            })
+            .expect("start recovery-cycle child");
+
+        (parent, child, provenance)
+    }
+
+    fn mutate_task_state(
+        workspace_root: &std::path::Path,
+        run_id: &str,
+        mutate: impl FnOnce(&mut Value),
+    ) {
+        let state_path = workspace_root
+            .join(".brownie/runs")
+            .join(run_id)
+            .join("state.json");
+        let mut state: Value =
+            serde_json::from_str(&std::fs::read_to_string(&state_path).expect("task state"))
+                .expect("task state json");
+        mutate(&mut state);
+        std::fs::write(
+            &state_path,
+            serde_json::to_string_pretty(&state).expect("task state serialize"),
+        )
+        .expect("write task state");
+    }
+
+    fn assert_recovery_child_run_rejected_before_running(
+        workspace_root: &std::path::Path,
+        child: &TaskRecord,
+        expected_message: &str,
+    ) {
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":41,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.result.is_none());
+        let error = child_run.error.expect("child run error");
+        assert_eq!(error.code, -32602);
+        assert!(error.message.contains(expected_message));
+
+        let store = BrownieStore::new(workspace_root);
+        let rejected_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get rejected child")
+            .expect("rejected child");
+        assert_eq!(rejected_child.status, TaskStatus::Queued);
+        let child_events = store
+            .tasks()
+            .read_ledger_events(&child.run_id)
+            .expect("child events");
+        assert!(!child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+    }
+
     fn clear_llm_env_for_test() {
         for key in [
             "BROWNIE_LLM_PROVIDER",
@@ -18270,6 +18563,168 @@ mod tests {
             .any(|event| event.kind == LedgerEventKind::TaskRunning));
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+
+        let child_run = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":41,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            child.task_id
+        ));
+        assert!(child_run.error.is_none());
+        let child_run_result = child_run.result.expect("child run result");
+        assert_eq!(child_run_result["task_id"], child.task_id);
+        assert_eq!(child_run_result["run_id"], child.run_id);
+        assert_eq!(child_run_result["status"], "Completed");
+
+        let store = BrownieStore::new(temp.path());
+        let completed_child = store
+            .tasks()
+            .get_task(&child.task_id)
+            .expect("get completed recovery-cycle child")
+            .expect("completed recovery-cycle child");
+        assert_eq!(completed_child.status, TaskStatus::Completed);
+        assert_eq!(completed_child.recovery_cycle_provenance, Some(provenance));
+        let child_events = store
+            .tasks()
+            .read_ledger_events(&child.run_id)
+            .expect("child events");
+        assert!(child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskRunning));
+        assert!(child_events
+            .iter()
+            .any(|event| event.kind == LedgerEventKind::TaskCompleted));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_stale_parent_join_admission_id() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["recovery_cycle_provenance"]["parent_join_admission_id"] =
+                json!("parent_join_admission_stale");
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "recovery-cycle child task provenance does not match parent join admission",
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_stale_completion_fingerprint() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["recovery_cycle_provenance"]["parent_join_child_completion_fingerprint"] =
+                json!(format!("sha256:{}", "c".repeat(64)));
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "recovery-cycle child task provenance does not match parent join admission",
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_stale_terminal_counts() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["recovery_cycle_provenance"]["parent_join_child_completion_child_count"] =
+                json!(4);
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "recovery-cycle child task provenance is invalid",
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_stale_recovery_depth() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["recovery_cycle_provenance"]["parent_join_recovery_cycle_depth"] = json!(0);
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "recovery-cycle child task provenance is invalid",
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_stale_handoff_fingerprint() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["source_handoff_envelope_fingerprint"] =
+                json!(format!("sha256:{}", "d".repeat(64)));
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "queued child task source provenance is invalid",
+        );
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
     }
 
     #[test]

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -2793,6 +2793,15 @@ fn validate_recovery_cycle_child_run_provenance(
     source_handoff_envelope_fingerprint: &str,
 ) -> Result<(), TaskRunAdmissionRejection> {
     let Some(provenance) = record.recovery_cycle_provenance.as_ref() else {
+        if source_handoff_envelope_requires_recovery_cycle_provenance(
+            parent_events,
+            source_handoff_envelope_id,
+            source_handoff_envelope_fingerprint,
+        ) {
+            return Err(TaskRunAdmissionRejection::InvalidParams(
+                "invalid params: recovery-cycle child task provenance is missing",
+            ));
+        }
         return Ok(());
     };
     if !recovery_cycle_child_provenance_is_internally_valid(provenance) {
@@ -2824,6 +2833,35 @@ fn validate_recovery_cycle_child_run_provenance(
     }
 
     Ok(())
+}
+
+fn source_handoff_envelope_requires_recovery_cycle_provenance(
+    parent_events: &[LedgerEvent],
+    source_handoff_envelope_id: &str,
+    source_handoff_envelope_fingerprint: &str,
+) -> bool {
+    parent_events.iter().any(|event| {
+        if event.kind != LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded {
+            return false;
+        }
+        let Some(payload) = event.payload.as_ref() else {
+            return false;
+        };
+        payload
+            .get("handoff_envelope_status")
+            .and_then(Value::as_str)
+            == Some("Accepted")
+            && payload.get("handoff_envelope_id").and_then(Value::as_str)
+                == Some(source_handoff_envelope_id)
+            && payload
+                .get("handoff_envelope_fingerprint")
+                .and_then(Value::as_str)
+                == Some(source_handoff_envelope_fingerprint)
+            && payload
+                .get("parent_join_recovery_cycle")
+                .and_then(Value::as_bool)
+                == Some(true)
+    })
 }
 
 fn recovery_cycle_child_provenance_is_internally_valid(
@@ -18603,6 +18641,29 @@ mod tests {
         assert!(child_events
             .iter()
             .any(|event| event.kind == LedgerEventKind::TaskCompleted));
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
+    }
+
+    #[test]
+    fn task_run_rejects_recovery_cycle_child_with_missing_provenance() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let (_parent, child, _provenance) =
+            start_recovery_cycle_child_with_parent_evidence(temp.path());
+        mutate_task_state(temp.path(), &child.run_id, |state| {
+            state["recovery_cycle_provenance"] = Value::Null;
+        });
+
+        assert_recovery_child_run_rejected_before_running(
+            temp.path(),
+            &child,
+            "recovery-cycle child task provenance is missing",
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
         clear_llm_env_for_test();

--- a/docs/architecture/phase-value-manifest.m5.26.json
+++ b/docs/architecture/phase-value-manifest.m5.26.json
@@ -1,0 +1,87 @@
+{
+  "phase": "M5.26",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "recovery_child_run_provenance_admission_guard",
+  "forbidden_pattern": "additional_blocked_summary_event_wrapper_or_inspection_only_endpoint_without_child_run_provenance_admission_guard",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Turns M5.25 recovery-cycle child provenance from inspectable metadata into an explicit child run admission guard tied to parent ledger evidence."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Prevents stale or corrupted recovery-cycle child lineage from being admitted in unattended workflows before the child enters Running."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "explicit_child_run_guard",
+        "prompt": "Does explicit task.run for a queued recovery-cycle child validate provenance before Running?"
+      },
+      {
+        "id": "parent_join_evidence",
+        "prompt": "Does the guard require matching ParentJoinContinuationFingerprintConsumed evidence?"
+      },
+      {
+        "id": "handoff_evidence",
+        "prompt": "Does the guard require matching accepted SubtaskDispatchHandoffEnvelopeRecorded evidence?"
+      },
+      {
+        "id": "stale_rejection",
+        "prompt": "Do stale admission ids, completion fingerprints, and source handoff fingerprints reject before TaskRunning?"
+      },
+      {
+        "id": "non_recovery_compatibility",
+        "prompt": "Do normal and initial controlled child task.run paths remain compatible?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "explicit_child_run_guard": "Yes. Queued child task.run calls with recovery_cycle_provenance now pass through validate_recovery_cycle_child_run_provenance before status can change to Running.",
+      "parent_join_evidence": "Yes. The guard requires parent ledger ParentJoinContinuationFingerprintConsumed evidence matching parent_join_admission_id, parent_join_child_completion_fingerprint, terminal counts, and recovery-cycle depth.",
+      "handoff_evidence": "Yes. The guard requires accepted SubtaskDispatchHandoffEnvelopeRecorded evidence matching source_handoff_envelope_fingerprint, parent_join_admission_id, completion fingerprint, terminal counts, recovery flag, and depth.",
+      "stale_rejection": "Yes. Deterministic tests corrupt parent_join_admission_id, parent_join_child_completion_fingerprint, terminal child counts, recovery-cycle depth, and source_handoff_envelope_fingerprint and verify rejection before TaskRunning.",
+      "non_recovery_compatibility": "Yes. The guard is conditional on recovery_cycle_provenance, preserving existing explicit task.run behavior for non-recovery tasks and initial controlled children.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "explicit task.run for a queued recovery-cycle child validates parent ledger admission before TaskRunning.",
+    "explicit task.run for a queued recovery-cycle child validates accepted handoff envelope evidence before TaskRunning.",
+    "The parent ledger admission evidence is a matching ParentJoinContinuationFingerprintConsumed event.",
+    "The accepted handoff envelope evidence is a matching SubtaskDispatchHandoffEnvelopeRecorded event.",
+    "The guard validates parent_join_admission_id.",
+    "The guard validates parent_join_child_completion_fingerprint.",
+    "The guard validates source_handoff_envelope_fingerprint.",
+    "Stale terminal counts reject before TaskRunning.",
+    "Stale recovery-cycle flag or depth reject before TaskRunning.",
+    "Valid recovery-cycle children continue to run only through explicit task.run.",
+    "No child auto-run occurs.",
+    "No raw child prompts, provider responses, file contents, command strings, stdout, stderr, environment values, raw tool input objects, serialized request bodies, raw failure payloads, or unbounded error text are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "validate_recovery_cycle_child_run_provenance",
+      "recovery_cycle_child_provenance_is_internally_valid",
+      "recovery_cycle_provenance_matches_parent_join",
+      "recovery_cycle_provenance_matches_handoff_envelope",
+      "task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance",
+      "task_run_rejects_recovery_cycle_child_with_stale_parent_join_admission_id",
+      "task_run_rejects_recovery_cycle_child_with_stale_completion_fingerprint",
+      "task_run_rejects_recovery_cycle_child_with_stale_terminal_counts",
+      "task_run_rejects_recovery_cycle_child_with_stale_recovery_depth",
+      "task_run_rejects_recovery_cycle_child_with_stale_handoff_fingerprint",
+      "ParentJoinContinuationFingerprintConsumed",
+      "SubtaskDispatchHandoffEnvelopeRecorded",
+      "source_handoff_envelope_fingerprint",
+      "TaskRunning"
+    ]
+  }
+}

--- a/docs/architecture/phase-value-manifest.m5.26.json
+++ b/docs/architecture/phase-value-manifest.m5.26.json
@@ -31,7 +31,7 @@
       },
       {
         "id": "stale_rejection",
-        "prompt": "Do stale admission ids, completion fingerprints, and source handoff fingerprints reject before TaskRunning?"
+        "prompt": "Do missing provenance, stale admission ids, completion fingerprints, and source handoff fingerprints reject before TaskRunning?"
       },
       {
         "id": "non_recovery_compatibility",
@@ -46,7 +46,7 @@
       "explicit_child_run_guard": "Yes. Queued child task.run calls with recovery_cycle_provenance now pass through validate_recovery_cycle_child_run_provenance before status can change to Running.",
       "parent_join_evidence": "Yes. The guard requires parent ledger ParentJoinContinuationFingerprintConsumed evidence matching parent_join_admission_id, parent_join_child_completion_fingerprint, terminal counts, and recovery-cycle depth.",
       "handoff_evidence": "Yes. The guard requires accepted SubtaskDispatchHandoffEnvelopeRecorded evidence matching source_handoff_envelope_fingerprint, parent_join_admission_id, completion fingerprint, terminal counts, recovery flag, and depth.",
-      "stale_rejection": "Yes. Deterministic tests corrupt parent_join_admission_id, parent_join_child_completion_fingerprint, terminal child counts, recovery-cycle depth, and source_handoff_envelope_fingerprint and verify rejection before TaskRunning.",
+      "stale_rejection": "Yes. Deterministic tests remove recovery_cycle_provenance or corrupt parent_join_admission_id, parent_join_child_completion_fingerprint, terminal child counts, recovery-cycle depth, and source_handoff_envelope_fingerprint and verify rejection before TaskRunning.",
       "non_recovery_compatibility": "Yes. The guard is conditional on recovery_cycle_provenance, preserving existing explicit task.run behavior for non-recovery tasks and initial controlled children.",
       "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
     }
@@ -56,6 +56,7 @@
     "explicit task.run for a queued recovery-cycle child validates accepted handoff envelope evidence before TaskRunning.",
     "The parent ledger admission evidence is a matching ParentJoinContinuationFingerprintConsumed event.",
     "The accepted handoff envelope evidence is a matching SubtaskDispatchHandoffEnvelopeRecorded event.",
+    "Missing recovery-cycle provenance rejects before TaskRunning when the accepted handoff envelope requires recovery-cycle provenance.",
     "The guard validates parent_join_admission_id.",
     "The guard validates parent_join_child_completion_fingerprint.",
     "The guard validates source_handoff_envelope_fingerprint.",
@@ -69,10 +70,12 @@
   "source_evidence": {
     "rust_runtime_tokens": [
       "validate_recovery_cycle_child_run_provenance",
+      "source_handoff_envelope_requires_recovery_cycle_provenance",
       "recovery_cycle_child_provenance_is_internally_valid",
       "recovery_cycle_provenance_matches_parent_join",
       "recovery_cycle_provenance_matches_handoff_envelope",
       "task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance",
+      "task_run_rejects_recovery_cycle_child_with_missing_provenance",
       "task_run_rejects_recovery_cycle_child_with_stale_parent_join_admission_id",
       "task_run_rejects_recovery_cycle_child_with_stale_completion_fingerprint",
       "task_run_rejects_recovery_cycle_child_with_stale_terminal_counts",

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -81,6 +81,7 @@ function validateManifest(manifest) {
     'accepted handoff envelope',
     'ParentJoinContinuationFingerprintConsumed',
     'SubtaskDispatchHandoffEnvelopeRecorded',
+    'Missing recovery-cycle provenance',
     'parent_join_admission_id',
     'parent_join_child_completion_fingerprint',
     'source_handoff_envelope_fingerprint',
@@ -115,10 +116,12 @@ function validateSourceEvidence(manifest) {
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   for (const token of [
     'validate_recovery_cycle_child_run_provenance',
+    'source_handoff_envelope_requires_recovery_cycle_provenance',
     'recovery_cycle_child_provenance_is_internally_valid',
     'recovery_cycle_provenance_matches_parent_join',
     'recovery_cycle_provenance_matches_handoff_envelope',
     'task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance',
+    'task_run_rejects_recovery_cycle_child_with_missing_provenance',
     'task_run_rejects_recovery_cycle_child_with_stale_parent_join_admission_id',
     'task_run_rejects_recovery_cycle_child_with_stale_completion_fingerprint',
     'task_run_rejects_recovery_cycle_child_with_stale_terminal_counts',

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.25';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.25.json';
+const phase = 'M5.26';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.26.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'recovery_cycle_child_provenance_inspection',
-    `${phase} must declare the recovery-cycle child provenance inspection transition.`
+    manifest.concrete_capability_transition === 'recovery_child_run_provenance_admission_guard',
+    `${phase} must declare the recovery child run provenance admission guard transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_diagnostics_only_report_without_recovery_cycle_child_provenance_runtime_progress',
-    `${phase} must forbid wrapper-only or diagnostics-only work without recovery-cycle child provenance runtime progress.`
+    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_inspection_only_endpoint_without_child_run_provenance_admission_guard',
+    `${phase} must forbid wrapper-only or inspection-only work without child run provenance admission guard progress.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,22 +75,16 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'repeated recovery-cycle child',
-    'RecoveryCycleChildProvenance',
-    'recovery_cycle_provenance',
+    'explicit task.run',
+    'queued recovery-cycle child',
+    'parent ledger admission',
+    'accepted handoff envelope',
+    'ParentJoinContinuationFingerprintConsumed',
+    'SubtaskDispatchHandoffEnvelopeRecorded',
     'parent_join_admission_id',
     'parent_join_child_completion_fingerprint',
-    'parent_join_child_completion_child_count',
-    'parent_join_terminal_failed_child_count',
-    'parent_join_terminal_completed_child_count',
-    'parent_join_recovery_cycle',
-    'parent_join_recovery_cycle_depth',
-    'task.inspect',
-    'run.inspect',
-    'child_tasks',
-    'fail-closed',
-    'sha256:<64 lowercase hex>',
-    'failed plus completed counts',
+    'source_handoff_envelope_fingerprint',
+    'TaskRunning',
     'No child auto-run',
     'No raw child prompts',
     'No scheduler handoff'
@@ -111,63 +105,32 @@ function requireToken(relativePath, token) {
 
 function validateSourceEvidence(manifest) {
   const evidence = manifest.source_evidence ?? {};
-  for (const token of evidence.rust_tools_tokens ?? []) {
-    requireToken('crates/brownie-tools/src/lib.rs', token);
+  for (const token of evidence.rust_runtime_tokens ?? []) {
+    requireToken('crates/brownie-runtime/src/lib.rs', token);
   }
   for (const token of evidence.rust_store_tokens ?? []) {
     requireToken('crates/brownie-store/src/lib.rs', token);
   }
-  for (const token of evidence.rust_protocol_tokens ?? []) {
-    requireToken('crates/brownie-protocol/src/lib.rs', token);
-  }
-  for (const token of evidence.rust_context_tokens ?? []) {
-    requireToken('crates/brownie-context/src/lib.rs', token);
-  }
-  for (const token of evidence.rust_llm_tokens ?? []) {
-    requireToken('crates/brownie-llm/src/lib.rs', token);
-  }
-  for (const token of evidence.rust_runtime_tokens ?? []) {
-    requireToken('crates/brownie-runtime/src/lib.rs', token);
-  }
-  for (const token of evidence.vsix_protocol_tokens ?? []) {
-    requireToken('extensions/brownie-vsix/src/runtime/protocol.ts', token);
-  }
-  for (const token of evidence.vsix_test_tokens ?? []) {
-    requireToken('extensions/brownie-vsix/src/test/runtimeClient.test.ts', token);
-  }
-  for (const token of evidence.runtime_protocol_spec_tokens ?? []) {
-    requireToken('docs/specifications/runtime-protocol-spec-v0.md', token);
-  }
-  for (const token of evidence.task_runtime_spec_tokens ?? []) {
-    requireToken('docs/specifications/task-runtime-spec-v0.md', token);
-  }
-  for (const token of evidence.run_inspection_spec_tokens ?? []) {
-    requireToken('docs/specifications/run-inspection-spec-v0.md', token);
-  }
 
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
-  const storeText = readText('crates/brownie-store/src/lib.rs');
   for (const token of [
-    'RecoveryCycleChildProvenance',
-    'recovery_cycle_provenance',
-    'recovery_cycle_child_provenance_from_handoff_envelope',
-    'parent_join_admission_id',
-    'parent_join_child_completion_fingerprint',
-    'parent_join_child_completion_child_count',
-    'parent_join_terminal_failed_child_count',
-    'parent_join_terminal_completed_child_count',
-    'parent_join_recovery_cycle',
-    'parent_join_recovery_cycle_depth',
-    'task_run_parent_join_repeated_recovery_cycle_materializes_next_child_without_auto_run',
-    'recovery_cycle_child_provenance_validation_rejects_invalid_envelopes',
-    'invalid_recovery_cycle_handoff_envelope_does_not_materialize_child',
-    'is_sha256_fingerprint',
-    'task.inspect',
-    'run.inspect',
-    'child_tasks'
+    'validate_recovery_cycle_child_run_provenance',
+    'recovery_cycle_child_provenance_is_internally_valid',
+    'recovery_cycle_provenance_matches_parent_join',
+    'recovery_cycle_provenance_matches_handoff_envelope',
+    'task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance',
+    'task_run_rejects_recovery_cycle_child_with_stale_parent_join_admission_id',
+    'task_run_rejects_recovery_cycle_child_with_stale_completion_fingerprint',
+    'task_run_rejects_recovery_cycle_child_with_stale_terminal_counts',
+    'task_run_rejects_recovery_cycle_child_with_stale_recovery_depth',
+    'task_run_rejects_recovery_cycle_child_with_stale_handoff_fingerprint',
+    'ParentJoinContinuationFingerprintConsumed',
+    'SubtaskDispatchHandoffEnvelopeRecorded',
+    'source_handoff_envelope_fingerprint',
+    'TaskRunning'
   ]) {
-    if (!runtimeText.includes(token) && !storeText.includes(token)) {
-      errors.push(`${phase} source must include ${token}.`);
+    if (!runtimeText.includes(token)) {
+      errors.push(`${phase} runtime source must include ${token}.`);
     }
   }
   const forbiddenWrapperEvents = [
@@ -180,7 +143,7 @@ function validateSourceEvidence(manifest) {
     'SubtaskContinuationChildMaterialized'
   ];
   for (const token of forbiddenWrapperEvents) {
-    if (runtimeText.includes(token) || storeText.includes(token)) {
+    if (runtimeText.includes(token)) {
       errors.push(`${phase} must not add wrapper-only event ${token}.`);
     }
   }


### PR DESCRIPTION
## 概要
- queued recovery-cycle child の explicit `task.run` admission 前に、child の `recovery_cycle_provenance` を parent ledger evidence と照合する guard を追加しました。
- `ParentJoinContinuationFingerprintConsumed` と accepted `SubtaskDispatchHandoffEnvelopeRecorded` の両方に一致しない missing / stale / corrupted provenance は、`TaskRunning` へ進む前に `invalid params` で拒否します。
- M5.26 phase value manifest / guard を追加し、wrapper-only / inspection-only work ではなく runtime admission capability を検証します。

## 安全境界
- child auto-run、scheduler handoff、external worker、patch apply、process exec expansion、network bypass、service control、direct workspace mutation、diagnostics wrapper RPC は追加していません。
- raw prompts、provider responses、file contents、commands、stdout/stderr、env、raw tool input、raw payload、unbounded text は追加公開していません。
- non-recovery task と initial controlled child の explicit `task.run` behavior は維持しています。

## レビュー修正
- accepted recovery-cycle handoff が provenance を要求している child で `recovery_cycle_provenance` が欠落している場合、`TaskRunning` 前に拒否する guard と deterministic test を追加しました。

## 検証
- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
