### PR TITLE
M19.2 Headless context budget envelope reuse

### DIFF
--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -460,6 +460,8 @@ pub struct HeadlessContinueOnceParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_steps: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_budget: Option<TaskRunContextBudget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verification_recovery_source: Option<VerificationRecoverySource>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verification_recovery_goal: Option<String>,
@@ -490,6 +492,8 @@ pub struct HeadlessRunAdvanceParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_steps: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_budget: Option<TaskRunContextBudget>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_progress_fingerprint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expected_aggregate_sequence: Option<u64>,
@@ -507,6 +511,8 @@ pub struct HeadlessRunDriveParams {
     pub max_advances: Option<u8>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_steps_per_advance: Option<u8>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_budget: Option<TaskRunContextBudget>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -1190,6 +1196,8 @@ pub struct HeadlessContinueStepResult {
     pub post_progress_fingerprint: Option<String>,
     pub post_aggregate_sequence: Option<u64>,
     pub replayed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_budget: Option<TaskRunContextBudgetSummary>,
     pub next_route: Option<HeadlessContinueRoute>,
     pub next_action: String,
 }

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -33349,7 +33349,7 @@ mod tests {
             .expect("list result")["progress_overview"]
             .clone();
         let first_request = format!(
-            r#"{{"jsonrpc":"2.0","id":2,"method":"headless.run.advance","params":{{"authorize":true,"session_id":"m17.session","advance_id":"m17.advance.1","expected_session_sequence":1,"expected_progress_fingerprint":"{}","expected_aggregate_sequence":{},"max_steps":2}}}}"#,
+            r#"{{"jsonrpc":"2.0","id":2,"method":"headless.run.advance","params":{{"authorize":true,"session_id":"m17.session","advance_id":"m17.advance.1","expected_session_sequence":1,"expected_progress_fingerprint":"{}","expected_aggregate_sequence":{},"max_steps":2,"context_budget":{{"max_prompt_chars":4096,"max_ledger_events":1,"max_selected_index_chars":0}}}}}}"#,
             progress["source_fingerprint"]
                 .as_str()
                 .expect("fingerprint"),
@@ -33377,6 +33377,22 @@ mod tests {
             first_result["steps"][1]["continuation_id"],
             "run.m17.session.1.step.2"
         );
+        assert_eq!(
+            first_result["steps"][0]["context_budget"]["requested"],
+            true
+        );
+        assert_eq!(
+            first_result["steps"][0]["context_budget"]["max_ledger_events"],
+            1
+        );
+        assert_eq!(
+            first_result["steps"][1]["context_budget"]["requested"],
+            true
+        );
+        assert_eq!(
+            first_result["steps"][1]["context_budget"]["max_selected_index_chars"],
+            0
+        );
 
         let replay_response = parse_line(&first_request);
         let replay_result = replay_response
@@ -33386,6 +33402,10 @@ mod tests {
         assert_eq!(
             replay_result["checkpoint_fingerprint"],
             first_result["checkpoint_fingerprint"]
+        );
+        assert_eq!(
+            replay_result["steps"][0]["context_budget"],
+            first_result["steps"][0]["context_budget"]
         );
 
         let second_response = parse_line(
@@ -33540,7 +33560,7 @@ mod tests {
             .unwrap_or_else(|| panic!("seed advance failed"));
         assert_eq!(seed["session_sequence"], 1);
 
-        let drive_request = r#"{"jsonrpc":"2.0","id":3,"method":"headless.run.drive","params":{"authorize":true,"session_id":"m17.drive","drive_id":"m17.drive.1","expected_start_session_sequence":1,"max_advances":2,"max_steps_per_advance":1}}"#;
+        let drive_request = r#"{"jsonrpc":"2.0","id":3,"method":"headless.run.drive","params":{"authorize":true,"session_id":"m17.drive","drive_id":"m17.drive.1","expected_start_session_sequence":1,"max_advances":2,"max_steps_per_advance":1,"context_budget":{"max_prompt_chars":4096,"max_ledger_events":1,"max_selected_index_chars":0}}}"#;
         let drive = parse_line(drive_request)
             .result
             .unwrap_or_else(|| panic!("drive failed"));
@@ -33557,12 +33577,23 @@ mod tests {
             .as_str()
             .expect("drive fingerprint")
             .starts_with("sha256:"));
+        let drive_advances = drive["advances"].as_array().expect("drive advances");
+        assert!(drive_advances
+            .iter()
+            .all(|advance| advance["steps"][0]["context_budget"]["requested"] == true));
+        assert!(drive_advances
+            .iter()
+            .all(|advance| advance["steps"][0]["context_budget"]["max_selected_index_chars"] == 0));
 
         let replay = parse_line(drive_request)
             .result
             .unwrap_or_else(|| panic!("drive replay failed"));
         assert_eq!(replay["replayed"], true);
         assert_eq!(replay["drive_fingerprint"], drive["drive_fingerprint"]);
+        assert_eq!(
+            replay["advances"][0]["steps"][0]["context_budget"],
+            drive["advances"][0]["steps"][0]["context_budget"]
+        );
 
         let selected_run_ids = seed["steps"]
             .as_array()

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -5587,6 +5587,26 @@ fn validate_task_run_context_budget(
     }))
 }
 
+fn validate_headless_context_budget_bounds(
+    budget: Option<&TaskRunContextBudget>,
+) -> Result<(), &'static str> {
+    let Some(budget) = budget else {
+        return Ok(());
+    };
+    if !(TASK_RUN_CONTEXT_BUDGET_MIN_PROMPT_CHARS..=TASK_RUN_CONTEXT_BUDGET_MAX_PROMPT_CHARS)
+        .contains(&budget.max_prompt_chars)
+    {
+        return Err("invalid params: context_budget.max_prompt_chars is out of range");
+    }
+    if budget.max_ledger_events > TASK_RUN_CONTEXT_BUDGET_MAX_LEDGER_EVENTS {
+        return Err("invalid params: context_budget.max_ledger_events is out of range");
+    }
+    if budget.max_selected_index_chars > TASK_RUN_CONTEXT_BUDGET_MAX_SELECTED_INDEX_CHARS {
+        return Err("invalid params: context_budget.max_selected_index_chars is out of range");
+    }
+    Ok(())
+}
+
 fn task_run_context_budget_summary(
     context_budget: &ContextBudgetSummary,
 ) -> Option<TaskRunContextBudgetSummary> {
@@ -7804,6 +7824,9 @@ fn handle_headless_continue_once(id: Value, params: Option<Value>) -> JsonRpcRes
             "invalid params: verification_recovery_source cannot be combined with verification retry fields",
         );
     }
+    if let Err(message) = validate_headless_context_budget_bounds(params.context_budget.as_ref()) {
+        return error_response(id, -32602, message);
+    }
     if let Some(max_steps) = params.max_steps {
         if max_steps == 0 || max_steps > HEADLESS_CONTINUE_MAX_BUDGET_STEPS {
             return error_response(
@@ -7829,6 +7852,19 @@ fn handle_headless_continue_once(id: Value, params: Option<Value>) -> JsonRpcRes
             }
             return handle_headless_continue_budget(id, params);
         }
+    }
+    if params.context_budget.is_some()
+        && (params.verification_recovery_source.is_some()
+            || params.verification_recovery_retry_source.is_some()
+            || params.verification_recovery_run_target.is_some()
+            || params.verification_recovery_apply_target.is_some()
+            || params.verification_recovery_retry_run_target.is_some())
+    {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: context_budget is supported only for normal headless task continuation",
+        );
     }
 
     let store = match BrownieStore::from_env_or_cwd() {
@@ -8023,6 +8059,18 @@ fn handle_headless_continue_once(id: Value, params: Option<Value>) -> JsonRpcRes
             }),
         );
     }
+    if let Err(rejection) =
+        validate_task_run_context_budget(&selected_record, params.context_budget.as_ref())
+    {
+        return match rejection {
+            TaskRunAdmissionRejection::InvalidParams(message) => {
+                error_response(id, -32602, message)
+            }
+            TaskRunAdmissionRejection::Internal(message) => {
+                error_response(id, -32603, &format!("internal error: {message}"))
+            }
+        };
+    }
 
     let decision_id = format!("headless_decision_{}", uuid::Uuid::new_v4().simple());
     let policy_version = "headless_continue_once_v1";
@@ -8066,6 +8114,7 @@ fn handle_headless_continue_once(id: Value, params: Option<Value>) -> JsonRpcRes
         id.clone(),
         Some(json!({
             "task_id": selected_record.task_id,
+            "context_budget": params.context_budget.clone(),
         })),
     );
     let Some(task_run_value) = task_run_response.result else {
@@ -8158,6 +8207,9 @@ fn handle_headless_run_advance(id: Value, params: Option<Value>) -> JsonRpcRespo
             -32602,
             "invalid params: max_steps must be between 1 and 3",
         );
+    }
+    if let Err(message) = validate_headless_context_budget_bounds(params.context_budget.as_ref()) {
+        return error_response(id, -32602, message);
     }
     if params.expected_session_sequence == 0 {
         return error_response(
@@ -8263,7 +8315,8 @@ fn handle_headless_run_advance(id: Value, params: Option<Value>) -> JsonRpcRespo
             "expected_progress_fingerprint": start_fingerprint,
             "expected_aggregate_sequence": start_sequence,
             "continuation_id": continuation_id,
-            "max_steps": max_steps
+            "max_steps": max_steps,
+            "context_budget": params.context_budget.clone()
         })),
     );
     let Some(result_value) = response.result else {
@@ -8315,6 +8368,10 @@ fn handle_headless_run_advance(id: Value, params: Option<Value>) -> JsonRpcRespo
             post_progress_fingerprint: continue_result.post_progress_fingerprint.clone(),
             post_aggregate_sequence: continue_result.post_aggregate_sequence,
             replayed: continue_result.replayed,
+            context_budget: continue_result
+                .task_run_result
+                .as_ref()
+                .and_then(|result| result.context_budget.clone()),
             next_route: continue_result.next_route.clone(),
             next_action: continue_result.next_action.clone(),
         }]
@@ -8434,6 +8491,9 @@ fn handle_headless_run_drive(id: Value, params: Option<Value>) -> JsonRpcRespons
             "invalid params: max_steps_per_advance must be between 1 and 3",
         );
     }
+    if let Err(message) = validate_headless_context_budget_bounds(params.context_budget.as_ref()) {
+        return error_response(id, -32602, message);
+    }
 
     let store = match BrownieStore::from_env_or_cwd() {
         Ok(store) => store,
@@ -8499,7 +8559,8 @@ fn handle_headless_run_drive(id: Value, params: Option<Value>) -> JsonRpcRespons
                 "session_id": params.session_id,
                 "advance_id": advance_id,
                 "expected_session_sequence": session_sequence,
-                "max_steps": max_steps_per_advance
+                "max_steps": max_steps_per_advance,
+                "context_budget": params.context_budget.clone()
             })),
         );
         let Some(result_value) = response.result else {
@@ -9408,7 +9469,8 @@ fn handle_headless_continue_budget(
                 "authorize": true,
                 "expected_progress_fingerprint": expected_progress_fingerprint,
                 "expected_aggregate_sequence": expected_aggregate_sequence,
-                "continuation_id": step_continuation_id
+                "continuation_id": step_continuation_id,
+                "context_budget": params.context_budget.clone()
             })),
         );
         let Some(result_value) = response.result else {
@@ -9443,6 +9505,10 @@ fn handle_headless_continue_budget(
             post_progress_fingerprint: result.post_progress_fingerprint.clone(),
             post_aggregate_sequence: result.post_aggregate_sequence,
             replayed: result.replayed,
+            context_budget: result
+                .task_run_result
+                .as_ref()
+                .and_then(|task_run_result| task_run_result.context_budget.clone()),
             next_route: result.next_route.clone(),
             next_action: result.next_action.clone(),
         });
@@ -32959,7 +33025,7 @@ mod tests {
             .expect("list result")["progress_overview"]
             .clone();
         let response = parse_line(&format!(
-            r#"{{"jsonrpc":"2.0","id":2,"method":"headless.continue_once","params":{{"authorize":true,"expected_progress_fingerprint":"{}","expected_aggregate_sequence":{},"continuation_id":"continue.budget.1","max_steps":2}}}}"#,
+            r#"{{"jsonrpc":"2.0","id":2,"method":"headless.continue_once","params":{{"authorize":true,"expected_progress_fingerprint":"{}","expected_aggregate_sequence":{},"continuation_id":"continue.budget.1","max_steps":2,"context_budget":{{"max_prompt_chars":4096,"max_ledger_events":1,"max_selected_index_chars":0}}}}}}"#,
             progress["source_fingerprint"]
                 .as_str()
                 .expect("fingerprint"),
@@ -32984,6 +33050,10 @@ mod tests {
         assert_eq!(steps[1]["continuation_id"], "continue.budget.1.step.2");
         assert_eq!(steps[1]["status"], "task_executed");
         assert_ne!(steps[0]["selected_task_id"], steps[1]["selected_task_id"]);
+        assert_eq!(steps[0]["context_budget"]["requested"], true);
+        assert_eq!(steps[0]["context_budget"]["max_ledger_events"], 1);
+        assert_eq!(steps[1]["context_budget"]["requested"], true);
+        assert_eq!(steps[1]["context_budget"]["max_selected_index_chars"], 0);
 
         let selected_run_ids = steps
             .iter()
@@ -33171,6 +33241,14 @@ mod tests {
             progress["aggregate_sequence"].as_u64().expect("sequence")
         ));
         assert_eq!(too_large.error.expect("error").code, -32602);
+        let invalid_context_budget = parse_line(&format!(
+            r#"{{"jsonrpc":"2.0","id":4,"method":"headless.continue_once","params":{{"authorize":true,"expected_progress_fingerprint":"{}","expected_aggregate_sequence":{},"continuation_id":"continue.budget.invalid.context","context_budget":{{"max_prompt_chars":127,"max_ledger_events":1,"max_selected_index_chars":0}}}}}}"#,
+            progress["source_fingerprint"]
+                .as_str()
+                .expect("fingerprint"),
+            progress["aggregate_sequence"].as_u64().expect("sequence")
+        ));
+        assert_eq!(invalid_context_budget.error.expect("error").code, -32602);
         let events = store
             .tasks()
             .read_ledger_events(&task.run_id)

--- a/docs/architecture/phase-value-manifest.json
+++ b/docs/architecture/phase-value-manifest.json
@@ -1,39 +1,39 @@
 {
   "schema_version": 1,
-  "phase": "M19.1",
+  "phase": "M19.2",
   "current_milestone": "m19_runtime_context_budget_management",
   "milestone": "M19 Runtime Context Budget Management",
   "target_capability": "context_management",
-  "concrete_capability_transition": "task_run_materializes_runtime_context_under_explicit_caller_budget",
+  "concrete_capability_transition": "headless_continuation_reuses_runtime_context_budget_envelope_for_task_run_steps",
   "forbidden_pattern": "new_rpc_report_digest_history_readiness_inspection_only_route_status_wrapper_background_scheduler_daemon_automatic_apply_verifier_retry_execution_vsix_owned_policy_provider_shell_git_network_service_expansion_raw_prompt_provider_response_file_content_diff_command_stdout_stderr_environment_secret_path",
   "project_objective_ref": "docs/architecture/product-charter.md",
   "strategic_capability_mapping": [
     {
       "capability": "context_management",
-      "relationship": "The Rust runtime now honors caller-provided task-run context budgets while building the actual provider prompt, including ledger-window and selected-index-context bounds."
-    },
-    {
-      "capability": "persistent_structured_ledger",
-      "relationship": "PromptBuilt events record bounded budget metadata and truncation decisions without storing raw selected file content or prompt text."
+      "relationship": "Existing headless continuation methods carry an optional runtime context budget envelope into the task.run steps they execute."
     },
     {
       "capability": "headless_autonomous_development",
-      "relationship": "Headless callers can bound context materialization deterministically and inspect compact execution evidence to decide the next continuation step."
+      "relationship": "Headless callers can advance or drive multiple task steps while preserving deterministic context ceilings without caller-side per-step task.run reconstruction."
+    },
+    {
+      "capability": "persistent_structured_ledger",
+      "relationship": "Continuation, advance, drive, and PromptBuilt evidence expose only bounded numeric/boolean budget metadata and replay it without raw prompt or file content."
     }
   ],
   "phase_value_gate": {
     "required": true,
     "answers": {
-      "strategic_capabilities": "Advances context_management with supporting persistent_structured_ledger and headless_autonomous_development.",
-      "new_capability": "Existing task.run accepts an optional context_budget and Rust materialization applies max_prompt_chars, max_ledger_events, and max_selected_index_chars before provider execution.",
-      "why_existing_functionality_is_insufficient": "Provider max_prompt_chars only truncated final messages globally; callers could not bound ledger events or selected-index context at materialization time with structured replay evidence.",
-      "product_gap_if_skipped": "Long-running headless work could over-admit runtime context, making continuation behavior less predictable and forcing callers to rely on provider-level truncation instead of runtime-owned context policy.",
-      "non_duplicative": "Yes. M18.1-M18.3 advanced recovery-loop continuation boundaries; M19.1 changes task-run prompt materialization and budgeted context evidence.",
-      "no_new_rpc": "Yes. The existing task.run request/result contract is extended; no new JSON-RPC method is added.",
-      "no_new_summary": "Yes. The returned context_budget is execution evidence for task.run, not a standalone report/history/readiness surface.",
-      "runtime_behavior_change": "task.run now validates explicit context budgets, bounds ledger context, truncates selected-index prompt content, fails closed when protected prompt content cannot fit, and returns bounded budget evidence.",
-      "headless_autonomous_contribution": "Headless callers can choose deterministic context ceilings and decide whether to continue, split, or retry based on compact budget evidence.",
-      "milestone_progress": "Establishes the first M19 runtime-owned context budgeting slice for task execution."
+      "strategic_capabilities": "Advances context_management with supporting headless_autonomous_development and persistent_structured_ledger.",
+      "new_capability": "headless.continue_once, headless.run.advance, and headless.run.drive accept an optional context_budget envelope and apply it to normal task.run steps they execute.",
+      "why_existing_functionality_is_insufficient": "M19.1 direct task.run budgets do not affect task.run calls invoked internally by headless continuation, so headless drive loops could not prove a consistent runtime-owned context policy.",
+      "product_gap_if_skipped": "Long-running headless execution still depends on external controllers to reconstruct and pass context budgets per task step, or else risks unbounded context materialization.",
+      "non_duplicative": "Yes. M18.2/M18.3 handled recovery-loop execution/apply boundaries and M19.1 handled direct task.run budget materialization; M19.2 carries that budget into existing headless execution paths.",
+      "no_new_rpc": "Yes. The existing headless methods are extended; no JSON-RPC method is added.",
+      "no_new_summary": "Yes. Budget metadata is execution evidence attached to existing task-run and headless step results, not a standalone report/history/readiness surface.",
+      "runtime_behavior_change": "Normal headless continuation task execution forwards the context budget into task.run after validation and returns bounded per-step context budget evidence.",
+      "headless_autonomous_contribution": "Scheduled/headless callers can authorize bounded multi-step continuation without switching to direct task.run or duplicating policy outside Rust.",
+      "milestone_progress": "Combines direct task-run budget materialization with headless budget envelope reuse, the second core M19 context-management slice."
     },
     "questions": [
       {
@@ -85,25 +85,22 @@
       "report_only",
       "inspection_only_without_runtime_behavior_change",
       "new_json_rpc_method_for_context_budget_status",
-      "budget_result_without_prompt_materialization_behavior_change",
+      "budget_result_without_headless_task_run_materialization_behavior_change",
       "vsix_owned_routing_or_policy",
       "raw_prompt_provider_response_file_content_diff_command_output_environment_or_path_exposure",
       "source_file_token_presence_only_acceptance"
     ],
-    "review_intent": "M19.1 updates the deterministic current phase manifest. Review must confirm actual task.run context materialization behavior changes and no raw context leakage."
+    "review_intent": "Review must confirm the PR changes headless-executed task.run context materialization and preserves replay safety without raw context leakage."
   },
   "guard_engine_change_review": {
     "required": true,
     "strict_review_required": true,
     "no_self_approval": true,
-    "review_intent": "M19.1 updates the deterministic current phase manifest. Review must confirm actual task.run context materialization behavior changes and no raw context leakage.",
+    "review_intent": "M19.2 updates the deterministic current phase manifest. Review must confirm actual headless task-run budget behavior and no raw context leakage.",
     "changed_files": [
       "docs/architecture/phase-value-manifest.json",
-      "docs/architecture/phase-value-manifest.m18.3.json",
       "docs/architecture/phase-value-manifest.m19.1.json",
       "crates/brownie-protocol/src/lib.rs",
-      "crates/brownie-context/src/lib.rs",
-      "crates/brownie-agent-loop/src/lib.rs",
       "crates/brownie-runtime/src/lib.rs",
       "extensions/brownie-vsix/src/runtime/protocol.ts",
       "extensions/brownie-vsix/src/test/runtimeClient.test.ts"
@@ -114,27 +111,28 @@
     ]
   },
   "exit_criteria": [
-    "task.run accepts optional context_budget without adding a new RPC",
-    "invalid context_budget values are rejected before TaskRunning",
-    "max_ledger_events bounds the materialized ledger context window used for prompt construction",
-    "max_selected_index_chars truncates selected-index prompt content while result and ledger evidence remain summary-only",
-    "max_prompt_chars is enforced against the built prompt and impossible protected context budgets fail closed before provider execution",
-    "PromptBuilt records bounded budget metadata without raw prompt, provider response, file content, path, stdout, stderr, command, environment, or secret values",
-    "VSIX protocol types and validators accept valid context_budget request/result payloads and reject malformed or raw-content-bearing payloads",
-    "no new diagnostics wrapper, readiness report, history, digest, scheduler, provider/shell/git/network/service expansion, or VSIX-owned policy is introduced"
+    "headless.continue_once accepts optional context_budget for normal task continuation and rejects unsupported recovery/apply specialized combinations",
+    "headless.run.advance forwards context_budget into the continuation step it executes and replays bounded evidence",
+    "headless.run.drive forwards context_budget into each advance it executes and replays bounded evidence",
+    "invalid context_budget values are rejected before headless decision/task-running mutation",
+    "headless step results expose bounded context_budget evidence without raw prompt, selected-index content, file content, ledger payload, command output, environment, path, request body, or secrets",
+    "behavior tests prove the envelope changes task.run materialization behavior under headless execution"
   ],
-  "source_evidence": {
-    "runtime": [
-      "TaskRunContextBudget",
-      "ContextMaterializerInput.context_budget",
-      "PromptBuilt.context_budget_requested",
-      "task_run_applies_explicit_context_budget_to_materialized_context"
-    ],
-    "tests": [
-      "context materializer budget tests",
-      "task.run context budget runtime behavior tests",
-      "VSIX task.run context budget validator tests"
-    ]
-  },
-  "next_phase_candidate_notes": "After M19.1 merge, consider M19.2 for persisted resumable context-budget recommendations only if it changes headless continuation behavior; reject standalone context reports or budget histories."
+  "non_goals": [
+    "new JSON-RPC method",
+    "context budget report, digest, history, readiness, verdict, or inspection endpoint",
+    "provider policy expansion",
+    "workspace mutation",
+    "shell, git, test, network, or service execution expansion",
+    "automatic scheduler or background daemon",
+    "VSIX-owned context policy",
+    "raw prompt, provider response, file content, selected-index content, ledger payload, stdout, stderr, command, environment, path, request body, secret, or API key exposure"
+  ],
+  "tests": [
+    "headless_continue_once_budget_runs_bounded_sequential_created_tasks",
+    "headless_continue_once_budget_validates_budget_authorization_bounds",
+    "headless_run_advance_persists_checkpoint_replays_and_advances_from_checkpoint",
+    "headless_run_drive_advances_from_checkpoint_replays_and_records_drive_evidence",
+    "runtimeClient protocol guards accept context_budget on headless params and bounded step results"
+  ]
 }

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -295,6 +295,7 @@ export interface HeadlessContinueOnceParams {
   expected_aggregate_sequence: number;
   continuation_id?: string | null;
   max_steps?: number | null;
+  context_budget?: TaskRunContextBudget | null;
   verification_recovery_source?: VerificationRecoverySource | null;
   verification_recovery_goal?: string | null;
   verification_recovery_mode_id?: string | null;
@@ -312,6 +313,7 @@ export interface HeadlessRunAdvanceParams {
   advance_id?: string | null;
   expected_session_sequence: number;
   max_steps?: number | null;
+  context_budget?: TaskRunContextBudget | null;
   expected_progress_fingerprint?: string | null;
   expected_aggregate_sequence?: number | null;
 }
@@ -323,6 +325,7 @@ export interface HeadlessRunDriveParams {
   expected_start_session_sequence: number;
   max_advances?: number | null;
   max_steps_per_advance?: number | null;
+  context_budget?: TaskRunContextBudget | null;
 }
 
 export interface VerificationRecoverySource {
@@ -516,6 +519,7 @@ export interface HeadlessContinueStepResult {
   post_progress_fingerprint?: string | null;
   post_aggregate_sequence?: number | null;
   replayed: boolean;
+  context_budget?: TaskRunContextBudgetSummary | null;
   next_route?: HeadlessContinueRoute | null;
   next_action: string;
 }
@@ -4251,13 +4255,14 @@ export function isTaskRunContextBudget(value: unknown): value is TaskRunContextB
 export function isHeadlessContinueOnceParams(value: unknown): value is HeadlessContinueOnceParams {
   return (
     isRecord(value) &&
-    hasOnlyFields(value, ['authorize', 'expected_progress_fingerprint', 'expected_aggregate_sequence', 'continuation_id', 'max_steps', 'verification_recovery_source', 'verification_recovery_goal', 'verification_recovery_mode_id', 'verification_recovery_retry_source', 'verification_recovery_retry_goal', 'verification_recovery_retry_mode_id', 'verification_recovery_run_target', 'verification_recovery_apply_target', 'verification_recovery_retry_run_target']) &&
+    hasOnlyFields(value, ['authorize', 'expected_progress_fingerprint', 'expected_aggregate_sequence', 'continuation_id', 'max_steps', 'context_budget', 'verification_recovery_source', 'verification_recovery_goal', 'verification_recovery_mode_id', 'verification_recovery_retry_source', 'verification_recovery_retry_goal', 'verification_recovery_retry_mode_id', 'verification_recovery_run_target', 'verification_recovery_apply_target', 'verification_recovery_retry_run_target']) &&
     value.authorize === true &&
     typeof value.expected_progress_fingerprint === 'string' &&
     isSha256Fingerprint(value.expected_progress_fingerprint) &&
     isNonNegativeInteger(value.expected_aggregate_sequence) &&
     (value.continuation_id === undefined || value.continuation_id === null || isHeadlessContinuationId(value.continuation_id)) &&
     (value.max_steps === undefined || value.max_steps === null || (isNonNegativeInteger(value.max_steps) && value.max_steps >= 1 && value.max_steps <= 3)) &&
+    (value.context_budget === undefined || value.context_budget === null || isTaskRunContextBudget(value.context_budget)) &&
     (value.verification_recovery_source === undefined || value.verification_recovery_source === null || isVerificationRecoverySource(value.verification_recovery_source)) &&
     (value.verification_recovery_goal === undefined || value.verification_recovery_goal === null || typeof value.verification_recovery_goal === 'string') &&
     (value.verification_recovery_mode_id === undefined || value.verification_recovery_mode_id === null || typeof value.verification_recovery_mode_id === 'string') &&
@@ -4273,13 +4278,14 @@ export function isHeadlessContinueOnceParams(value: unknown): value is HeadlessC
 export function isHeadlessRunAdvanceParams(value: unknown): value is HeadlessRunAdvanceParams {
   return (
     isRecord(value) &&
-    hasOnlyFields(value, ['authorize', 'session_id', 'advance_id', 'expected_session_sequence', 'max_steps', 'expected_progress_fingerprint', 'expected_aggregate_sequence']) &&
+    hasOnlyFields(value, ['authorize', 'session_id', 'advance_id', 'expected_session_sequence', 'max_steps', 'context_budget', 'expected_progress_fingerprint', 'expected_aggregate_sequence']) &&
     value.authorize === true &&
     isHeadlessRunId(value.session_id) &&
     (value.advance_id === undefined || value.advance_id === null || isHeadlessRunId(value.advance_id)) &&
     isNonNegativeInteger(value.expected_session_sequence) &&
     value.expected_session_sequence >= 1 &&
     (value.max_steps === undefined || value.max_steps === null || (isNonNegativeInteger(value.max_steps) && value.max_steps >= 1 && value.max_steps <= 3)) &&
+    (value.context_budget === undefined || value.context_budget === null || isTaskRunContextBudget(value.context_budget)) &&
     (value.expected_progress_fingerprint === undefined || value.expected_progress_fingerprint === null || (typeof value.expected_progress_fingerprint === 'string' && isSha256Fingerprint(value.expected_progress_fingerprint))) &&
     (value.expected_aggregate_sequence === undefined || value.expected_aggregate_sequence === null || isNonNegativeInteger(value.expected_aggregate_sequence))
   );
@@ -4288,14 +4294,15 @@ export function isHeadlessRunAdvanceParams(value: unknown): value is HeadlessRun
 export function isHeadlessRunDriveParams(value: unknown): value is HeadlessRunDriveParams {
   return (
     isRecord(value) &&
-    hasOnlyFields(value, ['authorize', 'session_id', 'drive_id', 'expected_start_session_sequence', 'max_advances', 'max_steps_per_advance']) &&
+    hasOnlyFields(value, ['authorize', 'session_id', 'drive_id', 'expected_start_session_sequence', 'max_advances', 'max_steps_per_advance', 'context_budget']) &&
     value.authorize === true &&
     isHeadlessRunId(value.session_id) &&
     (value.drive_id === undefined || value.drive_id === null || isHeadlessRunId(value.drive_id)) &&
     isNonNegativeInteger(value.expected_start_session_sequence) &&
     value.expected_start_session_sequence >= 1 &&
     (value.max_advances === undefined || value.max_advances === null || (isNonNegativeInteger(value.max_advances) && value.max_advances >= 1 && value.max_advances <= 3)) &&
-    (value.max_steps_per_advance === undefined || value.max_steps_per_advance === null || (isNonNegativeInteger(value.max_steps_per_advance) && value.max_steps_per_advance >= 1 && value.max_steps_per_advance <= 3))
+    (value.max_steps_per_advance === undefined || value.max_steps_per_advance === null || (isNonNegativeInteger(value.max_steps_per_advance) && value.max_steps_per_advance >= 1 && value.max_steps_per_advance <= 3)) &&
+    (value.context_budget === undefined || value.context_budget === null || isTaskRunContextBudget(value.context_budget))
   );
 }
 
@@ -4544,6 +4551,7 @@ function isHeadlessContinueStepResult(value: unknown): value is HeadlessContinue
       'post_progress_fingerprint',
       'post_aggregate_sequence',
       'replayed',
+      'context_budget',
       'next_route',
       'next_action',
     ]) &&
@@ -4561,6 +4569,7 @@ function isHeadlessContinueStepResult(value: unknown): value is HeadlessContinue
     (value.post_progress_fingerprint === undefined || value.post_progress_fingerprint === null || (typeof value.post_progress_fingerprint === 'string' && isSha256Fingerprint(value.post_progress_fingerprint))) &&
     (value.post_aggregate_sequence === undefined || value.post_aggregate_sequence === null || isNonNegativeInteger(value.post_aggregate_sequence)) &&
     typeof value.replayed === 'boolean' &&
+    (value.context_budget === undefined || value.context_budget === null || isTaskRunContextBudgetSummary(value.context_budget)) &&
     (value.next_route === undefined || value.next_route === null || isHeadlessContinueRoute(value.next_route)) &&
     typeof value.next_action === 'string'
   );

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -567,6 +567,27 @@ describe('protocol validation', () => {
       status: 'Completed',
       agent_loop: { final_state: 'Completed', completion_summary: 'done' },
     };
+    const contextBudget = {
+      max_prompt_chars: 4096,
+      max_ledger_events: 1,
+      max_selected_index_chars: 0,
+    };
+    const contextBudgetSummary = {
+      requested: true,
+      max_prompt_chars: 4096,
+      max_ledger_events: 1,
+      max_selected_index_chars: 0,
+      total_events: 4,
+      included_events: 1,
+      omitted_events: 3,
+      selected_index_context_present: false,
+      selected_index_content_chars: 0,
+      selected_index_materialized_chars: 0,
+      selected_index_truncated: false,
+      protected_context_chars: 256,
+      prompt_chars: 512,
+      prompt_within_budget: true,
+    };
     const headlessResult = {
       status: 'task_executed',
       decision_id: `headless_decision_${'a'.repeat(32)}`,
@@ -596,6 +617,8 @@ describe('protocol validation', () => {
     };
     expect(isHeadlessContinueOnceParams(headlessParams)).toBe(true);
     expect(isHeadlessContinueOnceParams({ ...headlessParams, max_steps: 2 })).toBe(true);
+    expect(isHeadlessContinueOnceParams({ ...headlessParams, context_budget: contextBudget })).toBe(true);
+    expect(isHeadlessContinueOnceParams({ ...headlessParams, context_budget: { ...contextBudget, max_prompt_chars: 127 } })).toBe(false);
     expect(isHeadlessContinueOnceParams({ ...headlessParams, authorize: false })).toBe(false);
     expect(isHeadlessContinueOnceParams({ ...headlessParams, expected_progress_fingerprint: 'not-a-fingerprint' })).toBe(false);
     expect(isHeadlessContinueOnceParams({ ...headlessParams, max_steps: 0 })).toBe(false);
@@ -678,6 +701,7 @@ describe('protocol validation', () => {
         post_progress_fingerprint: `sha256:${'c'.repeat(64)}`,
         post_aggregate_sequence: taskListProgressOverview.aggregate_sequence + 1,
         replayed: false,
+        context_budget: contextBudgetSummary,
         next_route: {
           kind: 'start_verification_recovery_explicitly',
           reason: 'Selected task failed verifier completion.',
@@ -782,6 +806,7 @@ describe('protocol validation', () => {
       advance_id: 'm17.advance.1',
       expected_session_sequence: 1,
       max_steps: 2,
+      context_budget: contextBudget,
       expected_progress_fingerprint: taskListProgressOverview.source_fingerprint,
       expected_aggregate_sequence: taskListProgressOverview.aggregate_sequence,
     };
@@ -810,6 +835,7 @@ describe('protocol validation', () => {
       next_action: 'start_verification_recovery_explicitly',
     };
     expect(isHeadlessRunAdvanceParams(headlessRunAdvanceParams)).toBe(true);
+    expect(isHeadlessRunAdvanceParams({ ...headlessRunAdvanceParams, context_budget: { ...contextBudget, max_prompt_chars: 127 } })).toBe(false);
     expect(isHeadlessRunAdvanceParams({ ...headlessRunAdvanceParams, authorize: false })).toBe(false);
     expect(isHeadlessRunAdvanceParams({ ...headlessRunAdvanceParams, session_id: 'x'.repeat(49) })).toBe(false);
     expect(isHeadlessRunAdvanceParams({ ...headlessRunAdvanceParams, expected_session_sequence: 0 })).toBe(false);
@@ -825,6 +851,7 @@ describe('protocol validation', () => {
       expected_start_session_sequence: 1,
       max_advances: 2,
       max_steps_per_advance: 1,
+      context_budget: contextBudget,
     };
     const headlessRunDriveResult = {
       status: 'task_executed',
@@ -847,6 +874,7 @@ describe('protocol validation', () => {
       next_action: 'inspect_progress_overview',
     };
     expect(isHeadlessRunDriveParams(headlessRunDriveParams)).toBe(true);
+    expect(isHeadlessRunDriveParams({ ...headlessRunDriveParams, context_budget: { ...contextBudget, max_prompt_chars: 127 } })).toBe(false);
     expect(isHeadlessRunDriveParams({ ...headlessRunDriveParams, authorize: false })).toBe(false);
     expect(isHeadlessRunDriveParams({ ...headlessRunDriveParams, max_advances: 4 })).toBe(false);
     expect(isHeadlessRunDriveResult(headlessRunDriveResult)).toBe(true);


### PR DESCRIPTION
## Summary

Implements M19.2 Headless Context Budget Envelope Reuse.

## Capability gain

Existing headless continuation methods now accept an optional `context_budget` envelope and carry it into normal headless-executed `task.run` steps. `headless.continue_once`, `headless.run.advance`, and `headless.run.drive` can run bounded task steps without a caller reconstructing per-step direct `task.run` requests.

## Why existing behavior was insufficient

M19.1 made direct `task.run` budget-aware, but headless continuation still invoked `task.run` internally without that budget. Long-running headless sessions could not prove consistent runtime-owned prompt materialization ceilings across advance/drive steps.

## Architecture

- Extends existing protocol params with `context_budget`; no new RPC.
- Validates envelope bounds before headless decision/task-running mutation.
- Reuses existing `task.run` context-budget validation for selected task protected-context fit.
- Adds bounded `context_budget` evidence to existing headless step results.
- Mirrors protocol shape in the VSIX without moving policy out of Rust.

## Safety boundary

No raw prompt, selected-index content, file content, ledger payload, provider response, command output, environment, path, request body, or secret is added to headless evidence. Specialized recovery/apply headless targets reject `context_budget` in this phase. No shell/git/network/service/workspace mutation capability is added.

## Tests

- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
- `git diff --check`

## Non-goals

- No new JSON-RPC method.
- No context budget report/history/digest/readiness wrapper.
- No VSIX-owned policy.
- No provider policy expansion.
- No automatic scheduler or background daemon.

## Value gate

- target capability: `context_management`
- concrete gain: headless continuation reuses a runtime-owned context budget envelope for `task.run` steps
- non-duplicative: distinct from M18 recovery boundaries and M19.1 direct task-run budget materialization
- wrapper-only: false
- runtime behavior changed: true
