### PR TITLE
M9.1 Runtime workspace file inventory index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,12 @@ version = "0.1.0"
 [[package]]
 name = "brownie-indexer"
 version = "0.1.0"
+dependencies = [
+ "serde",
+ "sha2",
+ "tempfile",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "brownie-llama"
@@ -130,6 +136,7 @@ dependencies = [
  "brownie-agentmodes",
  "brownie-config",
  "brownie-context",
+ "brownie-indexer",
  "brownie-llm",
  "brownie-modepack",
  "brownie-protocol",

--- a/crates/brownie-indexer/Cargo.toml
+++ b/crates/brownie-indexer/Cargo.toml
@@ -8,3 +8,11 @@ rust-version.workspace = true
 
 [lib]
 path = "src/lib.rs"
+
+[dependencies]
+serde.workspace = true
+sha2.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/brownie-indexer/src/lib.rs
+++ b/crates/brownie-indexer/src/lib.rs
@@ -1,5 +1,22 @@
 //! Codebase indexing crate.
 
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::cmp::Ordering;
+use std::collections::VecDeque;
+use std::fs;
+use std::path::{Component, Path, PathBuf};
+use thiserror::Error;
+
+pub const DEFAULT_MAX_INDEXED_FILES: usize = 10_000;
+pub const DEFAULT_MAX_WALKED_DIRECTORIES: usize = 2_000;
+pub const DEFAULT_MAX_PATH_CHARS: usize = 512;
+pub const DEFAULT_MAX_FILE_BYTES: u64 = 1_048_576;
+pub const HARD_MAX_INDEXED_FILES: usize = 20_000;
+pub const HARD_MAX_WALKED_DIRECTORIES: usize = 5_000;
+pub const HARD_MAX_PATH_CHARS: usize = 1_024;
+pub const HARD_MAX_FILE_BYTES: u64 = 2_097_152;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IndexStage {
     Scan,
@@ -8,4 +25,655 @@ pub enum IndexStage {
     Embed,
     Write,
     Manifest,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CodebaseIndexBuildOptions {
+    pub root: Option<String>,
+    pub max_files: Option<usize>,
+    pub max_directories: Option<usize>,
+    pub max_path_chars: Option<usize>,
+    pub max_file_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexSnapshot {
+    pub index_id: String,
+    pub root: String,
+    pub workspace_fingerprint: String,
+    pub snapshot_fingerprint: String,
+    pub counts: CodebaseIndexCounts,
+    pub limits: CodebaseIndexLimits,
+    pub truncated: bool,
+    pub entries: Vec<CodebaseIndexFileEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct CodebaseIndexCounts {
+    pub indexed_files: usize,
+    pub walked_directories: usize,
+    pub skipped_protected: usize,
+    pub skipped_symlink: usize,
+    pub skipped_too_large: usize,
+    pub skipped_binary_like: usize,
+    pub skipped_unreadable: usize,
+    pub skipped_unsafe_path: usize,
+    pub skipped_other: usize,
+    pub truncated_entries: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexLimits {
+    pub max_files: usize,
+    pub max_directories: usize,
+    pub max_path_chars: usize,
+    pub max_file_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexFileEntry {
+    pub path: String,
+    pub file_kind: CodebaseIndexFileKind,
+    pub byte_length: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_sha256: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CodebaseIndexFileKind {
+    Rust,
+    TypeScript,
+    JavaScript,
+    Json,
+    Toml,
+    Markdown,
+    Yaml,
+    Shell,
+    Text,
+    Other,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum CodebaseIndexError {
+    #[error("unsafe root: {0}")]
+    UnsafeRoot(String),
+    #[error("workspace root is unreadable")]
+    WorkspaceRootUnreadable,
+}
+
+pub fn build_workspace_file_inventory(
+    workspace_root: impl AsRef<Path>,
+    options: CodebaseIndexBuildOptions,
+) -> Result<CodebaseIndexSnapshot, CodebaseIndexError> {
+    let workspace_root = workspace_root.as_ref();
+    let limits = limits_from_options(&options);
+    let root = resolve_safe_root(options.root.as_deref(), &limits)?;
+    let scan_root = workspace_root.join(root.as_path());
+
+    let root_metadata = fs::symlink_metadata(&scan_root)
+        .map_err(|_| CodebaseIndexError::WorkspaceRootUnreadable)?;
+    if root_metadata.file_type().is_symlink() {
+        return Err(CodebaseIndexError::UnsafeRoot(
+            "root must not be a symlink".to_string(),
+        ));
+    }
+    if !root_metadata.is_dir() {
+        return Err(CodebaseIndexError::UnsafeRoot(
+            "root must be an existing directory".to_string(),
+        ));
+    }
+
+    let mut counts = CodebaseIndexCounts::default();
+    let mut entries = Vec::new();
+    let mut queue = VecDeque::from([(scan_root, root.clone())]);
+    let mut truncated = false;
+
+    while let Some((directory, relative_directory)) = queue.pop_front() {
+        if counts.walked_directories >= limits.max_directories {
+            truncated = true;
+            counts.truncated_entries += 1;
+            break;
+        }
+        counts.walked_directories += 1;
+
+        let children = match sorted_directory_entries(&directory) {
+            Ok(children) => children,
+            Err(_) => {
+                counts.skipped_unreadable += 1;
+                continue;
+            }
+        };
+
+        for child in children {
+            let name = child.file_name();
+            let child_relative = relative_directory.join(&name);
+            let Some(relative_path) = workspace_relative_path(&child_relative) else {
+                counts.skipped_unsafe_path += 1;
+                continue;
+            };
+
+            if relative_path.chars().count() > limits.max_path_chars {
+                counts.skipped_unsafe_path += 1;
+                continue;
+            }
+
+            let metadata = match fs::symlink_metadata(child.path()) {
+                Ok(metadata) => metadata,
+                Err(_) => {
+                    counts.skipped_unreadable += 1;
+                    continue;
+                }
+            };
+            let file_type = metadata.file_type();
+
+            if file_type.is_symlink() {
+                counts.skipped_symlink += 1;
+                continue;
+            }
+
+            if file_type.is_dir() {
+                if is_protected_or_generated_component(&name) {
+                    counts.skipped_protected += 1;
+                    continue;
+                }
+                queue.push_back((child.path(), child_relative));
+                continue;
+            }
+
+            if !file_type.is_file() {
+                counts.skipped_other += 1;
+                continue;
+            }
+
+            if metadata.len() > limits.max_file_bytes {
+                counts.skipped_too_large += 1;
+                continue;
+            }
+
+            if entries.len() >= limits.max_files {
+                truncated = true;
+                counts.truncated_entries += 1;
+                continue;
+            }
+
+            let bytes = match fs::read(child.path()) {
+                Ok(bytes) => bytes,
+                Err(_) => {
+                    counts.skipped_unreadable += 1;
+                    continue;
+                }
+            };
+
+            if bytes.contains(&0) {
+                counts.skipped_binary_like += 1;
+                continue;
+            }
+
+            let line_count = std::str::from_utf8(&bytes)
+                .ok()
+                .map(|text| text.lines().count());
+
+            entries.push(CodebaseIndexFileEntry {
+                file_kind: classify_file(&relative_path),
+                path: relative_path,
+                byte_length: metadata.len(),
+                line_count,
+                content_sha256: Some(sha256_fingerprint(&bytes)),
+            });
+        }
+    }
+
+    entries.sort_by(|a, b| {
+        a.path
+            .cmp(&b.path)
+            .then_with(|| a.file_kind.cmp(&b.file_kind))
+            .then_with(|| a.byte_length.cmp(&b.byte_length))
+    });
+    counts.indexed_files = entries.len();
+
+    let workspace_fingerprint = workspace_fingerprint(&entries);
+    let snapshot_fingerprint = snapshot_fingerprint(&root, &entries, &counts, &limits, truncated);
+    let index_id = format!(
+        "idx_{}",
+        snapshot_fingerprint
+            .strip_prefix("sha256:")
+            .unwrap_or(&snapshot_fingerprint)
+            .chars()
+            .take(16)
+            .collect::<String>()
+    );
+
+    Ok(CodebaseIndexSnapshot {
+        index_id,
+        root: workspace_relative_path(&root).unwrap_or_else(|| ".".to_string()),
+        workspace_fingerprint,
+        snapshot_fingerprint,
+        counts,
+        limits,
+        truncated,
+        entries,
+    })
+}
+
+fn limits_from_options(options: &CodebaseIndexBuildOptions) -> CodebaseIndexLimits {
+    CodebaseIndexLimits {
+        max_files: clamp_usize(
+            options.max_files,
+            DEFAULT_MAX_INDEXED_FILES,
+            1,
+            HARD_MAX_INDEXED_FILES,
+        ),
+        max_directories: clamp_usize(
+            options.max_directories,
+            DEFAULT_MAX_WALKED_DIRECTORIES,
+            1,
+            HARD_MAX_WALKED_DIRECTORIES,
+        ),
+        max_path_chars: clamp_usize(
+            options.max_path_chars,
+            DEFAULT_MAX_PATH_CHARS,
+            32,
+            HARD_MAX_PATH_CHARS,
+        ),
+        max_file_bytes: clamp_u64(
+            options.max_file_bytes,
+            DEFAULT_MAX_FILE_BYTES,
+            1,
+            HARD_MAX_FILE_BYTES,
+        ),
+    }
+}
+
+fn clamp_usize(value: Option<usize>, default: usize, min: usize, max: usize) -> usize {
+    value.unwrap_or(default).clamp(min, max)
+}
+
+fn clamp_u64(value: Option<u64>, default: u64, min: u64, max: u64) -> u64 {
+    value.unwrap_or(default).clamp(min, max)
+}
+
+fn resolve_safe_root(
+    root: Option<&str>,
+    limits: &CodebaseIndexLimits,
+) -> Result<PathBuf, CodebaseIndexError> {
+    let Some(root) = root else {
+        return Ok(PathBuf::new());
+    };
+    if root.trim().is_empty() || root == "." {
+        return Ok(PathBuf::new());
+    }
+    if root.chars().count() > limits.max_path_chars {
+        return Err(CodebaseIndexError::UnsafeRoot(
+            "root path exceeds max_path_chars".to_string(),
+        ));
+    }
+    if Path::new(root).is_absolute() {
+        return Err(CodebaseIndexError::UnsafeRoot(
+            "absolute roots are rejected".to_string(),
+        ));
+    }
+
+    let mut normalized = PathBuf::new();
+    for component in Path::new(root).components() {
+        match component {
+            Component::Normal(part) => {
+                if is_protected_or_generated_component(part) {
+                    return Err(CodebaseIndexError::UnsafeRoot(format!(
+                        "protected root component rejected: {}",
+                        part.to_string_lossy()
+                    )));
+                }
+                normalized.push(part);
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(CodebaseIndexError::UnsafeRoot(
+                    "parent traversal is rejected".to_string(),
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(CodebaseIndexError::UnsafeRoot(
+                    "absolute roots are rejected".to_string(),
+                ));
+            }
+        }
+    }
+
+    Ok(normalized)
+}
+
+fn sorted_directory_entries(directory: &Path) -> std::io::Result<Vec<fs::DirEntry>> {
+    let mut entries = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    entries.sort_by(|a, b| compare_os_names(&a.file_name(), &b.file_name()));
+    Ok(entries)
+}
+
+fn compare_os_names(a: &std::ffi::OsStr, b: &std::ffi::OsStr) -> Ordering {
+    a.to_string_lossy().cmp(&b.to_string_lossy())
+}
+
+fn workspace_relative_path(path: &Path) -> Option<String> {
+    let mut parts = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(part) => parts.push(part.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+    if parts.is_empty() {
+        Some(".".to_string())
+    } else {
+        Some(parts.join("/"))
+    }
+}
+
+fn is_protected_or_generated_component(component: &std::ffi::OsStr) -> bool {
+    matches!(
+        component.to_string_lossy().as_ref(),
+        ".git"
+            | ".brownie"
+            | "node_modules"
+            | "target"
+            | "dist"
+            | "build"
+            | "coverage"
+            | ".next"
+            | "out"
+            | "vendor"
+    )
+}
+
+fn classify_file(path: &str) -> CodebaseIndexFileKind {
+    let lower = path.to_ascii_lowercase();
+    let file_name = lower.rsplit('/').next().unwrap_or(lower.as_str());
+    match file_name {
+        "cargo.toml" => return CodebaseIndexFileKind::Toml,
+        "readme" | "license" | "notice" => return CodebaseIndexFileKind::Text,
+        _ => {}
+    }
+    match lower.rsplit('.').next() {
+        Some("rs") => CodebaseIndexFileKind::Rust,
+        Some("ts") | Some("tsx") => CodebaseIndexFileKind::TypeScript,
+        Some("js") | Some("jsx") | Some("mjs") | Some("cjs") => CodebaseIndexFileKind::JavaScript,
+        Some("json") | Some("jsonc") => CodebaseIndexFileKind::Json,
+        Some("toml") => CodebaseIndexFileKind::Toml,
+        Some("md") | Some("markdown") => CodebaseIndexFileKind::Markdown,
+        Some("yaml") | Some("yml") => CodebaseIndexFileKind::Yaml,
+        Some("sh") | Some("bash") | Some("zsh") => CodebaseIndexFileKind::Shell,
+        Some("txt") => CodebaseIndexFileKind::Text,
+        _ => CodebaseIndexFileKind::Other,
+    }
+}
+
+fn workspace_fingerprint(entries: &[CodebaseIndexFileEntry]) -> String {
+    let mut inputs = Vec::with_capacity(entries.len() + 1);
+    inputs.push("workspace_file_inventory_entries_v1".to_string());
+    for entry in entries {
+        inputs.push(format!(
+            "{}\t{:?}\t{}\t{}\t{}",
+            entry.path,
+            entry.file_kind,
+            entry.byte_length,
+            entry
+                .line_count
+                .map_or_else(String::new, |count| count.to_string()),
+            entry.content_sha256.as_deref().unwrap_or("")
+        ));
+    }
+    sha256_fingerprint(inputs.join("\n").as_bytes())
+}
+
+fn snapshot_fingerprint(
+    root: &Path,
+    entries: &[CodebaseIndexFileEntry],
+    counts: &CodebaseIndexCounts,
+    limits: &CodebaseIndexLimits,
+    truncated: bool,
+) -> String {
+    let mut inputs = vec![
+        "codebase_index_snapshot_v1".to_string(),
+        format!(
+            "root={}",
+            workspace_relative_path(root).unwrap_or_else(|| ".".to_string())
+        ),
+        format!("truncated={truncated}"),
+        format!(
+            "counts={} {} {} {} {} {} {} {} {} {}",
+            counts.indexed_files,
+            counts.walked_directories,
+            counts.skipped_protected,
+            counts.skipped_symlink,
+            counts.skipped_too_large,
+            counts.skipped_binary_like,
+            counts.skipped_unreadable,
+            counts.skipped_unsafe_path,
+            counts.skipped_other,
+            counts.truncated_entries
+        ),
+        format!(
+            "limits={} {} {} {}",
+            limits.max_files, limits.max_directories, limits.max_path_chars, limits.max_file_bytes
+        ),
+    ];
+    for entry in entries {
+        inputs.push(format!(
+            "{}\t{:?}\t{}\t{}\t{}",
+            entry.path,
+            entry.file_kind,
+            entry.byte_length,
+            entry
+                .line_count
+                .map_or_else(String::new, |count| count.to_string()),
+            entry.content_sha256.as_deref().unwrap_or("")
+        ));
+    }
+    sha256_fingerprint(inputs.join("\n").as_bytes())
+}
+
+fn sha256_fingerprint(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    fn write_file(root: &Path, path: &str, content: &[u8]) {
+        let target = root.join(path);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        let mut file = fs::File::create(target).expect("create file");
+        file.write_all(content).expect("write file");
+    }
+
+    fn entry<'a>(snapshot: &'a CodebaseIndexSnapshot, path: &str) -> &'a CodebaseIndexFileEntry {
+        snapshot
+            .entries
+            .iter()
+            .find(|entry| entry.path == path)
+            .expect("entry")
+    }
+
+    #[test]
+    fn builds_sorted_metadata_only_file_inventory() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_file(
+            temp.path(),
+            "src/lib.rs",
+            b"pub fn answer() -> u8 {\n    42\n}\n",
+        );
+        write_file(
+            temp.path(),
+            "Cargo.toml",
+            b"[package]\nname = \"fixture\"\n",
+        );
+        write_file(temp.path(), "README.md", b"# Fixture\n");
+        write_file(temp.path(), "package.json", br#"{"name":"fixture"}"#);
+        write_file(temp.path(), "web/app.ts", b"export const ok = true;\n");
+
+        let snapshot = build_workspace_file_inventory(
+            temp.path(),
+            CodebaseIndexBuildOptions {
+                max_files: Some(20),
+                ..Default::default()
+            },
+        )
+        .expect("snapshot");
+
+        let paths = snapshot
+            .entries
+            .iter()
+            .map(|entry| entry.path.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            paths,
+            vec![
+                "Cargo.toml",
+                "README.md",
+                "package.json",
+                "src/lib.rs",
+                "web/app.ts"
+            ]
+        );
+        assert_eq!(
+            entry(&snapshot, "src/lib.rs").file_kind,
+            CodebaseIndexFileKind::Rust
+        );
+        assert_eq!(
+            entry(&snapshot, "web/app.ts").file_kind,
+            CodebaseIndexFileKind::TypeScript
+        );
+        assert_eq!(entry(&snapshot, "README.md").line_count, Some(1));
+        assert!(entry(&snapshot, "Cargo.toml")
+            .content_sha256
+            .as_ref()
+            .is_some_and(|hash| hash.starts_with("sha256:")));
+        assert!(snapshot.snapshot_fingerprint.starts_with("sha256:"));
+        assert!(snapshot.workspace_fingerprint.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn skips_protected_directories_and_oversized_or_binary_files() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_file(temp.path(), "src/lib.rs", b"pub fn ok() {}\n");
+        write_file(temp.path(), ".git/config", b"secret-ish");
+        write_file(temp.path(), ".brownie/current.json", b"state");
+        write_file(temp.path(), "node_modules/pkg/index.js", b"module");
+        write_file(temp.path(), "target/debug/app", b"binary");
+        write_file(temp.path(), "big.txt", b"012345678901234567890");
+        write_file(temp.path(), "image.bin", b"a\0b");
+
+        let snapshot = build_workspace_file_inventory(
+            temp.path(),
+            CodebaseIndexBuildOptions {
+                max_file_bytes: Some(20),
+                ..Default::default()
+            },
+        )
+        .expect("snapshot");
+
+        assert_eq!(snapshot.entries.len(), 1);
+        assert_eq!(snapshot.entries[0].path, "src/lib.rs");
+        assert_eq!(snapshot.counts.skipped_protected, 4);
+        assert_eq!(snapshot.counts.skipped_too_large, 1);
+        assert_eq!(snapshot.counts.skipped_binary_like, 1);
+        assert!(!snapshot
+            .entries
+            .iter()
+            .any(|entry| entry.path.contains(".git") || entry.path.contains("node_modules")));
+    }
+
+    #[test]
+    fn rejects_absolute_and_parent_traversal_roots() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let parent = build_workspace_file_inventory(
+            temp.path(),
+            CodebaseIndexBuildOptions {
+                root: Some("../outside".to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(parent, Err(CodebaseIndexError::UnsafeRoot(_))));
+
+        let absolute = build_workspace_file_inventory(
+            temp.path(),
+            CodebaseIndexBuildOptions {
+                root: Some(temp.path().to_string_lossy().to_string()),
+                ..Default::default()
+            },
+        );
+        assert!(matches!(absolute, Err(CodebaseIndexError::UnsafeRoot(_))));
+    }
+
+    #[test]
+    fn repeated_builds_are_deterministic_and_changed_files_change_fingerprint() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_file(temp.path(), "src/lib.rs", b"pub fn one() -> u8 { 1 }\n");
+
+        let first = build_workspace_file_inventory(temp.path(), Default::default()).expect("first");
+        let second =
+            build_workspace_file_inventory(temp.path(), Default::default()).expect("second");
+        assert_eq!(first.snapshot_fingerprint, second.snapshot_fingerprint);
+
+        write_file(temp.path(), "src/lib.rs", b"pub fn two() -> u8 { 2 }\n");
+        let changed =
+            build_workspace_file_inventory(temp.path(), Default::default()).expect("changed");
+        assert_ne!(first.snapshot_fingerprint, changed.snapshot_fingerprint);
+    }
+
+    #[test]
+    fn truncates_when_file_limit_is_reached() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        write_file(temp.path(), "a.txt", b"a");
+        write_file(temp.path(), "b.txt", b"b");
+
+        let snapshot = build_workspace_file_inventory(
+            temp.path(),
+            CodebaseIndexBuildOptions {
+                max_files: Some(1),
+                ..Default::default()
+            },
+        )
+        .expect("snapshot");
+
+        assert_eq!(snapshot.entries.len(), 1);
+        assert!(snapshot.truncated);
+        assert_eq!(snapshot.counts.truncated_entries, 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlink_files_and_directories_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let outside = tempfile::tempdir().expect("outside");
+        write_file(temp.path(), "src/lib.rs", b"pub fn ok() {}\n");
+        write_file(outside.path(), "secret.rs", b"pub fn secret() {}\n");
+        symlink(
+            outside.path().join("secret.rs"),
+            temp.path().join("linked.rs"),
+        )
+        .expect("file symlink");
+        symlink(outside.path(), temp.path().join("linked_dir")).expect("dir symlink");
+
+        let snapshot =
+            build_workspace_file_inventory(temp.path(), Default::default()).expect("snapshot");
+
+        assert_eq!(snapshot.entries.len(), 1);
+        assert_eq!(snapshot.entries[0].path, "src/lib.rs");
+        assert_eq!(snapshot.counts.skipped_symlink, 2);
+        assert!(!snapshot
+            .entries
+            .iter()
+            .any(|entry| entry.path == "linked.rs"));
+    }
 }

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -383,6 +383,83 @@ pub struct RunInspectParams {
     pub run_id: String,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(deny_unknown_fields)]
+pub struct CodebaseIndexBuildParams {
+    #[serde(default)]
+    pub root: Option<String>,
+    #[serde(default)]
+    pub force_refresh: Option<bool>,
+    #[serde(default)]
+    pub max_files: Option<usize>,
+    #[serde(default)]
+    pub max_directories: Option<usize>,
+    #[serde(default)]
+    pub max_path_chars: Option<usize>,
+    #[serde(default)]
+    pub max_file_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexBuildResult {
+    pub snapshot: CodebaseIndexSnapshotSummary,
+    pub persisted: bool,
+    pub ledger_event_id: String,
+    pub ledger_event_kind: String,
+    pub next_action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexSnapshotManifest {
+    pub snapshot: CodebaseIndexSnapshotSummary,
+    pub entries: Vec<CodebaseIndexFileEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexSnapshotSummary {
+    pub index_id: String,
+    pub root: String,
+    pub workspace_fingerprint: String,
+    pub snapshot_fingerprint: String,
+    pub built_at: String,
+    pub counts: CodebaseIndexCountsSummary,
+    pub limits: CodebaseIndexLimitsSummary,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexCountsSummary {
+    pub indexed_files: usize,
+    pub walked_directories: usize,
+    pub skipped_protected: usize,
+    pub skipped_symlink: usize,
+    pub skipped_too_large: usize,
+    pub skipped_binary_like: usize,
+    pub skipped_unreadable: usize,
+    pub skipped_unsafe_path: usize,
+    pub skipped_other: usize,
+    pub truncated_entries: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexLimitsSummary {
+    pub max_files: usize,
+    pub max_directories: usize,
+    pub max_path_chars: usize,
+    pub max_file_bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexFileEntry {
+    pub path: String,
+    pub file_kind: String,
+    pub byte_length: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line_count: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub content_sha256: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ProposalListParams {
     pub run_id: String,

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -12,6 +12,7 @@ brownie-agentmodes = { path = "../brownie-agentmodes" }
 brownie-agent-loop = { path = "../brownie-agent-loop" }
 brownie-context = { path = "../brownie-context" }
 brownie-config = { path = "../brownie-config" }
+brownie-indexer = { path = "../brownie-indexer" }
 brownie-llm = { path = "../brownie-llm" }
 brownie-modepack = { path = "../brownie-modepack" }
 brownie-protocol = { path = "../brownie-protocol" }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -8,6 +8,9 @@ use brownie_config::{
     BrownieConfig, LlmProfile, LlmRequestBudgetConfig, RuntimeConfigLoader, CONFIG_RELATIVE_PATH,
 };
 use brownie_context::{ContextMaterializer, ContextMaterializerInput, ContextWindowSummary};
+use brownie_indexer::{
+    build_workspace_file_inventory, CodebaseIndexBuildOptions, CodebaseIndexSnapshot,
+};
 use brownie_llm::{
     redact_secret, scan_prompt_for_sensitive_content, validate_llm_request_budget, FakeLlmProvider,
     LlmMessage, LlmProvider, LlmProviderKind, LlmProviderStatus, LlmRequestBudget,
@@ -18,18 +21,20 @@ use brownie_modepack::load_workspace_modepack;
 use brownie_protocol::{
     BoundedCargoDiagnostic, ChildInspectConsumedParentJoinRecoverySummary,
     ChildInspectParentJoinReadinessSummary, ChildTaskInspectSummary, ChildTaskSourceIntentSummary,
-    DiagnosticSeverity, JsonRpcError, JsonRpcRequest, JsonRpcResponse, LedgerEventSummary,
-    LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary, LlmStatusResult, ModeGetParams,
-    ModeListResult, ModePermissionsSummary, ModeSummary, PermissionCheckParams,
-    PermissionCheckResult, ProposalApplyCapabilityParams, ProposalApplyCapabilityResult,
-    ProposalApplyDryRunHistoryParams, ProposalApplyDryRunHistoryResult, ProposalApplyDryRunParams,
-    ProposalApplyDryRunResult, ProposalApplyParams, ProposalApplyResult, ProposalApproveParams,
-    ProposalApproveResult, ProposalAuditTrailParams, ProposalAuditTrailResult,
-    ProposalInspectParams, ProposalInspectResult, ProposalListParams, ProposalListResult,
-    ProposalPreflightParams, ProposalPreflightResult, ProposalReadinessParams,
-    ProposalReadinessResult, ProposalRejectParams, ProposalRejectResult,
-    ProposalReviewBundleParams, ProposalReviewBundleResult,
-    ProposalReviewQueueDiagnosticsDigestHistoryParams,
+    CodebaseIndexBuildParams, CodebaseIndexBuildResult, CodebaseIndexCountsSummary,
+    CodebaseIndexFileEntry, CodebaseIndexLimitsSummary, CodebaseIndexSnapshotManifest,
+    CodebaseIndexSnapshotSummary, DiagnosticSeverity, JsonRpcError, JsonRpcRequest,
+    JsonRpcResponse, LedgerEventSummary, LlmHealthParams, LlmHealthResult, LlmRequestBudgetSummary,
+    LlmStatusResult, ModeGetParams, ModeListResult, ModePermissionsSummary, ModeSummary,
+    PermissionCheckParams, PermissionCheckResult, ProposalApplyCapabilityParams,
+    ProposalApplyCapabilityResult, ProposalApplyDryRunHistoryParams,
+    ProposalApplyDryRunHistoryResult, ProposalApplyDryRunParams, ProposalApplyDryRunResult,
+    ProposalApplyParams, ProposalApplyResult, ProposalApproveParams, ProposalApproveResult,
+    ProposalAuditTrailParams, ProposalAuditTrailResult, ProposalInspectParams,
+    ProposalInspectResult, ProposalListParams, ProposalListResult, ProposalPreflightParams,
+    ProposalPreflightResult, ProposalReadinessParams, ProposalReadinessResult,
+    ProposalRejectParams, ProposalRejectResult, ProposalReviewBundleParams,
+    ProposalReviewBundleResult, ProposalReviewQueueDiagnosticsDigestHistoryParams,
     ProposalReviewQueueDiagnosticsDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestParams,
     ProposalReviewQueueDiagnosticsDigestReportHistoryParams,
     ProposalReviewQueueDiagnosticsDigestReportHistoryResult,
@@ -234,6 +239,7 @@ const METHOD_TOOL_INTENT_PARSE: &str = "tool.intent.parse";
 const METHOD_TOOL_EXECUTE: &str = "tool.execute";
 const METHOD_RUN_EVENTS: &str = "run.events";
 const METHOD_RUN_INSPECT: &str = "run.inspect";
+const METHOD_CODEBASE_INDEX_BUILD: &str = "codebase.index.build";
 const METHOD_PROPOSAL_LIST: &str = "proposal.list";
 const METHOD_PROPOSAL_INSPECT: &str = "proposal.inspect";
 const METHOD_PROPOSAL_APPROVE: &str = "proposal.approve";
@@ -384,6 +390,7 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         METHOD_TOOL_EXECUTE => handle_tool_execute(request.id, request.params),
         METHOD_RUN_EVENTS => handle_run_events(request.id, request.params),
         METHOD_RUN_INSPECT => handle_run_inspect(request.id, request.params),
+        METHOD_CODEBASE_INDEX_BUILD => handle_codebase_index_build(request.id, request.params),
         METHOD_PROPOSAL_LIST => handle_proposal_list(request.id, request.params),
         METHOD_PROPOSAL_INSPECT => handle_proposal_inspect(request.id, request.params),
         METHOD_PROPOSAL_APPROVE => handle_proposal_approve(request.id, request.params),
@@ -3653,6 +3660,150 @@ fn handle_run_inspect(id: Value, params: Option<Value>) -> JsonRpcResponse<Value
         Ok(run) => result_response(id, json!(RunInspectResult { run })),
         Err(message) => error_response(id, -32602, &message),
     }
+}
+
+fn handle_codebase_index_build(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
+    let params = match params {
+        Some(value) => match serde_json::from_value::<CodebaseIndexBuildParams>(value) {
+            Ok(params) => params,
+            Err(error) => return error_response(id, -32602, &format!("invalid params: {error}")),
+        },
+        None => CodebaseIndexBuildParams::default(),
+    };
+
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+
+    let built_at = match codebase_index_timestamp() {
+        Ok(timestamp) => timestamp,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+
+    let snapshot = match build_workspace_file_inventory(
+        store.workspace_root(),
+        CodebaseIndexBuildOptions {
+            root: params.root.clone(),
+            max_files: params.max_files,
+            max_directories: params.max_directories,
+            max_path_chars: params.max_path_chars,
+            max_file_bytes: params.max_file_bytes,
+        },
+    ) {
+        Ok(snapshot) => snapshot,
+        Err(error) => return error_response(id, -32602, &format!("invalid params: {error}")),
+    };
+
+    let manifest = codebase_index_manifest(snapshot, built_at);
+    if let Err(error) = store.codebase_index().write_current_snapshot(&manifest) {
+        return error_response(
+            id,
+            -32603,
+            &format!("internal error: failed to persist codebase index snapshot: {error}"),
+        );
+    }
+
+    let event_payload = serde_json::json!({
+        "index_id": manifest.snapshot.index_id.clone(),
+        "root": manifest.snapshot.root.clone(),
+        "workspace_fingerprint": manifest.snapshot.workspace_fingerprint.clone(),
+        "snapshot_fingerprint": manifest.snapshot.snapshot_fingerprint.clone(),
+        "built_at": manifest.snapshot.built_at.clone(),
+        "indexed_files": manifest.snapshot.counts.indexed_files,
+        "walked_directories": manifest.snapshot.counts.walked_directories,
+        "skipped_protected": manifest.snapshot.counts.skipped_protected,
+        "skipped_symlink": manifest.snapshot.counts.skipped_symlink,
+        "skipped_too_large": manifest.snapshot.counts.skipped_too_large,
+        "skipped_binary_like": manifest.snapshot.counts.skipped_binary_like,
+        "skipped_unreadable": manifest.snapshot.counts.skipped_unreadable,
+        "skipped_unsafe_path": manifest.snapshot.counts.skipped_unsafe_path,
+        "skipped_other": manifest.snapshot.counts.skipped_other,
+        "truncated_entries": manifest.snapshot.counts.truncated_entries,
+        "truncated": manifest.snapshot.truncated,
+        "max_files": manifest.snapshot.limits.max_files,
+        "max_directories": manifest.snapshot.limits.max_directories,
+        "max_path_chars": manifest.snapshot.limits.max_path_chars,
+        "max_file_bytes": manifest.snapshot.limits.max_file_bytes,
+        "force_refresh": params.force_refresh.unwrap_or(false),
+        "next_action": "use_codebase_index_for_context_planning"
+    });
+
+    let event = match store
+        .codebase_index()
+        .append_event(LedgerEventKind::CodebaseIndexSnapshotBuilt, event_payload)
+    {
+        Ok(event) => event,
+        Err(error) => {
+            return error_response(
+                id,
+                -32603,
+                &format!("internal error: failed to append codebase index ledger event: {error}"),
+            )
+        }
+    };
+
+    result_response(
+        id,
+        json!(CodebaseIndexBuildResult {
+            snapshot: manifest.snapshot,
+            persisted: true,
+            ledger_event_id: event.event_id,
+            ledger_event_kind: format!("{:?}", event.kind),
+            next_action: "use_codebase_index_for_context_planning".to_string(),
+        }),
+    )
+}
+
+fn codebase_index_manifest(
+    snapshot: CodebaseIndexSnapshot,
+    built_at: String,
+) -> CodebaseIndexSnapshotManifest {
+    CodebaseIndexSnapshotManifest {
+        snapshot: CodebaseIndexSnapshotSummary {
+            index_id: snapshot.index_id,
+            root: snapshot.root,
+            workspace_fingerprint: snapshot.workspace_fingerprint,
+            snapshot_fingerprint: snapshot.snapshot_fingerprint,
+            built_at,
+            counts: CodebaseIndexCountsSummary {
+                indexed_files: snapshot.counts.indexed_files,
+                walked_directories: snapshot.counts.walked_directories,
+                skipped_protected: snapshot.counts.skipped_protected,
+                skipped_symlink: snapshot.counts.skipped_symlink,
+                skipped_too_large: snapshot.counts.skipped_too_large,
+                skipped_binary_like: snapshot.counts.skipped_binary_like,
+                skipped_unreadable: snapshot.counts.skipped_unreadable,
+                skipped_unsafe_path: snapshot.counts.skipped_unsafe_path,
+                skipped_other: snapshot.counts.skipped_other,
+                truncated_entries: snapshot.counts.truncated_entries,
+            },
+            limits: CodebaseIndexLimitsSummary {
+                max_files: snapshot.limits.max_files,
+                max_directories: snapshot.limits.max_directories,
+                max_path_chars: snapshot.limits.max_path_chars,
+                max_file_bytes: snapshot.limits.max_file_bytes,
+            },
+            truncated: snapshot.truncated,
+        },
+        entries: snapshot
+            .entries
+            .into_iter()
+            .map(|entry| CodebaseIndexFileEntry {
+                path: entry.path,
+                file_kind: format!("{:?}", entry.file_kind),
+                byte_length: entry.byte_length,
+                line_count: entry.line_count,
+                content_sha256: entry.content_sha256,
+            })
+            .collect(),
+    }
+}
+
+fn codebase_index_timestamp() -> anyhow::Result<String> {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .map_err(anyhow::Error::from)
 }
 
 fn handle_proposal_list(id: Value, params: Option<Value>) -> JsonRpcResponse<Value> {
@@ -19206,6 +19357,133 @@ mod tests {
     pub(super) fn parse_line(line: &str) -> JsonRpcResponse<Value> {
         serde_json::from_str(&handle_jsonrpc_input_line(line).expect("response line"))
             .expect("valid response")
+    }
+
+    #[test]
+    fn codebase_index_build_persists_snapshot_and_bounded_ledger_event() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir(temp.path().join(".brownie")).expect("brownie dir");
+        std::fs::create_dir(temp.path().join("src")).expect("src dir");
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn ok() -> u8 {\n    1\n}\n",
+        )
+        .expect("src");
+        std::fs::write(
+            temp.path().join("Cargo.toml"),
+            "[package]\nname = \"idx\"\n",
+        )
+        .expect("manifest");
+        std::fs::write(temp.path().join("README.md"), "# Index\n").expect("readme");
+        std::fs::create_dir_all(temp.path().join("node_modules/pkg")).expect("node_modules");
+        std::fs::write(
+            temp.path().join("node_modules/pkg/index.js"),
+            "module.exports = 1;",
+        )
+        .expect("dependency");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let first =
+            parse_line(r#"{"jsonrpc":"2.0","id":1,"method":"codebase.index.build","params":{}}"#);
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        let result = first.result.expect("index build result");
+        assert_eq!(result["persisted"], true);
+        assert_eq!(result["ledger_event_kind"], "CodebaseIndexSnapshotBuilt");
+        assert_eq!(
+            result["next_action"],
+            "use_codebase_index_for_context_planning"
+        );
+        assert_eq!(result["snapshot"]["root"], ".");
+        assert_eq!(result["snapshot"]["counts"]["indexed_files"], 3);
+        assert_eq!(result["snapshot"]["counts"]["skipped_protected"], 2);
+        assert!(result["snapshot"]["snapshot_fingerprint"]
+            .as_str()
+            .expect("snapshot fingerprint")
+            .starts_with("sha256:"));
+
+        let store = BrownieStore::new(temp.path());
+        let current = store
+            .codebase_index()
+            .read_current_snapshot()
+            .expect("read current")
+            .expect("current snapshot");
+        assert_eq!(current.entries.len(), 3);
+        assert!(current.entries.iter().all(|entry| {
+            !entry.path.contains(".brownie")
+                && !entry.path.contains("node_modules")
+                && !entry.path.starts_with('/')
+        }));
+        assert!(current
+            .entries
+            .iter()
+            .any(|entry| entry.path == "src/lib.rs" && entry.file_kind == "Rust"));
+
+        let events = store.codebase_index().read_events().expect("index events");
+        assert_eq!(events.len(), 1);
+        let payload = &events[0].payload;
+        for forbidden in [
+            "content",
+            "file_content",
+            "full_content",
+            "absolute_path",
+            "canonical_path",
+            "stdout",
+            "stderr",
+            "env",
+            "raw_input",
+        ] {
+            assert!(
+                payload.get(forbidden).is_none(),
+                "forbidden payload field {forbidden}"
+            );
+        }
+
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let second =
+            parse_line(r#"{"jsonrpc":"2.0","id":2,"method":"codebase.index.build","params":{}}"#);
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        let second_result = second.result.expect("second result");
+        assert_eq!(
+            result["snapshot"]["snapshot_fingerprint"],
+            second_result["snapshot"]["snapshot_fingerprint"]
+        );
+
+        std::fs::write(
+            temp.path().join("src/lib.rs"),
+            "pub fn ok() -> u8 {\n    2\n}\n",
+        )
+        .expect("change src");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let changed =
+            parse_line(r#"{"jsonrpc":"2.0","id":3,"method":"codebase.index.build","params":{}}"#);
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        let changed_result = changed.result.expect("changed result");
+        assert_ne!(
+            result["snapshot"]["snapshot_fingerprint"],
+            changed_result["snapshot"]["snapshot_fingerprint"]
+        );
+    }
+
+    #[test]
+    fn codebase_index_build_rejects_unsafe_and_unknown_params() {
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+
+        let unsafe_root = parse_line(
+            r#"{"jsonrpc":"2.0","id":1,"method":"codebase.index.build","params":{"root":"../outside"}}"#,
+        );
+        assert_eq!(unsafe_root.error.expect("unsafe error").code, -32602);
+
+        let unknown_field = parse_line(
+            r#"{"jsonrpc":"2.0","id":2,"method":"codebase.index.build","params":{"root":".","raw_input":"nope"}}"#,
+        );
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+        assert_eq!(
+            unknown_field.error.expect("unknown field error").code,
+            -32602
+        );
     }
 
     fn write_cargo_check_fixture(workspace_root: &Path, package_name: &str, source: &str) {

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -8,8 +8,9 @@ use std::time::Duration;
 
 use anyhow::{bail, Context, Result};
 use brownie_protocol::{
-    ChildTaskSourceIntentSummary, RecoveryCycleChildProvenance, TaskRecord, TaskStartParams,
-    TaskStatus, VerificationRecoveryProvenance, VerificationRecoveryRetryProvenance,
+    ChildTaskSourceIntentSummary, CodebaseIndexSnapshotManifest, RecoveryCycleChildProvenance,
+    TaskRecord, TaskStartParams, TaskStatus, VerificationRecoveryProvenance,
+    VerificationRecoveryRetryProvenance,
 };
 use serde::{Deserialize, Serialize};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -17,6 +18,7 @@ use uuid::Uuid;
 
 pub const WORKSPACE_STATE_DIR: &str = ".brownie";
 pub const RUNS_DIR: &str = "runs";
+pub const CODEBASE_INDEX_DIR: &str = "codebase-index";
 const RUN_ADMISSION_LOCK_RETRIES: usize = 200;
 const RUN_ADMISSION_LOCK_SLEEP: Duration = Duration::from_millis(10);
 
@@ -44,6 +46,10 @@ impl BrownieStore {
         &self.task_store
     }
 
+    pub fn codebase_index(&self) -> CodebaseIndexStore {
+        CodebaseIndexStore::new(self.workspace_root().to_path_buf())
+    }
+
     pub fn workspace_root(&self) -> &std::path::Path {
         self.task_store.workspace_root()
     }
@@ -52,6 +58,119 @@ impl BrownieStore {
 #[derive(Debug, Clone)]
 pub struct TaskStore {
     workspace_root: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodebaseIndexStore {
+    workspace_root: PathBuf,
+}
+
+impl CodebaseIndexStore {
+    pub fn new(workspace_root: impl Into<PathBuf>) -> Self {
+        Self {
+            workspace_root: workspace_root.into(),
+        }
+    }
+
+    pub fn write_current_snapshot(&self, manifest: &CodebaseIndexSnapshotManifest) -> Result<()> {
+        let root = self.index_dir();
+        let snapshots_dir = root.join("snapshots");
+        fs::create_dir_all(&snapshots_dir)
+            .with_context(|| format!("failed to create {}", snapshots_dir.display()))?;
+
+        let body =
+            serde_json::to_string_pretty(manifest).context("failed to serialize index snapshot")?;
+        let snapshot_path = snapshots_dir.join(format!("{}.json", manifest.snapshot.index_id));
+        let snapshot_tmp = snapshots_dir.join(format!(
+            "{}.json.tmp-{}",
+            manifest.snapshot.index_id,
+            Uuid::new_v4().simple()
+        ));
+        fs::write(&snapshot_tmp, &body).context("failed to write temporary index snapshot")?;
+        fs::rename(&snapshot_tmp, &snapshot_path).with_context(|| {
+            format!(
+                "failed to atomically replace index snapshot {}",
+                snapshot_path.display()
+            )
+        })?;
+
+        let current_path = root.join("current.json");
+        let current_tmp = root.join(format!("current.json.tmp-{}", Uuid::new_v4().simple()));
+        fs::write(&current_tmp, body).context("failed to write temporary current index")?;
+        fs::rename(&current_tmp, &current_path).with_context(|| {
+            format!(
+                "failed to atomically replace current index {}",
+                current_path.display()
+            )
+        })
+    }
+
+    pub fn read_current_snapshot(&self) -> Result<Option<CodebaseIndexSnapshotManifest>> {
+        let current_path = self.index_dir().join("current.json");
+        if !current_path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&current_path)
+            .with_context(|| format!("failed to read {}", current_path.display()))?;
+        Ok(Some(serde_json::from_str(&content).with_context(|| {
+            format!("failed to parse {}", current_path.display())
+        })?))
+    }
+
+    pub fn append_event(
+        &self,
+        kind: LedgerEventKind,
+        payload: serde_json::Value,
+    ) -> Result<CodebaseIndexLedgerEvent> {
+        let event = CodebaseIndexLedgerEvent {
+            event_id: format!("event_{}", Uuid::new_v4()),
+            kind,
+            timestamp: timestamp()?,
+            payload,
+        };
+        fs::create_dir_all(self.index_dir())
+            .with_context(|| format!("failed to create {}", self.index_dir().display()))?;
+        let mut buffer = Vec::new();
+        serde_json::to_writer(&mut buffer, &event)
+            .context("failed to serialize codebase index ledger event")?;
+        writeln!(&mut buffer).context("failed to write index ledger newline")?;
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.index_dir().join("ledger.jsonl"))
+            .context("failed to open codebase index ledger")?;
+        file.write_all(&buffer)
+            .context("failed to append codebase index ledger event")?;
+        Ok(event)
+    }
+
+    pub fn read_events(&self) -> Result<Vec<CodebaseIndexLedgerEvent>> {
+        let ledger_path = self.index_dir().join("ledger.jsonl");
+        if !ledger_path.exists() {
+            return Ok(Vec::new());
+        }
+        let file = fs::File::open(&ledger_path)
+            .with_context(|| format!("failed to open {}", ledger_path.display()))?;
+        let reader = BufReader::new(file);
+        let mut events = Vec::new();
+        for line in reader.lines() {
+            let line = line.context("failed to read codebase index ledger line")?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            events.push(
+                serde_json::from_str(&line)
+                    .with_context(|| format!("failed to parse {}", ledger_path.display()))?,
+            );
+        }
+        Ok(events)
+    }
+
+    fn index_dir(&self) -> PathBuf {
+        self.workspace_root
+            .join(WORKSPACE_STATE_DIR)
+            .join(CODEBASE_INDEX_DIR)
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -874,7 +993,16 @@ pub struct LedgerEvent {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CodebaseIndexLedgerEvent {
+    pub event_id: String,
+    pub kind: LedgerEventKind,
+    pub timestamp: String,
+    pub payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum LedgerEventKind {
+    CodebaseIndexSnapshotBuilt,
     TaskStarted,
     ModeResolved,
     PermissionChecked,
@@ -942,6 +1070,77 @@ fn timestamp() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn codebase_index_store_writes_current_snapshot_and_bounded_event() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let store = BrownieStore::new(temp.path());
+        let manifest = CodebaseIndexSnapshotManifest {
+            snapshot: brownie_protocol::CodebaseIndexSnapshotSummary {
+                index_id: "idx_abc".to_string(),
+                root: ".".to_string(),
+                workspace_fingerprint: format!("sha256:{}", "a".repeat(64)),
+                snapshot_fingerprint: format!("sha256:{}", "b".repeat(64)),
+                built_at: "2026-07-24T00:00:00Z".to_string(),
+                counts: brownie_protocol::CodebaseIndexCountsSummary {
+                    indexed_files: 1,
+                    walked_directories: 1,
+                    skipped_protected: 0,
+                    skipped_symlink: 0,
+                    skipped_too_large: 0,
+                    skipped_binary_like: 0,
+                    skipped_unreadable: 0,
+                    skipped_unsafe_path: 0,
+                    skipped_other: 0,
+                    truncated_entries: 0,
+                },
+                limits: brownie_protocol::CodebaseIndexLimitsSummary {
+                    max_files: 10,
+                    max_directories: 10,
+                    max_path_chars: 512,
+                    max_file_bytes: 1024,
+                },
+                truncated: false,
+            },
+            entries: vec![brownie_protocol::CodebaseIndexFileEntry {
+                path: "src/lib.rs".to_string(),
+                file_kind: "Rust".to_string(),
+                byte_length: 12,
+                line_count: Some(1),
+                content_sha256: Some(format!("sha256:{}", "c".repeat(64))),
+            }],
+        };
+
+        store
+            .codebase_index()
+            .write_current_snapshot(&manifest)
+            .expect("write snapshot");
+        let current = store
+            .codebase_index()
+            .read_current_snapshot()
+            .expect("read current")
+            .expect("current snapshot");
+        assert_eq!(current, manifest);
+
+        let event = store
+            .codebase_index()
+            .append_event(
+                LedgerEventKind::CodebaseIndexSnapshotBuilt,
+                serde_json::json!({
+                    "index_id": "idx_abc",
+                    "snapshot_fingerprint": manifest.snapshot.snapshot_fingerprint,
+                    "indexed_files": 1,
+                    "truncated": false,
+                    "next_action": "use_codebase_index_for_context_planning"
+                }),
+            )
+            .expect("append event");
+        assert_eq!(event.kind, LedgerEventKind::CodebaseIndexSnapshotBuilt);
+        assert_eq!(
+            store.codebase_index().read_events().expect("read events")[0],
+            event
+        );
+    }
 
     #[test]
     fn task_start_creates_state_and_ledger() {

--- a/docs/architecture/phase-value-manifest.m9.1.json
+++ b/docs/architecture/phase-value-manifest.m9.1.json
@@ -105,7 +105,7 @@
     "required": true,
     "strict_review_required": true,
     "no_self_approval": true,
-    "review_intent": "M9.1 updates the deterministic current phase manifest and archives the M9.1 value gate. Review must confirm this describes real runtime index build behavior and does not weaken generic diagnostics or phase-value enforcement.",
+    "review_intent": "M9.1 archives the behavior-backed value gate. Review must confirm this describes real runtime index build behavior and does not weaken generic diagnostics or phase-value enforcement.",
     "changed_files": [
       "docs/architecture/phase-value-manifest.json",
       "docs/architecture/phase-value-manifest.m9.1.json",

--- a/docs/architecture/runtime-overview.md
+++ b/docs/architecture/runtime-overview.md
@@ -86,6 +86,24 @@ M8.3 lets the caller continue after an approved recovery proposal has been appli
 
 R3.3 makes failed `verification.cargo_check` recovery actionable without raw log exposure. The controlled verifier runs Cargo with structured JSON output, keeps captured stdout/stderr internal to the verifier, and emits at most five `bounded_cargo_diagnostics` entries with tool ID, check ID, diagnostic kind, severity, optional code, normalized workspace-relative path, line, column, and truncation state. The runtime sanitizes those entries before ledger insertion, includes them on failed verification completion gates and `VerificationRecoveryProvenance`, and materializes them into recovery prompts. It must not persist raw stdout/stderr, rendered compiler diagnostics, source snippets, commands, environment values, absolute or canonical paths, file content, provider responses, or raw prompt text.
 
+## Runtime Codebase Indexing Boundary
+
+M9.1 introduces `codebase.index.build`, the first runtime-owned codebase
+indexing execution path. The Rust runtime calls `brownie-indexer` to scan an
+optional workspace-relative root, reject unsafe roots, skip protected or
+generated directories, reject symlinks without following them, classify regular
+files, compute bounded metadata, persist a sorted snapshot manifest under
+`.brownie/codebase-index`, append a `CodebaseIndexSnapshotBuilt` ledger event,
+and return a compact snapshot handle and counts for headless callers.
+
+The VSIX remains a protocol client and does not own indexing policy. M9.1 does
+not implement semantic symbols, chunks, embeddings, Qdrant writes, retrieval,
+reranking, LLM calls, shell/git/network execution, service control, or
+workspace mutation. Snapshot manifests, ledger events, and RPC responses must
+not expose raw file content, snippets, diffs, absolute paths, canonical paths,
+raw prompts, provider responses, stdout/stderr, environment values, commands,
+or secrets.
+
 Generic `process.exec` remains listed as a non-executable planning surface. The runtime denies it even for modes that may execute the controlled verifier. Verifier results expose only check id, verifier status, launch/timeout flags, exit code, duration, byte counts, truncation flags, redaction status, and bounded reason strings. They must not expose raw stdout, stderr, command strings, environment values, stdin, raw input JSON, file content, canonical paths, absolute paths, shell execution, git execution, network access, service control, or arbitrary test execution.
 
 ## R3 Verifier Integrity Recovery

--- a/docs/specifications/indexing-spec-v0.md
+++ b/docs/specifications/indexing-spec-v0.md
@@ -54,3 +54,50 @@ Initial retrieval should combine lexical search and vector search, then merge re
 - Production reranker.
 - Replacing Qdrant.
 - Full language-server semantic indexing.
+
+## M9.1 Runtime File Inventory Slice
+
+M9.1 implements the first executable indexer behavior: a runtime-owned
+metadata-only workspace file inventory. The JSON-RPC method
+`codebase.index.build` invokes `brownie-indexer` through the Rust runtime,
+not the VSIX.
+
+The M9.1 scanner:
+
+- accepts only an optional workspace-relative root;
+- rejects absolute roots and parent traversal before traversal;
+- never follows symlinks;
+- skips symlink files and directories;
+- skips protected or generated components including `.git`, `.brownie`,
+  `node_modules`, `target`, `dist`, `build`, `coverage`, `.next`, `out`, and
+  `vendor`;
+- indexes existing regular files only;
+- classifies bounded entries as Rust, TypeScript, JavaScript, JSON, TOML,
+  Markdown, YAML, Shell, Text, or Other;
+- clamps caller-supplied file, directory, path-length, and per-file byte
+  limits to runtime maxima;
+- reads file bytes only transiently for SHA-256 change detection and UTF-8 line
+  counts, then discards the bytes.
+
+The persisted manifest lives under runtime-owned state:
+
+```text
+.brownie/
+└─ codebase-index/
+   ├─ current.json
+   ├─ ledger.jsonl
+   └─ snapshots/
+      └─ <index_id>.json
+```
+
+Snapshots contain sorted metadata-only entries, counts, effective limits,
+workspace and snapshot fingerprints, and truncation state. They must not
+contain raw file content, snippets, diffs, absolute paths, canonical paths,
+prompts, provider responses, stdout/stderr, environment values, commands, or
+secrets.
+
+The M9.1 ledger event is `CodebaseIndexSnapshotBuilt`. Its payload contains
+only the index id, root, fingerprints, counts, limits, truncation state,
+`force_refresh`, and `next_action`. It does not create embeddings, chunks,
+Qdrant writes, retrieval results, shell/git/network execution, or workspace
+mutation.

--- a/docs/specifications/runtime-protocol-spec-v0.md
+++ b/docs/specifications/runtime-protocol-spec-v0.md
@@ -39,6 +39,21 @@ Task run data is stored under:
 
 `state.json` contains the persisted `TaskRecord`. `ledger.jsonl` contains append-only RunLedger events, one JSON object per line.
 
+Codebase index snapshots are stored separately from task runs:
+
+```text
+.brownie/
+└─ codebase-index/
+   ├─ current.json
+   ├─ ledger.jsonl
+   └─ snapshots/
+      └─ <index_id>.json
+```
+
+`current.json` and `snapshots/<index_id>.json` contain metadata-only
+`CodebaseIndexSnapshotManifest` documents. `ledger.jsonl` contains
+append-only `CodebaseIndexSnapshotBuilt` evidence events without task/run IDs.
+
 ## `runtime.status`
 
 Request line:
@@ -96,6 +111,72 @@ R3.3 adds optional `bounded_cargo_diagnostics` to failed `verification.cargo_che
 ```
 
 The runtime and VSIX validators must reject raw nested stdout/stderr/rendered messages/source snippets, absolute paths, parent traversal, protected path components, non-positive line or column values, and arrays above the bound. This extends existing results only; it does not add a new RPC, report, digest, history, readiness wrapper, or inspection surface.
+
+## `codebase.index.build`
+
+M9.1 adds the first runtime-owned codebase indexing execution method. The
+method builds or refreshes a bounded metadata-only workspace file inventory
+snapshot and persists it under `.brownie/codebase-index`.
+
+Request line with default workspace root:
+
+```json
+{"jsonrpc":"2.0","id":10,"method":"codebase.index.build","params":{}}
+```
+
+Optional params:
+
+```json
+{"root":"crates","force_refresh":true,"max_files":2000,"max_directories":500,"max_path_chars":512,"max_file_bytes":1048576}
+```
+
+The runtime rejects unknown fields, absolute roots, parent traversal, protected
+root components, non-directory roots, and symlink roots with `-32602`. Caller
+limits are clamped to runtime maxima.
+
+Successful response:
+
+```json
+{
+  "snapshot": {
+    "index_id": "idx_<16 lowercase hex>",
+    "root": ".",
+    "workspace_fingerprint": "sha256:<64 lowercase hex>",
+    "snapshot_fingerprint": "sha256:<64 lowercase hex>",
+    "built_at": "2026-07-24T00:00:00Z",
+    "counts": {
+      "indexed_files": 123,
+      "walked_directories": 20,
+      "skipped_protected": 4,
+      "skipped_symlink": 0,
+      "skipped_too_large": 1,
+      "skipped_binary_like": 0,
+      "skipped_unreadable": 0,
+      "skipped_unsafe_path": 0,
+      "skipped_other": 0,
+      "truncated_entries": 0
+    },
+    "limits": {
+      "max_files": 10000,
+      "max_directories": 2000,
+      "max_path_chars": 512,
+      "max_file_bytes": 1048576
+    },
+    "truncated": false
+  },
+  "persisted": true,
+  "ledger_event_id": "event_<uuid>",
+  "ledger_event_kind": "CodebaseIndexSnapshotBuilt",
+  "next_action": "use_codebase_index_for_context_planning"
+}
+```
+
+The RPC result is compact; full metadata entries are persisted in the snapshot
+manifest. Snapshot entries contain workspace-relative path, file kind,
+byte-length, optional line count, and optional content SHA-256. They must not
+contain raw file content, snippets, diffs, absolute paths, canonical paths,
+prompts, provider responses, stdout/stderr, environment values, commands, or
+secrets.
 
 ## `task.get`
 

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -568,6 +568,58 @@ export interface RunInspectResult {
   run: RunInspectSummary;
 }
 
+export interface CodebaseIndexBuildResult {
+  snapshot: CodebaseIndexSnapshotSummary;
+  persisted: boolean;
+  ledger_event_id: string;
+  ledger_event_kind: 'CodebaseIndexSnapshotBuilt';
+  next_action: 'use_codebase_index_for_context_planning';
+}
+
+export interface CodebaseIndexSnapshotManifest {
+  snapshot: CodebaseIndexSnapshotSummary;
+  entries: CodebaseIndexFileEntry[];
+}
+
+export interface CodebaseIndexSnapshotSummary {
+  index_id: string;
+  root: string;
+  workspace_fingerprint: string;
+  snapshot_fingerprint: string;
+  built_at: string;
+  counts: CodebaseIndexCountsSummary;
+  limits: CodebaseIndexLimitsSummary;
+  truncated: boolean;
+}
+
+export interface CodebaseIndexCountsSummary {
+  indexed_files: number;
+  walked_directories: number;
+  skipped_protected: number;
+  skipped_symlink: number;
+  skipped_too_large: number;
+  skipped_binary_like: number;
+  skipped_unreadable: number;
+  skipped_unsafe_path: number;
+  skipped_other: number;
+  truncated_entries: number;
+}
+
+export interface CodebaseIndexLimitsSummary {
+  max_files: number;
+  max_directories: number;
+  max_path_chars: number;
+  max_file_bytes: number;
+}
+
+export interface CodebaseIndexFileEntry {
+  path: string;
+  file_kind: 'Rust' | 'TypeScript' | 'JavaScript' | 'Json' | 'Toml' | 'Markdown' | 'Yaml' | 'Shell' | 'Text' | 'Other';
+  byte_length: number;
+  line_count?: number | null;
+  content_sha256?: string | null;
+}
+
 export interface TaskInspectResult {
   task: TaskRecord;
   run: RunInspectSummary;
@@ -3755,6 +3807,113 @@ function isSanitizedLedgerPayload(value: unknown): boolean {
 
 export function isRunEventsResult(value: unknown): value is RunEventsResult {
   return isRecord(value) && typeof value.run_id === 'string' && Array.isArray(value.events) && value.events.every(isLedgerEventSummary);
+}
+
+export function isCodebaseIndexBuildResult(value: unknown): value is CodebaseIndexBuildResult {
+  return (
+    isRecord(value) &&
+    hasNoForbiddenRawFields(value) &&
+    isCodebaseIndexSnapshotSummary(value.snapshot) &&
+    value.persisted === true &&
+    typeof value.ledger_event_id === 'string' &&
+    value.ledger_event_kind === 'CodebaseIndexSnapshotBuilt' &&
+    value.next_action === 'use_codebase_index_for_context_planning'
+  );
+}
+
+export function isCodebaseIndexSnapshotManifest(value: unknown): value is CodebaseIndexSnapshotManifest {
+  return (
+    isRecord(value) &&
+    hasNoForbiddenRawFields(value) &&
+    isCodebaseIndexSnapshotSummary(value.snapshot) &&
+    Array.isArray(value.entries) &&
+    value.entries.length <= 20000 &&
+    value.entries.every(isCodebaseIndexFileEntry) &&
+    value.entries.length === value.snapshot.counts.indexed_files
+  );
+}
+
+export function isCodebaseIndexSnapshotSummary(value: unknown): value is CodebaseIndexSnapshotSummary {
+  return (
+    isRecord(value) &&
+    hasNoForbiddenRawFields(value) &&
+    typeof value.index_id === 'string' &&
+    /^idx_[a-f0-9]{16}$/.test(value.index_id) &&
+    typeof value.root === 'string' &&
+    isSafeIndexRoot(value.root) &&
+    typeof value.workspace_fingerprint === 'string' &&
+    isSha256Fingerprint(value.workspace_fingerprint) &&
+    typeof value.snapshot_fingerprint === 'string' &&
+    isSha256Fingerprint(value.snapshot_fingerprint) &&
+    typeof value.built_at === 'string' &&
+    isCodebaseIndexCountsSummary(value.counts) &&
+    isCodebaseIndexLimitsSummary(value.limits) &&
+    typeof value.truncated === 'boolean'
+  );
+}
+
+function isCodebaseIndexCountsSummary(value: unknown): value is CodebaseIndexCountsSummary {
+  return (
+    isRecord(value) &&
+    Object.values(value).every(isNonNegativeInteger) &&
+    isNonNegativeInteger(value.indexed_files) &&
+    isNonNegativeInteger(value.walked_directories) &&
+    isNonNegativeInteger(value.skipped_protected) &&
+    isNonNegativeInteger(value.skipped_symlink) &&
+    isNonNegativeInteger(value.skipped_too_large) &&
+    isNonNegativeInteger(value.skipped_binary_like) &&
+    isNonNegativeInteger(value.skipped_unreadable) &&
+    isNonNegativeInteger(value.skipped_unsafe_path) &&
+    isNonNegativeInteger(value.skipped_other) &&
+    isNonNegativeInteger(value.truncated_entries)
+  );
+}
+
+function isCodebaseIndexLimitsSummary(value: unknown): value is CodebaseIndexLimitsSummary {
+  return (
+    isRecord(value) &&
+    isNonNegativeInteger(value.max_files) &&
+    value.max_files > 0 &&
+    value.max_files <= 20000 &&
+    isNonNegativeInteger(value.max_directories) &&
+    value.max_directories > 0 &&
+    value.max_directories <= 5000 &&
+    isNonNegativeInteger(value.max_path_chars) &&
+    value.max_path_chars > 0 &&
+    value.max_path_chars <= 1024 &&
+    isNonNegativeInteger(value.max_file_bytes) &&
+    value.max_file_bytes > 0 &&
+    value.max_file_bytes <= 2097152
+  );
+}
+
+function isCodebaseIndexFileEntry(value: unknown): value is CodebaseIndexFileEntry {
+  return (
+    isRecord(value) &&
+    hasNoForbiddenRawFields(value) &&
+    typeof value.path === 'string' &&
+    isSafeIndexEntryPath(value.path) &&
+    isCodebaseIndexFileKind(value.file_kind) &&
+    isNonNegativeInteger(value.byte_length) &&
+    (value.line_count === undefined || value.line_count === null || isNonNegativeInteger(value.line_count)) &&
+    (value.content_sha256 === undefined || value.content_sha256 === null || (typeof value.content_sha256 === 'string' && isSha256Fingerprint(value.content_sha256)))
+  );
+}
+
+function isCodebaseIndexFileKind(value: unknown): value is CodebaseIndexFileEntry['file_kind'] {
+  return value === 'Rust' || value === 'TypeScript' || value === 'JavaScript' || value === 'Json' || value === 'Toml' || value === 'Markdown' || value === 'Yaml' || value === 'Shell' || value === 'Text' || value === 'Other';
+}
+
+function isSafeIndexRoot(value: string): boolean {
+  return value === '.' || isSafeIndexEntryPath(value);
+}
+
+function isSafeIndexEntryPath(value: string): boolean {
+  if (value.length === 0 || value.length > 1024 || value.startsWith('/') || value.startsWith('~') || value.includes('\\')) {
+    return false;
+  }
+  const parts = value.split('/');
+  return parts.every((part) => part.length > 0 && part !== '.' && part !== '..' && !['.git', '.brownie', 'node_modules', 'target'].includes(part));
 }
 
 export function isChildTaskInspectSummary(value: unknown): value is ChildTaskInspectSummary {

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { isProposalApplyResult, isTaskRunVerificationRecoveryRepairOutcome, isTaskRunVerificationRecoveryRetryOutcome } from '../runtime/protocol';
+import { isCodebaseIndexBuildResult, isCodebaseIndexSnapshotManifest } from '../runtime/protocol';
 import { RuntimeJsonRpcError } from '../runtime/errors';
 import { isChildInspectConsumedParentJoinRecoverySummary, isChildInspectParentJoinReadinessSummary, isRecoveryCycleBudgetOutcome, isRecoveryCycleChildProvenance, isRunInspectConsumedParentJoinRecoverySummary, isRunInspectParentJoinReadinessSummary, isTaskInspectResult, isTaskRecord, isTaskRunChildOrchestrationOutcome, isTaskRunParentJoinReadinessOutcome, isTaskRunResult } from '../runtime/protocol';
 import { isJsonRpcResponse, isLedgerEventSummary, isLlmHealthResult, isLlmStatusResult, isModeSummary, isPermissionCheckResult, isRunInspectSummary, isProposalApplyCapabilityResult, isProposalApplyDryRunHistoryResult, isProposalApplyDryRunResult, isProposalApproveResult, isProposalAuditTrailResult, isProposalPreflightResult, isProposalReadinessResult, isProposalInspectResult, isProposalListResult, isProposalRejectResult, isProposalReviewBundleResult, isProposalReviewQueueDiagnosticsDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryResult, isProposalReviewQueueDiagnosticsDigestReportVerdictReportResult, isProposalReviewQueueDiagnosticsDigestReportVerdictResult, isProposalReviewQueueDiagnosticsDigestResult, isProposalReviewQueueDiagnosticsHistoryResult, isProposalReviewQueueDiagnosticsReportResult, isProposalReviewQueueDiagnosticsResult, isProposalReviewQueueResult, isProposalReviewReportResult, isProposalReviewVerdictResult, isRuntimeConfigGetResult, isRuntimeDiagnosticsResult, isRuntimeStatusResult, isToolExecuteResult, isToolIntentParseResult, isToolPlanResult, type JsonRpcRequest, type JsonRpcResponse } from '../runtime/protocol';
@@ -505,6 +506,58 @@ describe('protocol validation', () => {
       timestamp: '2026-06-26T00:00:00Z',
       payload: { ...verifierPayload, process_tree_kill_attempted: 'false' },
     })).toBe(false);
+  });
+
+  it('validates codebase index build results and rejects raw or unsafe fields', () => {
+    const snapshot = {
+      index_id: 'idx_abcdef1234567890',
+      root: '.',
+      workspace_fingerprint: `sha256:${'a'.repeat(64)}`,
+      snapshot_fingerprint: `sha256:${'b'.repeat(64)}`,
+      built_at: '2026-07-24T00:00:00Z',
+      counts: {
+        indexed_files: 1,
+        walked_directories: 2,
+        skipped_protected: 1,
+        skipped_symlink: 0,
+        skipped_too_large: 0,
+        skipped_binary_like: 0,
+        skipped_unreadable: 0,
+        skipped_unsafe_path: 0,
+        skipped_other: 0,
+        truncated_entries: 0,
+      },
+      limits: {
+        max_files: 100,
+        max_directories: 100,
+        max_path_chars: 512,
+        max_file_bytes: 1048576,
+      },
+      truncated: false,
+    };
+    const entry = {
+      path: 'src/lib.rs',
+      file_kind: 'Rust',
+      byte_length: 12,
+      line_count: 1,
+      content_sha256: `sha256:${'c'.repeat(64)}`,
+    };
+    const result = {
+      snapshot,
+      persisted: true,
+      ledger_event_id: 'event_1',
+      ledger_event_kind: 'CodebaseIndexSnapshotBuilt',
+      next_action: 'use_codebase_index_for_context_planning',
+    };
+    const manifest = { snapshot, entries: [entry] };
+
+    expect(isCodebaseIndexBuildResult(result)).toBe(true);
+    expect(isCodebaseIndexSnapshotManifest(manifest)).toBe(true);
+    expect(isCodebaseIndexBuildResult({ ...result, snapshot: { ...snapshot, root: '/tmp/repo' } })).toBe(false);
+    expect(isCodebaseIndexSnapshotManifest({ ...manifest, entries: [{ ...entry, path: '../secret.rs' }] })).toBe(false);
+    expect(isCodebaseIndexSnapshotManifest({ ...manifest, entries: [{ ...entry, path: '.brownie/current.json' }] })).toBe(false);
+    expect(isCodebaseIndexSnapshotManifest({ ...manifest, entries: [{ ...entry, content: 'raw source' }] })).toBe(false);
+    expect(isCodebaseIndexBuildResult({ ...result, absolute_path: '/tmp/repo' })).toBe(false);
   });
 
   it('validates recovery-cycle child provenance invariants', () => {


### PR DESCRIPTION
## Summary
- Add `codebase.index.build` as the M9.1 runtime-owned codebase index build RPC.
- Add `brownie-indexer` workspace scanning, filtering, classification, deterministic metadata fingerprints, and safety bounds.
- Persist metadata-only snapshots under `.brownie/codebase-index` and append bounded `CodebaseIndexSnapshotBuilt` evidence.
- Add VSIX protocol validators and tests for valid index results plus raw-field and unsafe-path rejection.

## Capability gain
Brownie can now build a deterministic workspace file inventory from a safe workspace-relative root, skip protected/generated paths and symlinks, classify regular files, persist the snapshot, and return a compact handle for later context planning.

## Why existing behavior was insufficient
`workspace.read` can read one requested file, and existing inspection/report surfaces summarize ledger state. None of the existing runtime paths can recursively scan, classify, fingerprint, persist, or replay a codebase inventory for headless planning.

## Architecture
- `brownie-indexer` owns the scanner/filter/classifier and produces metadata-only `CodebaseIndexSnapshot` values.
- `brownie-runtime` exposes exactly one new M9.1 method, `codebase.index.build`, maps snapshots to protocol summaries, persists current and archived manifests, and appends bounded event metadata.
- `brownie-store` owns `.brownie/codebase-index/current.json`, `snapshots/<index_id>.json`, and `ledger.jsonl`.
- VSIX remains validation-only and does not own policy decisions.

## Safety boundary
- Workspace-relative root only; absolute roots and parent traversal are rejected.
- Protected/generated directories and symlinks are skipped without following them.
- Metadata only: no raw file content, snippets, diffs, absolute/canonical paths, prompts, provider responses, stdout/stderr, environment values, commands, or secrets are returned or persisted.
- No shell, git, network, service control, workspace mutation, embeddings, Qdrant writes, retrieval, chunks, or semantic symbols are added.

## Tests
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
- `git diff --check`

## Non-goals
- No index query RPC, semantic graph, chunks, embeddings, Qdrant integration, retrieval/ranking, or context assembly.
- No file creation/deletion/rewrite outside runtime-owned `.brownie/codebase-index` state.
- No wrapper/report/digest/history/readiness surface.

## Value gate
- Target capability: `codebase_indexing`.
- Concrete gain: runtime-owned persisted file inventory build.
- Non-duplicative: follows R3 verifier/recovery integrity work and starts a new indexing capability family.
- Wrapper-only: false. The runtime behavior now scans, classifies, persists, and records bounded ledger evidence.