### PR TITLE
M5.29: replay recovery budget outcome

### DIFF
--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1754,6 +1754,23 @@ fn handle_task_run(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
 
+    match recovery_cycle_budget_outcome_for_replay(&store, &record) {
+        Ok(Some((agent_loop, recovery_cycle_budget_outcome))) => {
+            return result_response(
+                id,
+                json!(TaskRunResult {
+                    task_id: record.task_id,
+                    run_id: record.run_id,
+                    status: record.status,
+                    agent_loop,
+                    recovery_cycle_budget_outcome: Some(recovery_cycle_budget_outcome),
+                }),
+            );
+        }
+        Ok(None) => {}
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    }
+
     let admission = match validate_task_run_admission(&record, &store) {
         Ok(admission) => admission,
         Err(rejection) => {
@@ -10166,6 +10183,51 @@ fn recovery_cycle_budget_outcome_for_run(
     Ok(recovery_cycle_budget_outcome_from_events(&events))
 }
 
+fn recovery_cycle_budget_outcome_for_replay(
+    store: &BrownieStore,
+    record: &TaskRecord,
+) -> Result<Option<(TaskRunAgentLoopSummary, RecoveryCycleBudgetOutcome)>, String> {
+    if !matches!(
+        record.status,
+        TaskStatus::Completed | TaskStatus::Failed | TaskStatus::Cancelled
+    ) {
+        return Ok(None);
+    }
+
+    let events = store
+        .tasks()
+        .read_ledger_events(&record.run_id)
+        .map_err(|error| format!("invalid params: {error}"))?;
+    let Some(recovery_cycle_budget_outcome) = recovery_cycle_budget_outcome_from_events(&events)
+    else {
+        return Ok(None);
+    };
+    let Some(agent_loop) = task_run_agent_loop_summary_from_events(&events) else {
+        return Ok(None);
+    };
+
+    Ok(Some((agent_loop, recovery_cycle_budget_outcome)))
+}
+
+fn task_run_agent_loop_summary_from_events(
+    events: &[LedgerEvent],
+) -> Option<TaskRunAgentLoopSummary> {
+    let payload = events
+        .iter()
+        .rev()
+        .find(|event| event.kind == LedgerEventKind::AgentLoopCompleted)?
+        .payload
+        .as_ref()?;
+    Some(TaskRunAgentLoopSummary {
+        final_state: non_empty_payload_string(payload, "final_state")?,
+        completion_summary: payload
+            .get("completion_summary")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+    })
+}
+
 fn recovery_cycle_budget_outcome_from_events(
     events: &[LedgerEvent],
 ) -> Option<RecoveryCycleBudgetOutcome> {
@@ -18006,7 +18068,7 @@ mod tests {
     }
 
     #[test]
-    fn task_run_parent_join_budget_exhaustion_returns_bounded_outcome_without_child_materialization(
+    fn task_run_parent_join_budget_exhaustion_replays_bounded_outcome_without_child_materialization(
     ) {
         let _guard = ENV_LOCK.lock().expect("env lock");
         clear_llm_env_for_test();
@@ -18401,6 +18463,102 @@ mod tests {
         assert_eq!(
             child_running_event_count_after_budget_join,
             child_running_event_count_before_budget_join
+        );
+
+        let parent_event_count_after_budget_join = parent_events_after_budget_join.len();
+        let parent_task_running_count_after_budget_join = parent_events_after_budget_join
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+            .count();
+        let parent_join_consumption_count_after_budget_join = parent_events_after_budget_join
+            .iter()
+            .filter(|event| {
+                event.kind == LedgerEventKind::ParentJoinContinuationFingerprintConsumed
+            })
+            .count();
+        let handoff_envelope_count_after_budget_join = parent_events_after_budget_join
+            .iter()
+            .filter(|event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded)
+            .count();
+
+        let budget_parent_join_replay = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":34,"method":"task.run","params":{{"task_id":"{}"}}}}"#,
+            parent.task_id
+        ));
+        assert!(budget_parent_join_replay.error.is_none());
+        let budget_parent_join_replay_result = budget_parent_join_replay
+            .result
+            .expect("budget parent join replay result");
+        assert_eq!(
+            budget_parent_join_replay_result["recovery_cycle_budget_outcome"],
+            outcome
+        );
+        assert_eq!(
+            budget_parent_join_replay_result["agent_loop"],
+            budget_parent_join_result["agent_loop"]
+        );
+        assert_eq!(budget_parent_join_replay_result["status"], "Completed");
+
+        let parent_events_after_replay = store
+            .tasks()
+            .read_ledger_events(&parent.run_id)
+            .expect("parent events after budget replay");
+        assert_eq!(
+            parent_events_after_replay.len(),
+            parent_event_count_after_budget_join
+        );
+        assert_eq!(
+            parent_events_after_replay
+                .iter()
+                .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                .count(),
+            parent_task_running_count_after_budget_join
+        );
+        assert_eq!(
+            parent_events_after_replay
+                .iter()
+                .filter(|event| event.kind
+                    == LedgerEventKind::ParentJoinContinuationFingerprintConsumed)
+                .count(),
+            parent_join_consumption_count_after_budget_join
+        );
+        assert_eq!(
+            parent_events_after_replay
+                .iter()
+                .filter(
+                    |event| event.kind == LedgerEventKind::SubtaskDispatchHandoffEnvelopeRecorded
+                )
+                .count(),
+            handoff_envelope_count_after_budget_join
+        );
+
+        let child_count_after_replay = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks after budget replay")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .count();
+        assert_eq!(child_count_after_replay, child_count_after_budget_join);
+        let child_running_event_count_after_replay = store
+            .tasks()
+            .list_tasks()
+            .expect("list tasks after budget replay running events")
+            .into_iter()
+            .filter(|record| record.parent_run_id.as_deref() == Some(parent.run_id.as_str()))
+            .map(|record| {
+                store
+                    .tasks()
+                    .read_ledger_events(&record.run_id)
+                    .expect("read child events after budget replay")
+                    .into_iter()
+                    .filter(|event| event.kind == LedgerEventKind::TaskRunning)
+                    .count()
+            })
+            .sum::<usize>();
+        assert_eq!(
+            child_running_event_count_after_replay,
+            child_running_event_count_after_budget_join
         );
 
         let parent_run_inspect = parse_line(&format!(

--- a/docs/architecture/phase-value-manifest.m5.29.json
+++ b/docs/architecture/phase-value-manifest.m5.29.json
@@ -1,0 +1,104 @@
+{
+  "phase": "M5.29",
+  "current_milestone": "subtask_orchestration",
+  "target_capability": "subtask_orchestration",
+  "concrete_capability_transition": "stable_recovery_cycle_budget_outcome_replay",
+  "forbidden_pattern": "new_diagnostics_rpc_or_replayed_parent_join_without_stable_budget_outcome",
+  "project_objective_ref": "docs/architecture/runtime-overview.md",
+  "strategic_capability_mapping": [
+    {
+      "capability": "subtask_orchestration",
+      "relationship": "Makes recovery-cycle budget exhaustion replay-safe through the existing parent task.run contract, so orchestration callers can retry without mutating parent or child ledger state."
+    },
+    {
+      "capability": "headless_autonomous_development",
+      "relationship": "Gives unattended callers a deterministic repeated response for already-budget-exhausted parent runs without requiring diagnostics RPCs or ledger inference."
+    }
+  ],
+  "phase_value_gate": {
+    "questions": [
+      {
+        "id": "stable_parent_task_run_replay",
+        "prompt": "Does repeated parent task.run for an already-budget-exhausted parent return the same bounded recovery-cycle budget outcome?"
+      },
+      {
+        "id": "no_parent_ledger_mutation",
+        "prompt": "Does replay avoid adding parent TaskRunning, ParentJoinContinuationFingerprintConsumed, and SubtaskDispatchHandoffEnvelopeRecorded events?"
+      },
+      {
+        "id": "no_child_ledger_mutation",
+        "prompt": "Does replay avoid adding child TaskRecord and child TaskRunning evidence?"
+      },
+      {
+        "id": "existing_contract_only",
+        "prompt": "Does this phase use existing TaskRunResult and existing parent task.run instead of a new diagnostics RPC or wrapper?"
+      },
+      {
+        "id": "safety_boundary",
+        "prompt": "Does this phase avoid scheduler handoff, auto child run, external workers, process exec expansion, network bypass, service control, patch apply, diagnostics RPCs, and workspace mutation paths?"
+      }
+    ],
+    "answers": {
+      "stable_parent_task_run_replay": "Yes. A terminal task with an existing Exceeded recovery_cycle_budget_outcome returns that outcome from existing ledger evidence before task admission or TaskRunning updates.",
+      "no_parent_ledger_mutation": "Yes. The replay path exits before parent join continuation consumption, TaskRunning status updates, and handoff envelope recording.",
+      "no_child_ledger_mutation": "Yes. The replay test verifies child TaskRecord and child TaskRunning counts do not increase after repeated parent task.run.",
+      "existing_contract_only": "Yes. The replay path returns TaskRunResult from the existing task.run method and does not add a diagnostics RPC, wrapper summary, or new protocol surface.",
+      "safety_boundary": "Yes. The phase adds no scheduler handoff, child auto-run, external worker, patch apply, direct workspace mutation path, service control, network bypass, diagnostics RPC, or process execution expansion."
+    }
+  },
+  "exit_criteria": [
+    "Existing parent task.run output for an already-budget-exhausted parent returns the stable recovery-cycle budget outcome.",
+    "Repeated parent task.run for an already-budget-exhausted parent does not add a parent TaskRunning event.",
+    "Repeated parent task.run for an already-budget-exhausted parent does not add a ParentJoinContinuationFingerprintConsumed event.",
+    "Repeated parent task.run for an already-budget-exhausted parent does not add a SubtaskDispatchHandoffEnvelopeRecorded event.",
+    "Repeated parent task.run for an already-budget-exhausted parent does not create a child TaskRecord.",
+    "Repeated parent task.run for an already-budget-exhausted parent does not create a child TaskRunning event.",
+    "Existing parent inspection output still exposes the stable recovery-cycle budget outcome without a new diagnostics RPC.",
+    "In-budget recovery-cycle child materialization and explicit task.run behavior still works.",
+    "Non-recovery tasks and initial controlled children preserve explicit task.run behavior.",
+    "Failed-child and recovery-child outcome evidence remains bounded and sanitized.",
+    "No raw child prompts, provider responses, file contents, command strings, stdout, stderr, environment values, raw tool input objects, serialized request bodies, raw failure payloads, or unbounded error text are persisted or exposed.",
+    "No scheduler handoff, external worker, process exec expansion, network bypass, service control, patch apply, direct workspace mutation path, diagnostics wrapper RPC, or new blocked summary wrapper is added."
+  ],
+  "source_evidence": {
+    "rust_runtime_tokens": [
+      "recovery_cycle_budget_outcome_for_replay",
+      "recovery_cycle_budget_outcome_for_run",
+      "recovery_cycle_budget_outcome_from_events",
+      "task_run_agent_loop_summary_from_events",
+      "recovery_cycle_budget_status",
+      "child_materialization_enabled",
+      "child_running_enabled",
+      "stop_recovery_cycle_materialization",
+      "task_run_parent_join_budget_exhaustion_replays_bounded_outcome_without_child_materialization",
+      "parent_join_recovery_cycle_budget_blocks_next_child_materialization",
+      "task_run_rejects_over_budget_recovery_cycle_child_before_running",
+      "task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance",
+      "ParentJoinContinuationFingerprintConsumed",
+      "SubtaskDispatchHandoffEnvelopeRecorded",
+      "TaskRunning"
+    ],
+    "rust_protocol_tokens": [
+      "RecoveryCycleBudgetOutcome",
+      "recovery_cycle_budget_outcome",
+      "TaskRunResult",
+      "RunInspectSummary"
+    ],
+    "vsix_protocol_tokens": [
+      "RecoveryCycleBudgetOutcome",
+      "RECOVERY_CYCLE_BUDGET_OUTCOME_KEYS",
+      "isRecoveryCycleBudgetOutcome",
+      "recovery_cycle_budget_outcome"
+    ],
+    "vsix_test_tokens": [
+      "validates recovery-cycle budget exhaustion outcomes",
+      "child_running_enabled: true",
+      "stdout: 'raw'"
+    ],
+    "architecture_doc_tokens": [
+      "Recovery-cycle budget exhaustion is surfaced through the existing parent task.run response",
+      "already-budget-exhausted parent",
+      "recovery_cycle_budget_outcome"
+    ]
+  }
+}

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -68,4 +68,4 @@ The Phase 3.5-3.51 wrapper-chain history is archived in `docs/architecture/diagn
 
 ## Subtask Recovery Outcomes
 
-Recovery-cycle budget exhaustion is surfaced through the existing parent task.run response and parent inspection path as `recovery_cycle_budget_outcome`. The outcome is derived from bounded runtime ledger evidence and reports only budget status, exceeded depth, max depth, parent join admission id, blocked candidate count, disabled child materialization/running signals, and next action.
+Recovery-cycle budget exhaustion is surfaced through the existing parent task.run response and parent inspection path as `recovery_cycle_budget_outcome`. The outcome is derived from bounded runtime ledger evidence and reports only budget status, exceeded depth, max depth, parent join admission id, blocked candidate count, disabled child materialization/running signals, and next action. Repeated parent task.run for an already-budget-exhausted parent replays the existing outcome without adding parent TaskRunning, ParentJoinContinuationFingerprintConsumed, SubtaskDispatchHandoffEnvelopeRecorded, child TaskRecord, or child TaskRunning evidence.

--- a/scripts/guard-phase-value.mjs
+++ b/scripts/guard-phase-value.mjs
@@ -6,8 +6,8 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 const errors = [];
-const phase = 'M5.28';
-const manifestPath = 'docs/architecture/phase-value-manifest.m5.28.json';
+const phase = 'M5.29';
+const manifestPath = 'docs/architecture/phase-value-manifest.m5.29.json';
 
 function readText(relativePath) {
   const filePath = path.join(repoRoot, relativePath);
@@ -42,12 +42,12 @@ function validateManifest(manifest) {
   requireManifestValue(manifest.phase === phase, `${manifestPath} must describe phase ${phase}.`);
   requireManifestValue(manifest.target_capability === 'subtask_orchestration', `${phase} target_capability must be subtask_orchestration.`);
   requireManifestValue(
-    manifest.concrete_capability_transition === 'recovery_cycle_budget_exhaustion_outcome',
-    `${phase} must declare the recovery-cycle budget exhaustion outcome transition.`
+    manifest.concrete_capability_transition === 'stable_recovery_cycle_budget_outcome_replay',
+    `${phase} must declare the stable recovery-cycle budget outcome replay transition.`
   );
   requireManifestValue(
-    manifest.forbidden_pattern === 'new_diagnostics_rpc_or_wrapper_chain_without_existing_parent_outcome_contract',
-    `${phase} must forbid diagnostics-only or wrapper-chain work without an existing parent outcome contract.`
+    manifest.forbidden_pattern === 'new_diagnostics_rpc_or_replayed_parent_join_without_stable_budget_outcome',
+    `${phase} must forbid diagnostics-only work or replayed parent joins without stable budget outcomes.`
   );
 
   const mappings = Array.isArray(manifest.strategic_capability_mapping)
@@ -76,11 +76,13 @@ function validateManifest(manifest) {
   const exitCriteria = Array.isArray(manifest.exit_criteria) ? manifest.exit_criteria : [];
   for (const token of [
     'Existing parent task.run output',
+    'already-budget-exhausted parent',
     'Existing parent inspection output',
-    'recovery-cycle budget exhaustion outcome',
+    'stable recovery-cycle budget outcome',
     'child TaskRecord',
     'TaskRunning',
-    'Explicit task.run',
+    'ParentJoinContinuationFingerprintConsumed',
+    'SubtaskDispatchHandoffEnvelopeRecorded',
     'In-budget recovery-cycle child',
     'Non-recovery tasks',
     'bounded and sanitized',
@@ -124,17 +126,20 @@ function validateSourceEvidence(manifest) {
 
   const runtimeText = readText('crates/brownie-runtime/src/lib.rs');
   for (const token of [
+    'recovery_cycle_budget_outcome_for_replay',
     'recovery_cycle_budget_outcome_for_run',
     'recovery_cycle_budget_outcome_from_events',
+    'task_run_agent_loop_summary_from_events',
     'recovery_cycle_budget_status',
     'child_materialization_enabled',
     'child_running_enabled',
     'stop_recovery_cycle_materialization',
     'append_recovery_cycle_budget_blocked_handoff_envelope',
     'parent_join_recovery_cycle_budget_blocks_next_child_materialization',
-    'task_run_parent_join_budget_exhaustion_returns_bounded_outcome_without_child_materialization',
+    'task_run_parent_join_budget_exhaustion_replays_bounded_outcome_without_child_materialization',
     'task_run_rejects_over_budget_recovery_cycle_child_before_running',
     'task_run_accepts_recovery_cycle_child_with_parent_ledger_provenance',
+    'ParentJoinContinuationFingerprintConsumed',
     'SubtaskDispatchHandoffEnvelopeRecorded',
     'TaskRunning'
   ]) {


### PR DESCRIPTION
## 概要
- terminal parent run に既存の Exceeded recovery_cycle_budget_outcome がある場合、task.run が admission 前に既存 TaskRunResult として replay するようにしました。
- replay が parent TaskRunning / ParentJoinContinuationFingerprintConsumed / SubtaskDispatchHandoffEnvelopeRecorded、および child TaskRecord / TaskRunning を増やさないことを runtime test で固定しました。
- M5.29 の phase-value manifest と guard、runtime overview を更新しました。

## 検証
- pnpm install
- cargo fmt --check
- pnpm guard:phase-value
- pnpm guard:diagnostics
- cargo check --workspace
- cargo test --workspace
- pnpm --filter brownie-vsix check
- pnpm --filter brownie-vsix test
- pnpm --filter brownie-vsix build