### PR TITLE
M5.28: expose recovery budget outcome

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -640,12 +640,26 @@ pub struct TaskRunResult {
     pub run_id: String,
     pub status: TaskStatus,
     pub agent_loop: TaskRunAgentLoopSummary,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_cycle_budget_outcome: Option<RecoveryCycleBudgetOutcome>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TaskRunAgentLoopSummary {
     pub final_state: String,
     pub completion_summary: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RecoveryCycleBudgetOutcome {
+    pub recovery_cycle_budget_status: String,
+    pub parent_join_admission_id: String,
+    pub parent_join_recovery_cycle_depth: usize,
+    pub max_recovery_cycle_depth: usize,
+    pub blocked_candidate_count: usize,
+    pub child_materialization_enabled: bool,
+    pub child_running_enabled: bool,
+    pub next_action: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -2292,6 +2306,8 @@ pub struct RunInspectSummary {
     pub run_id: String,
     pub task_id: Option<String>,
     pub status: Option<TaskStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recovery_cycle_budget_outcome: Option<RecoveryCycleBudgetOutcome>,
     pub child_task_count: usize,
     pub child_task_ids: Vec<String>,
     pub child_tasks: Vec<ChildTaskInspectSummary>,

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -102,20 +102,20 @@ use brownie_protocol::{
     ProposalReviewQueueDiagnosticsReportParams, ProposalReviewQueueDiagnosticsReportResult,
     ProposalReviewQueueDiagnosticsResult, ProposalReviewQueueParams, ProposalReviewQueueResult,
     ProposalReviewReportParams, ProposalReviewReportResult, ProposalReviewVerdictParams,
-    ProposalReviewVerdictResult, RecoveryCycleChildProvenance, RunEventsParams, RunEventsResult,
-    RunInspectParams, RunInspectResult, RunInspectSummary, RuntimeActionName,
-    RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult, RuntimeState,
-    RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult, TaskListResult, TaskRecord,
-    TaskRunAgentLoopSummary, TaskRunParams, TaskRunResult, TaskStartParams, TaskStartResult,
-    TaskStatus, ToolExecuteParams, ToolExecuteResult, ToolExecuteStatus, ToolIntentDecisionSummary,
-    ToolIntentInputSummary, ToolIntentParseParams, ToolIntentParseResult,
-    ToolIntentParserConfigSummary, ToolIntentParserSummary, ToolIntentRejectedSummary,
-    ToolListResult, ToolPlanDecisionSummary, ToolPlanParams, ToolPlanResult, ToolSummary,
-    WorkspacePatchApplyCapabilityCheckSummary, WorkspacePatchApplyCapabilitySummary,
-    WorkspacePatchApplyCheckSummary, WorkspacePatchApplyDryRunCheckSummary,
-    WorkspacePatchApplyDryRunHistoryEntry, WorkspacePatchApplyDryRunHistorySummary,
-    WorkspacePatchApplyDryRunSummary, WorkspacePatchApplyPlanSummary,
-    WorkspacePatchAuditTrailEntry, WorkspacePatchAuditTrailSummary,
+    ProposalReviewVerdictResult, RecoveryCycleBudgetOutcome, RecoveryCycleChildProvenance,
+    RunEventsParams, RunEventsResult, RunInspectParams, RunInspectResult, RunInspectSummary,
+    RuntimeActionName, RuntimeConfigGetResult, RuntimeDiagnostic, RuntimeDiagnosticsResult,
+    RuntimeState, RuntimeStatus, TaskGetParams, TaskInspectParams, TaskInspectResult,
+    TaskListResult, TaskRecord, TaskRunAgentLoopSummary, TaskRunParams, TaskRunResult,
+    TaskStartParams, TaskStartResult, TaskStatus, ToolExecuteParams, ToolExecuteResult,
+    ToolExecuteStatus, ToolIntentDecisionSummary, ToolIntentInputSummary, ToolIntentParseParams,
+    ToolIntentParseResult, ToolIntentParserConfigSummary, ToolIntentParserSummary,
+    ToolIntentRejectedSummary, ToolListResult, ToolPlanDecisionSummary, ToolPlanParams,
+    ToolPlanResult, ToolSummary, WorkspacePatchApplyCapabilityCheckSummary,
+    WorkspacePatchApplyCapabilitySummary, WorkspacePatchApplyCheckSummary,
+    WorkspacePatchApplyDryRunCheckSummary, WorkspacePatchApplyDryRunHistoryEntry,
+    WorkspacePatchApplyDryRunHistorySummary, WorkspacePatchApplyDryRunSummary,
+    WorkspacePatchApplyPlanSummary, WorkspacePatchAuditTrailEntry, WorkspacePatchAuditTrailSummary,
     WorkspacePatchPreflightSnapshotSummary, WorkspacePatchProposalSummary,
     WorkspacePatchReadinessCheckSummary, WorkspacePatchReadinessReportSummary,
     WorkspacePatchReviewBundleSummary, WorkspacePatchReviewQueueDiagnosticsCheckSummary,
@@ -2125,6 +2125,12 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         }
     };
 
+    let recovery_cycle_budget_outcome =
+        match recovery_cycle_budget_outcome_for_run(&store, &running.run_id) {
+            Ok(outcome) => outcome,
+            Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+        };
+
     match store
         .tasks()
         .update_task_status(&running.task_id, final_status, event_kind)
@@ -2139,6 +2145,7 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
                     final_state: agent_loop_state_name(agent_loop_final_state).to_string(),
                     completion_summary: agent_loop_completion_summary,
                 },
+                recovery_cycle_budget_outcome,
             }),
         ),
         Err(error) => error_response(id, -32603, &format!("internal error: {error}")),
@@ -10114,6 +10121,7 @@ fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, 
         run_id: run_id.to_string(),
         task_id: task.as_ref().map(|task| task.task_id.clone()),
         status: task.as_ref().map(|task| task.status.clone()),
+        recovery_cycle_budget_outcome: recovery_cycle_budget_outcome_from_events(&events),
         child_task_count: child_task_ids.len(),
         child_task_ids,
         child_tasks: child_task_summaries,
@@ -10145,6 +10153,77 @@ fn inspect_run(store: &BrownieStore, run_id: &str) -> Result<RunInspectSummary, 
         final_response_preview,
         timeline: events.iter().map(timeline_entry).collect(),
     })
+}
+
+fn recovery_cycle_budget_outcome_for_run(
+    store: &BrownieStore,
+    run_id: &str,
+) -> Result<Option<RecoveryCycleBudgetOutcome>, String> {
+    let events = store
+        .tasks()
+        .read_ledger_events(run_id)
+        .map_err(|error| format!("invalid params: {error}"))?;
+    Ok(recovery_cycle_budget_outcome_from_events(&events))
+}
+
+fn recovery_cycle_budget_outcome_from_events(
+    events: &[LedgerEvent],
+) -> Option<RecoveryCycleBudgetOutcome> {
+    events.iter().rev().find_map(|event| {
+        if event.kind != LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded {
+            return None;
+        }
+        let payload = event.payload.as_ref()?;
+        if payload
+            .get("recovery_cycle_budget_status")
+            .and_then(Value::as_str)
+            != Some("Exceeded")
+        {
+            return None;
+        }
+
+        let parent_join_admission_id =
+            non_empty_payload_string(payload, "parent_join_admission_id")?;
+        let parent_join_recovery_cycle_depth =
+            payload_usize(payload, "parent_join_recovery_cycle_depth")?;
+        let max_recovery_cycle_depth = payload_usize(payload, "max_recovery_cycle_depth")?;
+        let blocked_candidate_count = payload_usize(payload, "blocked_candidate_count")
+            .unwrap_or_else(|| payload_string_array(payload, "blocked_candidate_ids").len());
+        if parent_join_recovery_cycle_depth <= max_recovery_cycle_depth
+            || blocked_candidate_count == 0
+        {
+            return None;
+        }
+        let next_action = non_empty_payload_string(payload, "next_action")
+            .unwrap_or_else(|| "stop_recovery_cycle_materialization".to_string());
+
+        Some(RecoveryCycleBudgetOutcome {
+            recovery_cycle_budget_status: "Exceeded".to_string(),
+            parent_join_admission_id,
+            parent_join_recovery_cycle_depth,
+            max_recovery_cycle_depth,
+            blocked_candidate_count,
+            child_materialization_enabled: false,
+            child_running_enabled: false,
+            next_action,
+        })
+    })
+}
+
+fn non_empty_payload_string(payload: &Value, key: &str) -> Option<String> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+fn payload_usize(payload: &Value, key: &str) -> Option<usize> {
+    payload
+        .get(key)
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok())
 }
 
 fn child_task_inspect_summary(
@@ -17924,6 +18003,442 @@ mod tests {
                 .count(),
             0
         );
+    }
+
+    #[test]
+    fn task_run_parent_join_budget_exhaustion_returns_bounded_outcome_without_child_materialization(
+    ) {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        clear_llm_env_for_test();
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let store = BrownieStore::new(temp.path());
+        let parent = store
+            .tasks()
+            .start_task(brownie_protocol::TaskStartParams {
+                goal: "Parent over-budget recovery-cycle outcome".into(),
+                mode_id: Some("orchestrator".into()),
+            })
+            .expect("start parent");
+        let running_parent = store
+            .tasks()
+            .update_task_status(
+                &parent.task_id,
+                TaskStatus::Running,
+                LedgerEventKind::TaskRunning,
+            )
+            .expect("run parent");
+        store
+            .tasks()
+            .append_task_event_with_payload(
+                &running_parent,
+                LedgerEventKind::AgentLoopCompleted,
+                Some(json!({
+                    "final_state": "Completed",
+                    "completion_summary": "Synthetic parent completed before budget exhaustion join.",
+                    "completion_result_fingerprint": format!("sha256:{}", "1".repeat(64))
+                })),
+            )
+            .expect("append parent completion");
+        store
+            .tasks()
+            .update_task_status(
+                &parent.task_id,
+                TaskStatus::Completed,
+                LedgerEventKind::TaskCompleted,
+            )
+            .expect("complete parent");
+
+        fn append_parent_handoff(
+            store: &BrownieStore,
+            parent: &TaskRecord,
+            candidate_id: &str,
+            handoff_id: &str,
+            handoff_fingerprint: &str,
+            provenance: Option<&RecoveryCycleChildProvenance>,
+        ) {
+            let mut payload = json!({
+                "handoff_envelope_status": "Accepted",
+                "handoff_envelope_id": handoff_id,
+                "handoff_envelope_fingerprint": handoff_fingerprint,
+                "candidate_ids": [candidate_id],
+                "scheduler_handoff_status": "Blocked",
+                "execution_enabled": false,
+                "reason": "Accepted synthetic handoff for M5.28 parent budget outcome test."
+            });
+            if let Some(provenance) = provenance {
+                payload["parent_join_admission_id"] = json!(provenance.parent_join_admission_id);
+                payload["parent_join_child_completion_fingerprint"] =
+                    json!(provenance.parent_join_child_completion_fingerprint);
+                payload["parent_join_child_completion_child_count"] =
+                    json!(provenance.parent_join_child_completion_child_count);
+                payload["parent_join_terminal_failed_child_count"] =
+                    json!(provenance.parent_join_terminal_failed_child_count);
+                payload["parent_join_terminal_completed_child_count"] =
+                    json!(provenance.parent_join_terminal_completed_child_count);
+                payload["parent_join_recovery_cycle"] =
+                    json!(provenance.parent_join_recovery_cycle);
+                payload["parent_join_recovery_cycle_depth"] =
+                    json!(provenance.parent_join_recovery_cycle_depth);
+            } else {
+                payload["parent_join_recovery_cycle"] = json!(false);
+                payload["parent_join_recovery_cycle_depth"] = json!(0);
+            }
+            store
+                .tasks()
+                .append_task_event_with_payload(
+                    parent,
+                    LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded,
+                    Some(payload),
+                )
+                .expect("append parent handoff");
+        }
+
+        fn append_parent_join_consumption(
+            store: &BrownieStore,
+            parent: &TaskRecord,
+            provenance: &RecoveryCycleChildProvenance,
+        ) {
+            store
+                .tasks()
+                .append_task_event_with_payload(
+                    parent,
+                    LedgerEventKind::ParentJoinContinuationFingerprintConsumed,
+                    Some(json!({
+                        "parent_join_continuation_status": "Consumed",
+                        "admission_id": provenance.parent_join_admission_id,
+                        "child_completion_fingerprint": provenance.parent_join_child_completion_fingerprint,
+                        "child_completion_child_count": provenance.parent_join_child_completion_child_count,
+                        "child_terminal_failed_count": provenance.parent_join_terminal_failed_child_count,
+                        "child_terminal_completed_count": provenance.parent_join_terminal_completed_child_count,
+                        "child_recovery_cycle_depth": provenance.parent_join_recovery_cycle_depth,
+                        "fingerprint_input_count": 6
+                    })),
+                )
+                .expect("append parent join consumption");
+        }
+
+        fn start_terminal_child(
+            store: &BrownieStore,
+            parent: &TaskRecord,
+            source_candidate_id: &str,
+            source_handoff_envelope_id: &str,
+            source_handoff_envelope_fingerprint: &str,
+            recovery_cycle_provenance: Option<RecoveryCycleChildProvenance>,
+            status: TaskStatus,
+            raw_marker: &str,
+        ) -> TaskRecord {
+            let child = store
+                .tasks()
+                .start_child_task(ChildTaskStartParams {
+                    goal: "Synthetic M5.28 child".into(),
+                    mode_id: Some("orchestrator".into()),
+                    parent_task_id: parent.task_id.clone(),
+                    parent_run_id: parent.run_id.clone(),
+                    source_candidate_id: source_candidate_id.into(),
+                    source_handoff_envelope_id: source_handoff_envelope_id.into(),
+                    source_handoff_envelope_fingerprint: source_handoff_envelope_fingerprint.into(),
+                    source_intent_summary: Some(ChildTaskSourceIntentSummary {
+                        tool_id: SUBTASK_SPAWN_TOOL_ID.into(),
+                        required_action: RuntimeActionName::SpawnSubtask,
+                        request_reason: raw_marker.into(),
+                        requested_goal_preview: Some(raw_marker.into()),
+                        requested_mode_id: Some("orchestrator".into()),
+                        input_summary: ToolIntentInputSummary {
+                            has_path: false,
+                            field_count: 0,
+                        },
+                    }),
+                    recovery_cycle_provenance,
+                })
+                .expect("start child");
+            let running_child = store
+                .tasks()
+                .update_task_status(
+                    &child.task_id,
+                    TaskStatus::Running,
+                    LedgerEventKind::TaskRunning,
+                )
+                .expect("run child");
+            let final_state = match &status {
+                TaskStatus::Completed => "Completed",
+                TaskStatus::Failed => "Failed",
+                _ => panic!("synthetic terminal child must complete or fail"),
+            };
+            let terminal_event_kind = match &status {
+                TaskStatus::Completed => LedgerEventKind::TaskCompleted,
+                TaskStatus::Failed => LedgerEventKind::TaskFailed,
+                _ => LedgerEventKind::TaskFailed,
+            };
+            store
+                .tasks()
+                .append_task_event_with_payload(
+                    &running_child,
+                    LedgerEventKind::AgentLoopCompleted,
+                    Some(json!({
+                        "final_state": final_state,
+                        "completion_summary": raw_marker,
+                        "completion_result_fingerprint": format!("sha256:{}", source_candidate_id.chars().filter(|ch| ch.is_ascii_hexdigit()).chain(std::iter::repeat('a')).take(64).collect::<String>())
+                    })),
+                )
+                .expect("append child completion");
+            store
+                .tasks()
+                .update_task_status(&child.task_id, status, terminal_event_kind)
+                .expect("terminal child")
+        }
+
+        let initial_handoff_fingerprint = format!("sha256:{}", "2".repeat(64));
+        append_parent_handoff(
+            &store,
+            &parent,
+            "candidate_initial_failed",
+            "handoff_initial_failed",
+            &initial_handoff_fingerprint,
+            None,
+        );
+        start_terminal_child(
+            &store,
+            &parent,
+            "candidate_initial_failed",
+            "handoff_initial_failed",
+            &initial_handoff_fingerprint,
+            None,
+            TaskStatus::Failed,
+            "RAW_M5_28_FAILED_CHILD_MARKER_SHOULD_NOT_APPEAR",
+        );
+
+        let first_handoff_fingerprint = format!("sha256:{}", "3".repeat(64));
+        append_parent_handoff(
+            &store,
+            &parent,
+            "candidate_first_recovery",
+            "handoff_first_recovery",
+            &first_handoff_fingerprint,
+            None,
+        );
+        start_terminal_child(
+            &store,
+            &parent,
+            "candidate_first_recovery",
+            "handoff_first_recovery",
+            &first_handoff_fingerprint,
+            None,
+            TaskStatus::Completed,
+            "RAW_M5_28_FIRST_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+        );
+
+        let second_provenance = RecoveryCycleChildProvenance {
+            parent_join_admission_id: "admission_second_recovery".into(),
+            parent_join_child_completion_fingerprint: format!("sha256:{}", "4".repeat(64)),
+            parent_join_child_completion_child_count: 2,
+            parent_join_terminal_failed_child_count: 1,
+            parent_join_terminal_completed_child_count: 1,
+            parent_join_recovery_cycle: true,
+            parent_join_recovery_cycle_depth: 1,
+        };
+        append_parent_join_consumption(&store, &parent, &second_provenance);
+        let second_handoff_fingerprint = format!("sha256:{}", "5".repeat(64));
+        append_parent_handoff(
+            &store,
+            &parent,
+            "candidate_second_recovery",
+            "handoff_second_recovery",
+            &second_handoff_fingerprint,
+            Some(&second_provenance),
+        );
+        start_terminal_child(
+            &store,
+            &parent,
+            "candidate_second_recovery",
+            "handoff_second_recovery",
+            &second_handoff_fingerprint,
+            Some(second_provenance),
+            TaskStatus::Completed,
+            "RAW_M5_28_SECOND_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+        );
+
+        let third_provenance = RecoveryCycleChildProvenance {
+            parent_join_admission_id: "admission_third_recovery".into(),
+            parent_join_child_completion_fingerprint: format!("sha256:{}", "6".repeat(64)),
+            parent_join_child_completion_child_count: 3,
+            parent_join_terminal_failed_child_count: 1,
+            parent_join_terminal_completed_child_count: 2,
+            parent_join_recovery_cycle: true,
+            parent_join_recovery_cycle_depth: MAX_RECOVERY_CYCLE_DEPTH,
+        };
+        append_parent_join_consumption(&store, &parent, &third_provenance);
+        let third_handoff_fingerprint = format!("sha256:{}", "7".repeat(64));
+        append_parent_handoff(
+            &store,
+            &parent,
+            "candidate_third_recovery",
+            "handoff_third_recovery",
+            &third_handoff_fingerprint,
+            Some(&third_provenance),
+        );
+        start_terminal_child(
+            &store,
+            &parent,
+            "candidate_third_recovery",
+            "handoff_third_recovery",
+            &third_handoff_fingerprint,
+            Some(third_provenance),
+            TaskStatus::Completed,
+            "RAW_M5_28_THIRD_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+        );
+
+        let child_count_before_budget_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks before budget join")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .count();
+        assert_eq!(child_count_before_budget_join, 4);
+        let child_running_event_count_before_budget_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks before budget join running events")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .map(|record| {
+                store
+                    .tasks()
+                    .read_ledger_events(&record.run_id)
+                    .expect("read child events before budget join")
+                    .into_iter()
+                    .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                    .count()
+            })
+            .sum::<usize>();
+
+        let budget_parent_join = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":31,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            parent.task_id
+        ));
+        assert!(budget_parent_join.error.is_none());
+        let budget_parent_join_result = budget_parent_join
+            .result
+            .expect("budget parent join result");
+        let outcome = budget_parent_join_result["recovery_cycle_budget_outcome"].clone();
+        assert_eq!(outcome["recovery_cycle_budget_status"], "Exceeded");
+        assert_eq!(
+            outcome["parent_join_recovery_cycle_depth"],
+            json!(MAX_RECOVERY_CYCLE_DEPTH + 1)
+        );
+        assert_eq!(
+            outcome["max_recovery_cycle_depth"],
+            json!(MAX_RECOVERY_CYCLE_DEPTH)
+        );
+        assert_eq!(outcome["blocked_candidate_count"], 1);
+        assert_eq!(outcome["child_materialization_enabled"], false);
+        assert_eq!(outcome["child_running_enabled"], false);
+        assert_eq!(
+            outcome["next_action"],
+            "stop_recovery_cycle_materialization"
+        );
+        let admission_id = outcome["parent_join_admission_id"]
+            .as_str()
+            .expect("budget outcome admission id")
+            .to_string();
+
+        let parent_events_after_budget_join = store
+            .tasks()
+            .read_ledger_events(&parent.run_id)
+            .expect("parent events after budget join");
+        let budget_block = parent_events_after_budget_join
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded)
+            .filter_map(|event| event.payload.as_ref())
+            .find(|payload| {
+                payload
+                    .get("parent_join_admission_id")
+                    .and_then(Value::as_str)
+                    == Some(admission_id.as_str())
+                    && payload
+                        .get("recovery_cycle_budget_status")
+                        .and_then(Value::as_str)
+                        == Some("Exceeded")
+            })
+            .expect("budget-blocked handoff for parent task.run");
+        assert_eq!(budget_block["handoff_envelope_status"], "Blocked");
+        assert_eq!(budget_block["blocked_candidate_count"], 1);
+        assert_eq!(budget_block["eligible_candidate_count"], 0);
+        assert_eq!(payload_string_array(budget_block, "candidate_ids").len(), 1);
+        assert_eq!(
+            payload_string_array(budget_block, "blocked_candidate_ids"),
+            payload_string_array(budget_block, "candidate_ids")
+        );
+
+        let child_count_after_budget_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks after budget join")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .count();
+        assert_eq!(
+            child_count_after_budget_join,
+            child_count_before_budget_join
+        );
+        let child_running_event_count_after_budget_join = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks after budget join running events")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .map(|record| {
+                store
+                    .tasks()
+                    .read_ledger_events(&record.run_id)
+                    .expect("read child events after budget join")
+                    .into_iter()
+                    .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                    .count()
+            })
+            .sum::<usize>();
+        assert_eq!(
+            child_running_event_count_after_budget_join,
+            child_running_event_count_before_budget_join
+        );
+
+        let parent_run_inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":32,"method":"run.inspect","params":{{"run_id":"{}"}}}}"#,
+            parent.run_id
+        ));
+        assert!(parent_run_inspect.error.is_none());
+        assert_eq!(
+            parent_run_inspect
+                .result
+                .expect("parent run inspect result")["run"]["recovery_cycle_budget_outcome"],
+            outcome
+        );
+
+        let parent_task_inspect = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":33,"method":"task.inspect","params":{{"task_id":"{}"}}}}"#,
+            parent.task_id
+        ));
+        assert!(parent_task_inspect.error.is_none());
+        assert_eq!(
+            parent_task_inspect
+                .result
+                .expect("parent task inspect result")["run"]["recovery_cycle_budget_outcome"],
+            outcome
+        );
+
+        let serialized_outcome = outcome.to_string();
+        for raw_marker in [
+            "RAW_M5_28_FAILED_CHILD_MARKER_SHOULD_NOT_APPEAR",
+            "RAW_M5_28_FIRST_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+            "RAW_M5_28_SECOND_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+            "RAW_M5_28_THIRD_RECOVERY_MARKER_SHOULD_NOT_APPEAR",
+        ] {
+            assert!(!serialized_outcome.contains(raw_marker));
+        }
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        clear_llm_env_for_test();
     }
 
     #[test]

--- a/docs/architecture/phase-value-manifest.m5.28.json
+++ b/docs/architecture/phase-value-manifest.m5.28.json
@@ -1,0 +1,99 @@
+{
+  "phase": "M5.28",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "recovery_cycle_budget_exhaustion_outcome",
+  "forbidden_pattern": "new_diagnostics_rpc_or_wrapper_chain_without_existing_parent_outcome_contract",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Turns the M5.27 recovery-cycle budget stop into a bounded parent task/run outcome that orchestration callers can consume without ledger inference."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Gives unattended callers a deterministic parent outcome for stopping recovery-cycle materialization when the runtime budget is exhausted."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "parent_task_run_outcome",
+        "prompt": "Does existing parent task.run output expose a bounded recovery-cycle budget exhaustion outcome?"
+      },
+      {
+        "id": "parent_inspection_outcome",
+        "prompt": "Does existing parent inspection output expose the same budget exhaustion outcome without a new diagnostics RPC?"
+      },
+      {
+        "id": "no_child_materialized",
+        "prompt": "Does over-budget recovery continuation still create no child TaskRecord and no child TaskRunning event?"
+      },
+      {
+        "id": "bounded_sanitized_contract",
+        "prompt": "Does the outcome include only deterministic bounded control-flow fields and omit raw child/runtime content?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "parent_task_run_outcome": "Yes. TaskRunResult can include recovery_cycle_budget_outcome when the parent run records recovery_cycle_budget_status Exceeded.",
+      "parent_inspection_outcome": "Yes. RunInspectSummary, used by run.inspect and task.inspect, exposes the same RecoveryCycleBudgetOutcome derived from existing parent ledger evidence.",
+      "no_child_materialized": "Yes. The M5.27 guard still records a blocked handoff envelope only, and the M5.28 test verifies child TaskRecord and TaskRunning counts do not increase.",
+      "bounded_sanitized_contract": "Yes. RecoveryCycleBudgetOutcome contains budget status, admission id, depth, max depth, blocked candidate count, child materialization/running disabled flags, and next action only.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "Existing parent task.run output exposes a bounded recovery-cycle budget exhaustion outcome.",
+    "Existing parent inspection output exposes the same bounded recovery-cycle budget exhaustion outcome without a new diagnostics RPC.",
+    "The recovery-cycle budget exhaustion outcome includes deterministic budget status, exceeded depth, max depth, parent join admission id, blocked candidate count, no-child-materialized signal, no-child-running signal, and next action.",
+    "Over-budget continuation still creates no child TaskRecord.",
+    "Over-budget continuation still creates no child TaskRunning event.",
+    "Explicit task.run still refuses over-budget queued recovery-cycle children before TaskRunning.",
+    "In-budget recovery-cycle child materialization and explicit task.run behavior still works.",
+    "Non-recovery tasks and initial controlled children preserve explicit task.run behavior.",
+    "Failed-child and recovery-child outcome evidence remains bounded and sanitized.",
+    "No raw child prompts, provider responses, file contents, command strings, stdout, stderr, environment values, raw tool input objects, serialized request bodies, raw failure payloads, or unbounded error text are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "recovery_cycle_budget_outcome_for_run",
+      "recovery_cycle_budget_outcome_from_events",
+      "recovery_cycle_budget_status",
+      "child_materialization_enabled",
+      "child_running_enabled",
+      "stop_recovery_cycle_materialization",
+      "task_run_parent_join_budget_exhaustion_returns_bounded_outcome_without_child_materialization",
+      "parent_join_recovery_cycle_budget_blocks_next_child_materialization",
+      "task_run_rejects_over_budget_recovery_cycle_child_before_running",
+      "task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance",
+      "SubtaskDispatchHandoffEnvelopeRecorded",
+      "TaskRunning"
+    ],
+    "rust_protocol_tokens": [
+      "RecoveryCycleBudgetOutcome",
+      "recovery_cycle_budget_outcome",
+      "TaskRunResult",
+      "RunInspectSummary"
+    ],
+    "vsix_protocol_tokens": [
+      "RecoveryCycleBudgetOutcome",
+      "RECOVERY_CYCLE_BUDGET_OUTCOME_KEYS",
+      "isRecoveryCycleBudgetOutcome",
+      "recovery_cycle_budget_outcome"
+    ],
+    "vsix_test_tokens": [
+      "validates recovery-cycle budget exhaustion outcomes",
+      "child_running_enabled: true",
+      "stdout: 'raw'"
+    ],
+    "architecture_doc_tokens": [
+      "Recovery-cycle budget exhaustion is surfaced through the existing parent task.run response",
+      "recovery_cycle_budget_outcome"
+    ]
+  }
+}

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -65,3 +65,7 @@ See `docs/architecture/diagnostics-api-consolidation.md`, `docs/architecture/pha
 Patch application remains a read-only design and inspection boundary. Brownie may report proposal readiness, review evidence, dry-run metadata, and diagnostics state, but it must not apply patches, write workspace files, execute shell or git commands, use network access, or return raw file content, raw diffs, raw input JSON, canonical paths, or absolute paths.
 
 The Phase 3.5-3.51 wrapper-chain history is archived in `docs/architecture/diagnostics-wrapper-history.md`, with the endpoint inventory and deprecation plan in `docs/architecture/diagnostics-api-consolidation.md`. After R1.1, the next milestone is M1 Agent Loop Integration (`agent_loop_integration`).
+
+## Subtask Recovery Outcomes
+
+Recovery-cycle budget exhaustion is surfaced through the existing parent task.run response and parent inspection path as `recovery_cycle_budget_outcome`. The outcome is derived from bounded runtime ledger evidence and reports only budget status, exceeded depth, max depth, parent join admission id, blocked candidate count, disabled child materialization/running signals, and next action.

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -220,11 +220,23 @@ export interface TaskRunResult {
   run_id: string;
   status: TaskStatus;
   agent_loop: AgentLoopRunSummary;
+  recovery_cycle_budget_outcome?: RecoveryCycleBudgetOutcome | null;
 }
 
 export interface AgentLoopRunSummary {
   final_state: string;
   completion_summary: string;
+}
+
+export interface RecoveryCycleBudgetOutcome {
+  recovery_cycle_budget_status: 'Exceeded';
+  parent_join_admission_id: string;
+  parent_join_recovery_cycle_depth: number;
+  max_recovery_cycle_depth: number;
+  blocked_candidate_count: number;
+  child_materialization_enabled: false;
+  child_running_enabled: false;
+  next_action: string;
 }
 
 export interface TaskRecord {
@@ -257,6 +269,7 @@ export interface RunInspectSummary {
   run_id: string;
   task_id?: string | null;
   status?: TaskStatus | null;
+  recovery_cycle_budget_outcome?: RecoveryCycleBudgetOutcome | null;
   child_task_count: number;
   child_task_ids: string[];
   child_tasks: ChildTaskInspectSummary[];
@@ -2515,6 +2528,17 @@ const RECOVERY_CYCLE_CHILD_PROVENANCE_KEYS = new Set([
   'parent_join_recovery_cycle_depth',
 ]);
 
+const RECOVERY_CYCLE_BUDGET_OUTCOME_KEYS = new Set([
+  'recovery_cycle_budget_status',
+  'parent_join_admission_id',
+  'parent_join_recovery_cycle_depth',
+  'max_recovery_cycle_depth',
+  'blocked_candidate_count',
+  'child_materialization_enabled',
+  'child_running_enabled',
+  'next_action',
+]);
+
 function hasOnlyKeys(value: Record<string, unknown>, allowedKeys: Set<string>): boolean {
   return Object.keys(value).every((key) => allowedKeys.has(key));
 }
@@ -2538,6 +2562,25 @@ export function isRecoveryCycleChildProvenance(value: unknown): value is Recover
     typeof value.parent_join_recovery_cycle === 'boolean' &&
     isNonNegativeInteger(value.parent_join_recovery_cycle_depth) &&
     ((value.parent_join_recovery_cycle && value.parent_join_recovery_cycle_depth >= 1) || (!value.parent_join_recovery_cycle && value.parent_join_recovery_cycle_depth === 0))
+  );
+}
+
+export function isRecoveryCycleBudgetOutcome(value: unknown): value is RecoveryCycleBudgetOutcome {
+  return (
+    isRecord(value) &&
+    hasOnlyKeys(value, RECOVERY_CYCLE_BUDGET_OUTCOME_KEYS) &&
+    value.recovery_cycle_budget_status === 'Exceeded' &&
+    typeof value.parent_join_admission_id === 'string' &&
+    value.parent_join_admission_id.trim().length > 0 &&
+    isNonNegativeInteger(value.parent_join_recovery_cycle_depth) &&
+    value.parent_join_recovery_cycle_depth > 0 &&
+    isNonNegativeInteger(value.max_recovery_cycle_depth) &&
+    isNonNegativeInteger(value.blocked_candidate_count) &&
+    value.blocked_candidate_count > 0 &&
+    value.child_materialization_enabled === false &&
+    value.child_running_enabled === false &&
+    typeof value.next_action === 'string' &&
+    value.next_action.trim().length > 0
   );
 }
 
@@ -2598,7 +2641,8 @@ export function isTaskRunResult(value: unknown): value is TaskRunResult {
     typeof value.task_id === 'string' &&
     typeof value.run_id === 'string' &&
     isTaskStatus(value.status) &&
-    isAgentLoopRunSummary(value.agent_loop)
+    isAgentLoopRunSummary(value.agent_loop) &&
+    (value.recovery_cycle_budget_outcome === undefined || value.recovery_cycle_budget_outcome === null || isRecoveryCycleBudgetOutcome(value.recovery_cycle_budget_outcome))
   );
 }
 
@@ -2673,6 +2717,7 @@ export function isRunInspectSummary(value: unknown): value is RunInspectSummary 
     typeof value.run_id === 'string' &&
     (value.task_id === undefined || value.task_id === null || typeof value.task_id === 'string') &&
     (value.status === undefined || value.status === null || isTaskStatus(value.status)) &&
+    (value.recovery_cycle_budget_outcome === undefined || value.recovery_cycle_budget_outcome === null || isRecoveryCycleBudgetOutcome(value.recovery_cycle_budget_outcome)) &&
     isNonNegativeInteger(value.child_task_count) &&
     Array.isArray(value.child_task_ids) &&
     value.child_task_ids.every((taskId) => typeof taskId === 'string') &&

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { RuntimeJsonRpcError } from '../runtime/errors';
-import { isRecoveryCycleChildProvenance, isTaskRecord } from '../runtime/protocol';
+import { isRecoveryCycleBudgetOutcome, isRecoveryCycleChildProvenance, isTaskRecord, isTaskRunResult } from '../runtime/protocol';
 import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApplyCapabilityResult, isProposalApplyDryRunHistoryResult, isProposalApplyDryRunResult, isProposalApproveResult, isProposalAuditTrailResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isProposalReviewBundleResult, isProposalReviewQueueDiagnosticsDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictResult, isProposalReviewQueueDiagnosticsDigestResult, isProposalReviewQueueDiagnosticsHistoryResult, isProposalReviewQueueDiagnosticsReportResult, isProposalReviewQueueDiagnosticsResult, isProposalReviewQueueResult, isProposalReviewReportResult, isProposalReviewVerdictResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
 import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult } from '../runtime/protocol';
 import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult } from '../runtime/protocol';
@@ -73,6 +73,17 @@ const recoveryCycleChildProvenance = {
   parent_join_terminal_completed_child_count: 2,
   parent_join_recovery_cycle: true,
   parent_join_recovery_cycle_depth: 2,
+};
+
+const recoveryCycleBudgetOutcome = {
+  recovery_cycle_budget_status: 'Exceeded',
+  parent_join_admission_id: 'admission_budget_1',
+  parent_join_recovery_cycle_depth: 3,
+  max_recovery_cycle_depth: 2,
+  blocked_candidate_count: 1,
+  child_materialization_enabled: false,
+  child_running_enabled: false,
+  next_action: 'stop_recovery_cycle_materialization',
 };
 
 describe('protocol validation', () => {
@@ -246,6 +257,9 @@ describe('protocol validation', () => {
     expect(isRunInspectSummary({ ...summary, subtask_dispatch_decision_count: -1 })).toBe(false);
     expect(isRunInspectSummary({ ...summary, subtask_dispatch_candidate_manifest_count: -1 })).toBe(false);
     expect(isRunInspectSummary({ ...summary, subtask_dispatch_handoff_envelope_count: -1 })).toBe(false);
+    expect(isRunInspectSummary({ ...summary, recovery_cycle_budget_outcome: recoveryCycleBudgetOutcome })).toBe(true);
+    expect(isRunInspectSummary({ ...summary, recovery_cycle_budget_outcome: { ...recoveryCycleBudgetOutcome, child_running_enabled: true } })).toBe(false);
+    expect(isRunInspectSummary({ ...summary, recovery_cycle_budget_outcome: { ...recoveryCycleBudgetOutcome, command: 'raw' } })).toBe(false);
     expect(isLedgerEventSummary({
       event_id: 'event_1',
       task_id: 'task_1',
@@ -273,6 +287,18 @@ describe('protocol validation', () => {
     expect(isRecoveryCycleChildProvenance({ ...recoveryCycleChildProvenance, parent_join_recovery_cycle: false, parent_join_recovery_cycle_depth: 1 })).toBe(false);
     expect(isRecoveryCycleChildProvenance({ ...recoveryCycleChildProvenance, content: 'raw child prompt' })).toBe(false);
     expect(isTaskRecord({ ...taskRecord, recovery_cycle_provenance: { ...recoveryCycleChildProvenance, parent_join_terminal_completed_child_count: 5 } })).toBe(false);
+  });
+
+  it('validates recovery-cycle budget exhaustion outcomes', () => {
+    expect(isRecoveryCycleBudgetOutcome(recoveryCycleBudgetOutcome)).toBe(true);
+    expect(isTaskRunResult({ task_id: 'task_1', run_id: 'run_1', status: 'Completed', agent_loop: { final_state: 'Completed', completion_summary: 'done' }, recovery_cycle_budget_outcome: recoveryCycleBudgetOutcome })).toBe(true);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, recovery_cycle_budget_status: 'Accepted' })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, parent_join_admission_id: '' })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, parent_join_recovery_cycle_depth: 0 })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, blocked_candidate_count: 0 })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, child_materialization_enabled: true })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, child_running_enabled: true })).toBe(false);
+    expect(isRecoveryCycleBudgetOutcome({ ...recoveryCycleBudgetOutcome, stdout: 'raw' })).toBe(false);
   });
 
 

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.27';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.27.json';
+const phase = 'M5.28';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.28.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'recovery_cycle_budget_admission_guard',
-    `${phase} must declare the recovery-cycle budget admission guard transition.`
+    manifest.concrete_capability_transition === 'recovery_cycle_budget_exhaustion_outcome',
+    `${phase} must declare the recovery-cycle budget exhaustion outcome transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'additional_blocked_summary_event_wrapper_or_unbounded_recovery_cycle_without_budget_guard',
-    `${phase} must forbid wrapper-only or unbounded recovery-cycle work without a budget guard.`
+    manifest.forbidden_pattern === 'new_diagnostics_rpc_or_wrapper_chain_without_existing_parent_outcome_contract',
+    `${phase} must forbid diagnostics-only or wrapper-chain work without an existing parent outcome contract.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -75,15 +75,15 @@ function validateManifest(manifest) {
 
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
-    'deterministic runtime recovery-cycle budget policy',
-    'Parent join recovery continuation',
+    'Existing parent task.run output',
+    'Existing parent inspection output',
+    'recovery-cycle budget exhaustion outcome',
     'child TaskRecord',
-    'Explicit task.run',
-    'over-budget queued recovery-cycle children',
     'TaskRunning',
+    'Explicit task.run',
     'In-budget recovery-cycle child',
+    'Non-recovery tasks',
     'bounded and sanitized',
-    'No child auto-run',
     'No raw child prompts',
     'No scheduler handoff'
   ]) {
@@ -106,18 +106,33 @@ function validateSourceEvidence(manifest) {
   for (const token of evidence.rust_runtime_tokens ?? []) {
     requireToken('crates/brownie-runtime/src/lib.rs', token);
   }
+  for (const token of evidence.rust_protocol_tokens ?? []) {
+    requireToken('crates/brownie-protocol/src/lib.rs', token);
+  }
   for (const token of evidence.rust_store_tokens ?? []) {
     requireToken('crates/brownie-store/src/lib.rs', token);
+  }
+  for (const token of evidence.vsix_protocol_tokens ?? []) {
+    requireToken('extensions/brownie-vsix/src/runtime/protocol.ts', token);
+  }
+  for (const token of evidence.vsix_test_tokens ?? []) {
+    requireToken('extensions/brownie-vsix/src/test/runtimeClient.test.ts', token);
+  }
+  for (const token of evidence.architecture_doc_tokens ?? []) {
+    requireToken('docs/architecture/runtime-overview.md', token);
   }
 
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   for (const token of [
-    'MAX_RECOVERY_CYCLE_DEPTH',
-    'recovery_cycle_depth_exceeds_budget',
-    'append_recovery_cycle_budget_blocked_handoff_envelope',
+    'recovery_cycle_budget_outcome_for_run',
+    'recovery_cycle_budget_outcome_from_events',
     'recovery_cycle_budget_status',
-    'RecoveryCycleBudgetExceeded',
+    'child_materialization_enabled',
+    'child_running_enabled',
+    'stop_recovery_cycle_materialization',
+    'append_recovery_cycle_budget_blocked_handoff_envelope',
     'parent_join_recovery_cycle_budget_blocks_next_child_materialization',
+    'task_run_parent_join_budget_exhaustion_returns_bounded_outcome_without_child_materialization',
     'task_run_rejects_over_budget_recovery_cycle_child_before_running',
     'task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance',
     'SubtaskDispatchHandoffEnvelopeRecorded',


### PR DESCRIPTION
## 概要

M5.28 として、M5.27 の recovery-cycle budget guard が親 join で materialization を止めた場合に、既存の親 `task.run` 応答と既存 inspect path へ bounded な `recovery_cycle_budget_outcome` を公開します。

## 能力差分

- `TaskRunResult` と `RunInspectSummary` に optional `RecoveryCycleBudgetOutcome` を追加しました。
- outcome は runtime-owned ledger の `recovery_cycle_budget_status: "Exceeded"` evidence から導出し、budget status / exceeded depth / max depth / parent join admission id / blocked candidate count / child materialization false / child running false / next action のみを返します。
- 新しい diagnostics RPC、scheduler auto-dispatch、child auto-run、patch apply、process/network/service-control 拡張は追加していません。
- VSIX protocol validator と M5.28 phase-value guard を更新しました。

## 検証

- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`