### PR TITLE
M39.1 Mode Pack candidate provenance verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +150,7 @@ name = "brownie-runtime"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64",
  "brownie-agent-loop",
  "brownie-agentmodes",
  "brownie-config",
@@ -154,6 +161,7 @@ dependencies = [
  "brownie-protocol",
  "brownie-store",
  "brownie-tools",
+ "ed25519-dalek",
  "reqwest",
  "serde",
  "serde_json",
@@ -235,6 +243,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +293,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +357,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +395,12 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
@@ -758,6 +839,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,7 +964,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -883,7 +974,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -973,6 +1073,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1040,6 +1149,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1114,6 +1229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1257,16 @@ checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,8 @@ version = "0.1.0"
 
 [workspace.dependencies]
 anyhow = "1"
+base64 = "0.22"
+ed25519-dalek = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/brownie-protocol/src/lib.rs
+++ b/crates/brownie-protocol/src/lib.rs
@@ -213,6 +213,17 @@ pub struct ModePackApproveCandidateParams {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePackVerifyCandidateProvenanceParams {
+    pub authorize_provenance_verification: bool,
+    pub expected_content_sha256: String,
+    pub expected_compiled_policy_fingerprint: String,
+    pub expected_signer_fingerprint: String,
+    pub provenance_statement_json: String,
+    pub provenance_signature_base64: String,
+    pub provenance_public_key_base64: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModePackActiveSnapshotSummary {
     pub activation_id: String,
     pub activation_fingerprint: String,
@@ -290,6 +301,26 @@ pub struct ModePackApprovedCandidateSummary {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePackCandidateProvenanceSummary {
+    pub provenance_id: String,
+    pub candidate_id: String,
+    pub source_kind: String,
+    pub source_url_host: String,
+    pub source_url_fingerprint: String,
+    pub content_sha256: String,
+    pub modepack_name: String,
+    pub schema_version: u64,
+    pub mode_count: usize,
+    pub mode_ids: Vec<String>,
+    pub compiled_policy_fingerprint: String,
+    pub signer_fingerprint: String,
+    pub statement_sha256: String,
+    pub signature_sha256: String,
+    pub verified_at: String,
+    pub provenance_event_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModePackFetchCandidateResult {
     pub fetched: bool,
     pub replayed: bool,
@@ -302,6 +333,14 @@ pub struct ModePackApproveCandidateResult {
     pub approved: bool,
     pub replayed: bool,
     pub approval: ModePackApprovedCandidateSummary,
+    pub next_action: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePackVerifyCandidateProvenanceResult {
+    pub verified: bool,
+    pub replayed: bool,
+    pub provenance: ModePackCandidateProvenanceSummary,
     pub next_action: String,
 }
 

--- a/crates/brownie-runtime/Cargo.toml
+++ b/crates/brownie-runtime/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 brownie-agentmodes = { path = "../brownie-agentmodes" }
 brownie-agent-loop = { path = "../brownie-agent-loop" }
 brownie-context = { path = "../brownie-context" }
@@ -18,6 +19,7 @@ brownie-modepack = { path = "../brownie-modepack" }
 brownie-protocol = { path = "../brownie-protocol" }
 brownie-store = { path = "../brownie-store" }
 brownie-tools = { path = "../brownie-tools" }
+ed25519-dalek.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/brownie-runtime/src/lib.rs
+++ b/crates/brownie-runtime/src/lib.rs
@@ -1,5 +1,6 @@
 //! Brownie runtime entry points.
 
+use base64::{engine::general_purpose, Engine as _};
 use brownie_agent_loop::{AgentLoop, AgentLoopState};
 use brownie_agentmodes::{
     BuiltinModeRegistry, CompiledModePolicy, RuntimeAction, RuntimePermissionGate,
@@ -40,14 +41,15 @@ use brownie_protocol::{
     LlmProviderFailureRetryRunTarget, LlmProviderFailureRetrySource, LlmRequestBudgetSummary,
     LlmStatusResult, ModeGetParams, ModeListResult, ModePackActivateParams, ModePackActivateResult,
     ModePackActiveSnapshotSummary, ModePackApproveCandidateParams, ModePackApproveCandidateResult,
-    ModePackApprovedCandidateSummary, ModePackCandidateSummary, ModePackFetchCandidateParams,
-    ModePackFetchCandidateResult, ModePackReplaceActiveParams, ModePackReplaceActiveResult,
-    ModePackRollbackActiveParams, ModePackRollbackActiveResult, ModePermissionsSummary,
-    ModeSummary, ParentJoinRunTarget, PatchApplyRecoveryAdmission, PatchApplyRecoveryApplyTarget,
-    PatchApplyRecoveryProvenance, PatchApplyRecoveryRunTarget, PatchApplyRecoverySource,
-    PermissionCheckParams, PermissionCheckResult, ProgressCurrentStage, ProgressLifecyclePhase,
-    ProgressNextAction, ProgressSnapshot, ProgressVerificationState, ProposalApplyCapabilityParams,
-    ProposalApplyCapabilityResult, ProposalApplyDryRunHistoryParams,
+    ModePackApprovedCandidateSummary, ModePackCandidateProvenanceSummary, ModePackCandidateSummary,
+    ModePackFetchCandidateParams, ModePackFetchCandidateResult, ModePackReplaceActiveParams,
+    ModePackReplaceActiveResult, ModePackRollbackActiveParams, ModePackRollbackActiveResult,
+    ModePackVerifyCandidateProvenanceParams, ModePackVerifyCandidateProvenanceResult,
+    ModePermissionsSummary, ModeSummary, ParentJoinRunTarget, PatchApplyRecoveryAdmission,
+    PatchApplyRecoveryApplyTarget, PatchApplyRecoveryProvenance, PatchApplyRecoveryRunTarget,
+    PatchApplyRecoverySource, PermissionCheckParams, PermissionCheckResult, ProgressCurrentStage,
+    ProgressLifecyclePhase, ProgressNextAction, ProgressSnapshot, ProgressVerificationState,
+    ProposalApplyCapabilityParams, ProposalApplyCapabilityResult, ProposalApplyDryRunHistoryParams,
     ProposalApplyDryRunHistoryResult, ProposalApplyDryRunParams, ProposalApplyDryRunResult,
     ProposalApplyParams, ProposalApplyResult, ProposalApproveParams, ProposalApproveResult,
     ProposalAuditTrailParams, ProposalAuditTrailResult, ProposalInspectParams,
@@ -228,9 +230,9 @@ use brownie_store::{
     HeadlessContinuationDecisionLookup, HeadlessRunCompletionFinalizationCheckpoint,
     HeadlessRunSessionCheckpoint, HeadlessRunSessionDriveCheckpoint, LedgerEvent, LedgerEventKind,
     LlmProviderFailureRetryTaskStartParams, ModePackApprovedCandidateSnapshot,
-    ModePackCandidateSnapshot, ParentJoinContinuationRunAdmission,
-    PatchApplyRecoveryTaskStartParams, VerificationRecoveryRetryTaskStartParams,
-    VerificationRecoveryTaskStartParams,
+    ModePackCandidateProvenanceSnapshot, ModePackCandidateSnapshot,
+    ParentJoinContinuationRunAdmission, PatchApplyRecoveryTaskStartParams,
+    VerificationRecoveryRetryTaskStartParams, VerificationRecoveryTaskStartParams,
 };
 use brownie_tools::{
     BuiltinToolRegistry, RejectedToolIntent, ToolExecutionRequest, ToolExecutionStatus,
@@ -242,6 +244,7 @@ use brownie_tools::{
     SUBTASK_SPAWN_TOOL_ID, VERIFICATION_CARGO_CHECK_TOOL_ID, VERIFICATION_CARGO_FMT_CHECK_TOOL_ID,
     VERIFICATION_CARGO_TEST_TOOL_ID, WORKSPACE_READ_TOOL_ID, WORKSPACE_WRITE_TOOL_ID,
 };
+use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use std::{
@@ -291,6 +294,7 @@ const METHOD_MODE_GET: &str = "mode.get";
 const METHOD_MODEPACK_ACTIVATE: &str = "modepack.activate";
 const METHOD_MODEPACK_FETCH_CANDIDATE: &str = "modepack.fetchCandidate";
 const METHOD_MODEPACK_APPROVE_CANDIDATE: &str = "modepack.approveCandidate";
+const METHOD_MODEPACK_VERIFY_CANDIDATE_PROVENANCE: &str = "modepack.verifyCandidateProvenance";
 const METHOD_MODEPACK_REPLACE_ACTIVE: &str = "modepack.replaceActive";
 const METHOD_MODEPACK_ROLLBACK_ACTIVE: &str = "modepack.rollbackActive";
 const METHOD_PERMISSION_CHECK: &str = "permission.check";
@@ -308,6 +312,7 @@ const CODEBASE_INDEX_SELECTION_READ_NEXT_ACTION: &str =
     "use_selected_file_context_for_prompt_materialization";
 const CODEBASE_INDEX_PROMPT_CONTEXT_NEXT_ACTION: &str =
     "continue_task_execution_with_materialized_context";
+const MODEPACK_PROVENANCE_STATEMENT_MAX_BYTES: usize = 16 * 1024;
 const CODEBASE_INDEX_QUERY_DEFAULT_MAX_RESULTS: usize = 10;
 const CODEBASE_INDEX_QUERY_MAX_RESULTS: usize = 50;
 const CODEBASE_INDEX_QUERY_MAX_CHARS: usize = 256;
@@ -464,6 +469,9 @@ pub fn handle_jsonrpc_request(request: JsonRpcRequest) -> JsonRpcResponse<Value>
         }
         METHOD_MODEPACK_APPROVE_CANDIDATE => {
             handle_modepack_approve_candidate(request.id, request.params)
+        }
+        METHOD_MODEPACK_VERIFY_CANDIDATE_PROVENANCE => {
+            handle_modepack_verify_candidate_provenance(request.id, request.params)
         }
         METHOD_MODEPACK_REPLACE_ACTIVE => {
             handle_modepack_replace_active(request.id, request.params)
@@ -14275,6 +14283,53 @@ fn handle_modepack_approve_candidate(id: Value, params: Option<Value>) -> JsonRp
         Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
     };
     let result = match approve_remote_modepack_candidate(&store, &params) {
+        Ok(result) => result,
+        Err(message) => return error_response(id, -32603, &format!("internal error: {message}")),
+    };
+    result_response(id, json!(result))
+}
+
+fn handle_modepack_verify_candidate_provenance(
+    id: Value,
+    params: Option<Value>,
+) -> JsonRpcResponse<Value> {
+    let params: ModePackVerifyCandidateProvenanceParams = match parse_params(params) {
+        Ok(params) => params,
+        Err(message) => return error_response(id, -32602, &message),
+    };
+    if !params.authorize_provenance_verification {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: Mode Pack provenance verification authorization required",
+        );
+    }
+    if !is_sha256_fingerprint(&params.expected_content_sha256) {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: expected_content_sha256 must be a sha256 fingerprint",
+        );
+    }
+    if !is_sha256_fingerprint(&params.expected_compiled_policy_fingerprint) {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: expected_compiled_policy_fingerprint must be a sha256 fingerprint",
+        );
+    }
+    if !is_sha256_fingerprint(&params.expected_signer_fingerprint) {
+        return error_response(
+            id,
+            -32602,
+            "invalid params: expected_signer_fingerprint must be a sha256 fingerprint",
+        );
+    }
+    let store = match BrownieStore::from_env_or_cwd() {
+        Ok(store) => store,
+        Err(error) => return error_response(id, -32603, &format!("internal error: {error}")),
+    };
+    let result = match verify_modepack_candidate_provenance(&store, &params) {
         Ok(result) => result,
         Err(message) => return error_response(id, -32603, &format!("internal error: {message}")),
     };
@@ -28905,6 +28960,278 @@ fn approve_remote_modepack_candidate(
         approval: committed.approval.summary,
         next_action: "replace_active_with_approved_modepack_candidate".to_string(),
     })
+}
+
+fn verify_modepack_candidate_provenance(
+    store: &BrownieStore,
+    params: &ModePackVerifyCandidateProvenanceParams,
+) -> Result<ModePackVerifyCandidateProvenanceResult, String> {
+    if params.provenance_statement_json.as_bytes().len() > MODEPACK_PROVENANCE_STATEMENT_MAX_BYTES {
+        return Err(
+            "modepack candidate provenance verification failed: statement exceeds byte limit"
+                .to_string(),
+        );
+    }
+    if scan_text_for_sensitive_content(&params.provenance_statement_json) {
+        return Err(
+            "modepack candidate provenance verification failed: statement contains sensitive-like content"
+                .to_string(),
+        );
+    }
+    let public_key_bytes = general_purpose::STANDARD
+        .decode(&params.provenance_public_key_base64)
+        .map_err(|_| {
+            "modepack candidate provenance verification failed: public key is not base64"
+                .to_string()
+        })?;
+    if public_key_bytes.len() != 32 {
+        return Err(
+            "modepack candidate provenance verification failed: public key must be 32 bytes"
+                .to_string(),
+        );
+    }
+    let signature_bytes = general_purpose::STANDARD
+        .decode(&params.provenance_signature_base64)
+        .map_err(|_| {
+            "modepack candidate provenance verification failed: signature is not base64".to_string()
+        })?;
+    if signature_bytes.len() != 64 {
+        return Err(
+            "modepack candidate provenance verification failed: signature must be 64 bytes"
+                .to_string(),
+        );
+    }
+    let signer_fingerprint = format!("sha256:{}", hex_sha256(&public_key_bytes));
+    if signer_fingerprint != params.expected_signer_fingerprint {
+        return Err(format!(
+            "modepack candidate provenance verification failed: signer fingerprint mismatch: expected {} but found {}",
+            params.expected_signer_fingerprint, signer_fingerprint
+        ));
+    }
+    let verifying_key =
+        VerifyingKey::from_bytes(public_key_bytes.as_slice().try_into().map_err(|_| {
+            "modepack candidate provenance verification failed: public key length invalid"
+                .to_string()
+        })?)
+        .map_err(|_| {
+            "modepack candidate provenance verification failed: public key invalid".to_string()
+        })?;
+    let signature = Signature::from_slice(&signature_bytes).map_err(|_| {
+        "modepack candidate provenance verification failed: signature invalid".to_string()
+    })?;
+    verifying_key
+        .verify(params.provenance_statement_json.as_bytes(), &signature)
+        .map_err(|_| {
+            "modepack candidate provenance verification failed: bad signature".to_string()
+        })?;
+    let statement: Value =
+        serde_json::from_str(&params.provenance_statement_json).map_err(|_| {
+            "modepack candidate provenance verification failed: statement is not JSON".to_string()
+        })?;
+    let cached = store
+        .read_modepack_candidate_snapshot(&params.expected_content_sha256)
+        .map_err(|error| format!("modepack candidate provenance verification failed: {error}"))?
+        .ok_or_else(|| {
+            "modepack candidate provenance verification failed: cached candidate not found"
+                .to_string()
+        })?;
+    let actual_content_sha256 = format!("sha256:{}", hex_sha256(cached.modepack_json.as_bytes()));
+    if actual_content_sha256 != params.expected_content_sha256 {
+        return Err(format!(
+            "modepack candidate provenance verification failed: cached content fingerprint mismatch: expected {} but found {}",
+            params.expected_content_sha256, actual_content_sha256
+        ));
+    }
+    if cached.summary.content_sha256 != params.expected_content_sha256 {
+        return Err(format!(
+            "modepack candidate provenance verification failed: cached summary fingerprint mismatch: expected {} but found {}",
+            params.expected_content_sha256, cached.summary.content_sha256
+        ));
+    }
+    let recompiled =
+        load_modepack_from_str(&cached.modepack_json, MODEPACK_CANDIDATE_CACHE_SOURCE_PATH)
+            .map_err(|error| {
+                format!("modepack candidate provenance verification compile failed: {error}")
+            })?;
+    for policy in &recompiled.modes {
+        if BuiltinModeRegistry::get(&policy.mode_id).is_some() {
+            return Err(format!(
+                "modepack candidate provenance verification failed: candidate duplicates existing mode_id: {}",
+                policy.mode_id
+            ));
+        }
+    }
+    let policy_snapshots = recompiled
+        .modes
+        .iter()
+        .map(|policy| ActiveModePackPolicySnapshot {
+            mode_id: policy.mode_id.clone(),
+            display_name: policy.display_name.clone(),
+            role_definition: policy.role_definition.clone(),
+            permissions: mode_permissions_payload(policy),
+            allowed_handoff_targets: policy.allowed_handoff_targets.clone(),
+            completion_rules: policy.completion_rules.clone(),
+            policy_fingerprint: external_modepack_policy_fingerprint(
+                &recompiled.name,
+                recompiled.schema_version,
+                policy,
+            ),
+        })
+        .collect::<Vec<_>>();
+    let mode_ids = policy_snapshots
+        .iter()
+        .map(|policy| policy.mode_id.clone())
+        .collect::<Vec<_>>();
+    let compiled_policy_fingerprint = active_modepack_compiled_policy_fingerprint(
+        &recompiled.name,
+        recompiled.schema_version,
+        &policy_snapshots,
+    );
+    if compiled_policy_fingerprint != params.expected_compiled_policy_fingerprint {
+        return Err(format!(
+            "modepack candidate provenance verification failed: compiled policy fingerprint mismatch: expected {} but found {}",
+            params.expected_compiled_policy_fingerprint, compiled_policy_fingerprint
+        ));
+    }
+    if cached.summary.compiled_policy_fingerprint != params.expected_compiled_policy_fingerprint {
+        return Err(format!(
+            "modepack candidate provenance verification failed: cached summary policy fingerprint mismatch: expected {} but found {}",
+            params.expected_compiled_policy_fingerprint, cached.summary.compiled_policy_fingerprint
+        ));
+    }
+    if cached.summary.mode_ids != mode_ids {
+        return Err(
+            "modepack candidate provenance verification failed: cached mode ids are stale"
+                .to_string(),
+        );
+    }
+    validate_modepack_provenance_statement(
+        &statement,
+        &cached.summary,
+        &mode_ids,
+        recompiled.schema_version,
+        &params.expected_content_sha256,
+        &params.expected_compiled_policy_fingerprint,
+        &signer_fingerprint,
+    )?;
+
+    let provenance_summary = ModePackCandidateProvenanceSummary {
+        provenance_id: format!(
+            "modepack_candidate_provenance_{}",
+            &actual_content_sha256[7..23]
+        ),
+        candidate_id: cached.summary.candidate_id,
+        source_kind: cached.summary.source_kind,
+        source_url_host: cached.summary.source_url_host,
+        source_url_fingerprint: cached.summary.source_url_fingerprint,
+        content_sha256: params.expected_content_sha256.clone(),
+        modepack_name: recompiled.name,
+        schema_version: recompiled.schema_version,
+        mode_count: mode_ids.len(),
+        mode_ids,
+        compiled_policy_fingerprint,
+        signer_fingerprint,
+        statement_sha256: format!(
+            "sha256:{}",
+            hex_sha256(params.provenance_statement_json.as_bytes())
+        ),
+        signature_sha256: format!("sha256:{}", hex_sha256(&signature_bytes)),
+        verified_at: codebase_index_timestamp().map_err(|error| error.to_string())?,
+        provenance_event_id: String::new(),
+    };
+    let committed = store
+        .verify_modepack_candidate_provenance_snapshot(&ModePackCandidateProvenanceSnapshot {
+            summary: provenance_summary,
+        })
+        .map_err(|error| format!("modepack candidate provenance verification failed: {error}"))?;
+    Ok(ModePackVerifyCandidateProvenanceResult {
+        verified: !committed.replayed,
+        replayed: committed.replayed,
+        provenance: committed.provenance.summary,
+        next_action: "approve_verified_modepack_candidate".to_string(),
+    })
+}
+
+fn validate_modepack_provenance_statement(
+    statement: &Value,
+    cached_summary: &ModePackCandidateSummary,
+    mode_ids: &[String],
+    schema_version: u64,
+    expected_content_sha256: &str,
+    expected_compiled_policy_fingerprint: &str,
+    signer_fingerprint: &str,
+) -> Result<(), String> {
+    if statement.get("content_sha256").and_then(Value::as_str) != Some(expected_content_sha256) {
+        return Err(
+            "modepack candidate provenance verification failed: statement content fingerprint mismatch"
+                .to_string(),
+        );
+    }
+    if statement
+        .get("compiled_policy_fingerprint")
+        .and_then(Value::as_str)
+        != Some(expected_compiled_policy_fingerprint)
+    {
+        return Err(
+            "modepack candidate provenance verification failed: statement policy fingerprint mismatch"
+                .to_string(),
+        );
+    }
+    if statement
+        .get("source_url_fingerprint")
+        .and_then(Value::as_str)
+        != Some(cached_summary.source_url_fingerprint.as_str())
+    {
+        return Err(
+            "modepack candidate provenance verification failed: statement source fingerprint mismatch"
+                .to_string(),
+        );
+    }
+    if statement.get("schema_version").and_then(Value::as_u64) != Some(schema_version) {
+        return Err(
+            "modepack candidate provenance verification failed: statement schema version mismatch"
+                .to_string(),
+        );
+    }
+    if statement.get("signer_fingerprint").and_then(Value::as_str) != Some(signer_fingerprint) {
+        return Err(
+            "modepack candidate provenance verification failed: statement signer fingerprint mismatch"
+                .to_string(),
+        );
+    }
+    if !statement
+        .get("signer_identity")
+        .and_then(Value::as_str)
+        .map(|value| !value.trim().is_empty())
+        .unwrap_or(false)
+    {
+        return Err(
+            "modepack candidate provenance verification failed: statement signer identity missing"
+                .to_string(),
+        );
+    }
+    let statement_mode_ids = statement
+        .get("mode_ids")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            "modepack candidate provenance verification failed: statement mode_ids missing"
+                .to_string()
+        })?
+        .iter()
+        .map(|value| {
+            value.as_str().map(ToString::to_string).ok_or_else(|| {
+                "modepack candidate provenance verification failed: statement mode_ids invalid"
+                    .to_string()
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    if statement_mode_ids != mode_ids {
+        return Err(
+            "modepack candidate provenance verification failed: statement mode ids mismatch"
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 fn validate_modepack_fetch_url(value: &str, resolve_addresses: bool) -> Result<url::Url, String> {
@@ -63021,6 +63348,245 @@ mod tests {
             .path()
             .join(".brownie/modepack-active/current.json")
             .exists());
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn modepack_verify_candidate_provenance_records_signed_state_and_replays() {
+        use base64::{engine::general_purpose, Engine as _};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let store = BrownieStore::from_env_or_cwd().expect("store");
+        let body = r#"{
+          "name": "remote-agentmodes",
+          "schema_version": 1,
+          "modes": [
+            {
+              "mode_id": "remote-provenance-reviewer",
+              "display_name": "Remote Provenance Reviewer",
+              "role_definition": "Review local changes without writing files.",
+              "permissions": {
+                "read_only": true,
+                "workspace_write": false,
+                "process_exec": false,
+                "network_access": false,
+                "service_control": false,
+                "destructive": false,
+                "can_spawn_subtasks": false
+              },
+              "completion_rules": ["Stop after bounded findings."]
+            }
+          ]
+        }"#;
+        let fetched = fetch_remote_modepack_candidate_with(
+            &store,
+            &ModePackFetchCandidateParams {
+                authorize_fetch: true,
+                url: "https://example.com/modepack.json".to_string(),
+                expected_content_sha256: Some(format!("sha256:{}", hex_sha256(body.as_bytes()))),
+            },
+            |_| {
+                Ok(RemoteModePackFetchResponse {
+                    status: 200,
+                    content_type: Some("application/json".to_string()),
+                    body: body.as_bytes().to_vec(),
+                })
+            },
+        )
+        .expect("candidate fetch");
+        let signing_key = SigningKey::from_bytes(&[7u8; 32]);
+        let public_key_bytes = signing_key.verifying_key().to_bytes();
+        let signer_fingerprint = format!("sha256:{}", hex_sha256(&public_key_bytes));
+        let statement = serde_json::json!({
+            "content_sha256": fetched.candidate.content_sha256,
+            "compiled_policy_fingerprint": fetched.candidate.compiled_policy_fingerprint,
+            "source_url_fingerprint": fetched.candidate.source_url_fingerprint,
+            "mode_ids": fetched.candidate.mode_ids,
+            "schema_version": fetched.candidate.schema_version,
+            "signer_fingerprint": signer_fingerprint,
+            "signer_identity": "example-publisher",
+        })
+        .to_string();
+        let signature = signing_key.sign(statement.as_bytes());
+        let request = format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"modepack.verifyCandidateProvenance","params":{{"authorize_provenance_verification":true,"expected_content_sha256":"{}","expected_compiled_policy_fingerprint":"{}","expected_signer_fingerprint":"{}","provenance_statement_json":{},"provenance_signature_base64":"{}","provenance_public_key_base64":"{}"}}}}"#,
+            fetched.candidate.content_sha256,
+            fetched.candidate.compiled_policy_fingerprint,
+            signer_fingerprint,
+            serde_json::to_string(&statement).expect("statement string"),
+            general_purpose::STANDARD.encode(signature.to_bytes()),
+            general_purpose::STANDARD.encode(public_key_bytes),
+        );
+
+        let verified = parse_line(&request);
+        assert!(verified.error.is_none());
+        let verified_result = verified.result.expect("verified result");
+        assert!(verified_result["verified"].as_bool().unwrap());
+        assert!(!verified_result["replayed"].as_bool().unwrap());
+        assert_eq!(
+            verified_result["provenance"]["content_sha256"],
+            fetched.candidate.content_sha256
+        );
+        assert_eq!(
+            verified_result["provenance"]["signer_fingerprint"],
+            signer_fingerprint
+        );
+        assert_eq!(
+            verified_result["next_action"],
+            "approve_verified_modepack_candidate"
+        );
+
+        let replay = parse_line(&request);
+        assert!(replay.error.is_none());
+        let replay_result = replay.result.expect("replay result");
+        assert!(!replay_result["verified"].as_bool().unwrap());
+        assert!(replay_result["replayed"].as_bool().unwrap());
+        assert_eq!(
+            replay_result["provenance"]["provenance_event_id"],
+            verified_result["provenance"]["provenance_event_id"]
+        );
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/modepack-candidates/ledger.jsonl"),
+        )
+        .expect("ledger");
+        assert_eq!(
+            ledger
+                .lines()
+                .filter(|line| line.contains("ModePackCandidateProvenanceVerified"))
+                .count(),
+            1
+        );
+        assert!(!ledger.contains("Review local changes without writing files."));
+        assert!(!ledger.contains("provenance_statement_json"));
+        assert!(!ledger.contains("provenance_signature_base64"));
+        assert!(!ledger.contains("provenance_public_key_base64"));
+        assert!(!temp
+            .path()
+            .join(".brownie/modepack-active/current.json")
+            .exists());
+
+        std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
+    }
+
+    #[test]
+    fn modepack_verify_candidate_provenance_rejects_bad_signature_and_statement_mismatch() {
+        use base64::{engine::general_purpose, Engine as _};
+        use ed25519_dalek::{Signer, SigningKey};
+
+        let _guard = ENV_LOCK.lock().expect("env lock");
+        let temp = tempfile::tempdir().expect("tempdir");
+        std::env::set_var("BROWNIE_WORKSPACE_ROOT", temp.path());
+        let store = BrownieStore::from_env_or_cwd().expect("store");
+        let body = r#"{
+          "name": "remote-agentmodes",
+          "schema_version": 1,
+          "modes": [
+            {
+              "mode_id": "remote-provenance-denial-reviewer",
+              "display_name": "Remote Provenance Denial Reviewer",
+              "role_definition": "Review local changes without writing files.",
+              "permissions": {
+                "read_only": true,
+                "workspace_write": false,
+                "process_exec": false,
+                "network_access": false,
+                "service_control": false,
+                "destructive": false,
+                "can_spawn_subtasks": false
+              },
+              "completion_rules": ["Stop after bounded findings."]
+            }
+          ]
+        }"#;
+        let fetched = fetch_remote_modepack_candidate_with(
+            &store,
+            &ModePackFetchCandidateParams {
+                authorize_fetch: true,
+                url: "https://example.com/modepack.json".to_string(),
+                expected_content_sha256: Some(format!("sha256:{}", hex_sha256(body.as_bytes()))),
+            },
+            |_| {
+                Ok(RemoteModePackFetchResponse {
+                    status: 200,
+                    content_type: Some("application/json".to_string()),
+                    body: body.as_bytes().to_vec(),
+                })
+            },
+        )
+        .expect("candidate fetch");
+        let signing_key = SigningKey::from_bytes(&[8u8; 32]);
+        let public_key_bytes = signing_key.verifying_key().to_bytes();
+        let signer_fingerprint = format!("sha256:{}", hex_sha256(&public_key_bytes));
+        let statement = serde_json::json!({
+            "content_sha256": fetched.candidate.content_sha256,
+            "compiled_policy_fingerprint": fetched.candidate.compiled_policy_fingerprint,
+            "source_url_fingerprint": fetched.candidate.source_url_fingerprint,
+            "mode_ids": fetched.candidate.mode_ids,
+            "schema_version": fetched.candidate.schema_version,
+            "signer_fingerprint": signer_fingerprint,
+            "signer_identity": "example-publisher",
+        })
+        .to_string();
+        let signature = signing_key.sign(statement.as_bytes());
+        let bad_request = format!(
+            r#"{{"jsonrpc":"2.0","id":2,"method":"modepack.verifyCandidateProvenance","params":{{"authorize_provenance_verification":true,"expected_content_sha256":"{}","expected_compiled_policy_fingerprint":"{}","expected_signer_fingerprint":"{}","provenance_statement_json":{},"provenance_signature_base64":"{}","provenance_public_key_base64":"{}"}}}}"#,
+            fetched.candidate.content_sha256,
+            fetched.candidate.compiled_policy_fingerprint,
+            signer_fingerprint,
+            serde_json::to_string(&statement.replace("content_sha256", "content_sha256"))
+                .expect("statement string"),
+            general_purpose::STANDARD.encode(signature.to_bytes()),
+            general_purpose::STANDARD.encode(public_key_bytes),
+        );
+        let mut value: Value = serde_json::from_str(&bad_request).expect("request json");
+        value["params"]["provenance_statement_json"] = Value::String(statement.replace(
+            &fetched.candidate.content_sha256,
+            "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+        ));
+        let bad_signature = parse_line(&value.to_string());
+        assert!(bad_signature.result.is_none());
+        assert_eq!(bad_signature.error.expect("bad signature").code, -32603);
+
+        let statement_mismatch = serde_json::json!({
+            "content_sha256": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "compiled_policy_fingerprint": fetched.candidate.compiled_policy_fingerprint,
+            "source_url_fingerprint": fetched.candidate.source_url_fingerprint,
+            "mode_ids": fetched.candidate.mode_ids,
+            "schema_version": fetched.candidate.schema_version,
+            "signer_fingerprint": signer_fingerprint,
+            "signer_identity": "example-publisher",
+        })
+        .to_string();
+        let mismatch_signature = signing_key.sign(statement_mismatch.as_bytes());
+        let mismatch_request = format!(
+            r#"{{"jsonrpc":"2.0","id":3,"method":"modepack.verifyCandidateProvenance","params":{{"authorize_provenance_verification":true,"expected_content_sha256":"{}","expected_compiled_policy_fingerprint":"{}","expected_signer_fingerprint":"{}","provenance_statement_json":{},"provenance_signature_base64":"{}","provenance_public_key_base64":"{}"}}}}"#,
+            fetched.candidate.content_sha256,
+            fetched.candidate.compiled_policy_fingerprint,
+            signer_fingerprint,
+            serde_json::to_string(&statement_mismatch).expect("statement mismatch string"),
+            general_purpose::STANDARD.encode(mismatch_signature.to_bytes()),
+            general_purpose::STANDARD.encode(public_key_bytes),
+        );
+        let mismatch = parse_line(&mismatch_request);
+        assert!(mismatch.result.is_none());
+        assert_eq!(mismatch.error.expect("statement mismatch").code, -32603);
+        let ledger = std::fs::read_to_string(
+            temp.path()
+                .join(".brownie/modepack-candidates/ledger.jsonl"),
+        )
+        .expect("ledger");
+        assert_eq!(
+            ledger
+                .lines()
+                .filter(|line| line.contains("ModePackCandidateProvenanceVerified"))
+                .count(),
+            0
+        );
 
         std::env::remove_var("BROWNIE_WORKSPACE_ROOT");
     }

--- a/crates/brownie-store/src/lib.rs
+++ b/crates/brownie-store/src/lib.rs
@@ -10,9 +10,10 @@ use anyhow::{bail, Context, Result};
 use brownie_protocol::{
     ChildTaskSourceIntentSummary, CodebaseIndexSnapshotManifest, HeadlessRunAdvanceResult,
     HeadlessRunCompletionFinalization, HeadlessRunDriveResult, LlmProviderFailureRetryProvenance,
-    ModePackActiveSnapshotSummary, ModePackApprovedCandidateSummary, ModePackCandidateSummary,
-    PatchApplyRecoveryProvenance, RecoveryCycleChildProvenance, TaskRecord, TaskStartParams,
-    TaskStatus, VerificationRecoveryProvenance, VerificationRecoveryRetryProvenance,
+    ModePackActiveSnapshotSummary, ModePackApprovedCandidateSummary,
+    ModePackCandidateProvenanceSummary, ModePackCandidateSummary, PatchApplyRecoveryProvenance,
+    RecoveryCycleChildProvenance, TaskRecord, TaskStartParams, TaskStatus,
+    VerificationRecoveryProvenance, VerificationRecoveryRetryProvenance,
 };
 use serde::{Deserialize, Serialize};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
@@ -518,6 +519,88 @@ impl BrownieStore {
         })?))
     }
 
+    pub fn read_modepack_candidate_provenance_snapshot(
+        &self,
+        content_sha256: &str,
+    ) -> Result<Option<ModePackCandidateProvenanceSnapshot>> {
+        let path = self.modepack_candidate_provenance_path(content_sha256);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let content = fs::read_to_string(&path)
+            .with_context(|| format!("failed to read {}", path.display()))?;
+        Ok(Some(serde_json::from_str(&content).with_context(|| {
+            format!("failed to parse {}", path.display())
+        })?))
+    }
+
+    pub fn verify_modepack_candidate_provenance_snapshot(
+        &self,
+        provenance: &ModePackCandidateProvenanceSnapshot,
+    ) -> Result<ModePackCandidateProvenanceCommit> {
+        if let Some(existing) =
+            self.read_modepack_candidate_provenance_snapshot(&provenance.summary.content_sha256)?
+        {
+            if existing.summary.compiled_policy_fingerprint
+                != provenance.summary.compiled_policy_fingerprint
+                || existing.summary.signer_fingerprint != provenance.summary.signer_fingerprint
+                || existing.summary.statement_sha256 != provenance.summary.statement_sha256
+                || existing.summary.signature_sha256 != provenance.summary.signature_sha256
+            {
+                bail!(
+                    "conflicting Mode Pack candidate provenance for {}",
+                    provenance.summary.content_sha256
+                );
+            }
+            if !self.modepack_candidate_provenance_event_exists(
+                &existing.summary.provenance_event_id,
+                &existing.summary.content_sha256,
+                &existing.summary.signer_fingerprint,
+                &existing.summary.statement_sha256,
+            )? {
+                let event = ModePackCandidateLedgerEvent {
+                    event_id: existing.summary.provenance_event_id.clone(),
+                    kind: "ModePackCandidateProvenanceVerified".to_string(),
+                    timestamp: existing.summary.verified_at.clone(),
+                    payload: serde_json::to_value(&existing.summary)
+                        .context("failed to serialize Mode Pack candidate provenance summary")?,
+                };
+                self.append_modepack_candidate_event(&event)?;
+            }
+            return Ok(ModePackCandidateProvenanceCommit {
+                replayed: true,
+                event_id: existing.summary.provenance_event_id.clone(),
+                provenance: existing,
+            });
+        }
+
+        let root = self.modepack_candidates_dir();
+        fs::create_dir_all(&root)
+            .with_context(|| format!("failed to create {}", root.display()))?;
+        let mut committed = provenance.clone();
+        committed.summary.provenance_event_id = format!("event_{}", Uuid::new_v4());
+        let body = serde_json::to_string_pretty(&committed)
+            .context("failed to serialize Mode Pack candidate provenance")?;
+        write_file_atomically(
+            &self.modepack_candidate_provenance_path(&committed.summary.content_sha256),
+            body.as_bytes(),
+        )
+        .context("failed to write Mode Pack candidate provenance")?;
+        let event = ModePackCandidateLedgerEvent {
+            event_id: committed.summary.provenance_event_id.clone(),
+            kind: "ModePackCandidateProvenanceVerified".to_string(),
+            timestamp: committed.summary.verified_at.clone(),
+            payload: serde_json::to_value(&committed.summary)
+                .context("failed to serialize Mode Pack candidate provenance summary")?,
+        };
+        self.append_modepack_candidate_event(&event)?;
+        Ok(ModePackCandidateProvenanceCommit {
+            replayed: false,
+            event_id: event.event_id,
+            provenance: committed,
+        })
+    }
+
     pub fn approve_modepack_candidate_snapshot(
         &self,
         approval: &ModePackApprovedCandidateSnapshot,
@@ -684,6 +767,14 @@ impl BrownieStore {
             .join(format!("{slug}.approved.json"))
     }
 
+    fn modepack_candidate_provenance_path(&self, content_sha256: &str) -> PathBuf {
+        let slug = content_sha256
+            .strip_prefix("sha256:")
+            .unwrap_or(content_sha256);
+        self.modepack_candidates_dir()
+            .join(format!("{slug}.provenance.json"))
+    }
+
     fn append_active_modepack_event(&self, event: &ActiveModePackLedgerEvent) -> Result<()> {
         let root = self.active_modepack_dir();
         fs::create_dir_all(&root)
@@ -765,6 +856,60 @@ impl BrownieStore {
                     .get("compiled_policy_fingerprint")
                     .and_then(serde_json::Value::as_str)
                     == Some(compiled_policy_fingerprint)
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    fn modepack_candidate_provenance_event_exists(
+        &self,
+        provenance_event_id: &str,
+        content_sha256: &str,
+        signer_fingerprint: &str,
+        statement_sha256: &str,
+    ) -> Result<bool> {
+        let ledger_path = self.modepack_candidates_dir().join("ledger.jsonl");
+        let file = match OpenOptions::new().read(true).open(&ledger_path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to open Mode Pack candidate ledger {}",
+                        ledger_path.display()
+                    )
+                })
+            }
+        };
+        for line in BufReader::new(file).lines() {
+            let line = line.context("failed to read Mode Pack candidate ledger")?;
+            if line.trim().is_empty() {
+                continue;
+            }
+            let event: ModePackCandidateLedgerEvent = serde_json::from_str(&line)
+                .context("failed to parse Mode Pack candidate ledger")?;
+            if event.kind != "ModePackCandidateProvenanceVerified"
+                || event.event_id != provenance_event_id
+            {
+                continue;
+            }
+            if event
+                .payload
+                .get("content_sha256")
+                .and_then(serde_json::Value::as_str)
+                == Some(content_sha256)
+                && event
+                    .payload
+                    .get("signer_fingerprint")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(signer_fingerprint)
+                && event
+                    .payload
+                    .get("statement_sha256")
+                    .and_then(serde_json::Value::as_str)
+                    == Some(statement_sha256)
             {
                 return Ok(true);
             }
@@ -925,6 +1070,18 @@ pub struct ModePackCandidateApprovalCommit {
     pub replayed: bool,
     pub event_id: String,
     pub approval: ModePackApprovedCandidateSnapshot,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePackCandidateProvenanceSnapshot {
+    pub summary: ModePackCandidateProvenanceSummary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModePackCandidateProvenanceCommit {
+    pub replayed: bool,
+    pub event_id: String,
+    pub provenance: ModePackCandidateProvenanceSnapshot,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]

--- a/docs/architecture/phase-value-manifest.m39.1.json
+++ b/docs/architecture/phase-value-manifest.m39.1.json
@@ -38,49 +38,7 @@
       "runtime_behavior_change": "The runtime can verify signer-bound candidate provenance, persist it, replay it idempotently, and reject stale or unsigned evidence without mutating approval or active state.",
       "headless_autonomous_contribution": "Headless callers can advance remote Mode Pack trust using explicit signer evidence and bounded fingerprints without raw cache inspection.",
       "milestone_progress": "Establishes the first M39 cryptographic provenance primitive and prepares the next phase for provenance-gated approval."
-    },
-    "questions": [
-      {
-        "id": "strategic_capabilities",
-        "question": "Which strategic capabilities does this phase advance?"
-      },
-      {
-        "id": "new_capability",
-        "question": "What new runtime capability does it add?"
-      },
-      {
-        "id": "why_existing_functionality_is_insufficient",
-        "question": "Why can existing functionality not substitute for this work?"
-      },
-      {
-        "id": "product_gap_if_skipped",
-        "question": "What concrete product gap remains if this is skipped?"
-      },
-      {
-        "id": "non_duplicative",
-        "question": "Is this semantically distinct from the previous three phases?"
-      },
-      {
-        "id": "no_new_rpc",
-        "question": "Can this be done without adding a new RPC?"
-      },
-      {
-        "id": "no_new_summary",
-        "question": "Can this be done without adding a new summary surface?"
-      },
-      {
-        "id": "runtime_behavior_change",
-        "question": "What runtime behavior changes?"
-      },
-      {
-        "id": "headless_autonomous_contribution",
-        "question": "How does this help headless autonomous development?"
-      },
-      {
-        "id": "milestone_progress",
-        "question": "How does this move the milestone toward completion?"
-      }
-    ]
+    }
   },
   "review_value_gate": {
     "required": true,

--- a/extensions/brownie-vsix/src/runtime/protocol.ts
+++ b/extensions/brownie-vsix/src/runtime/protocol.ts
@@ -237,6 +237,32 @@ export interface ModePackApproveCandidateResult {
   next_action: string;
 }
 
+export interface ModePackCandidateProvenanceSummary {
+  provenance_id: string;
+  candidate_id: string;
+  source_kind: string;
+  source_url_host: string;
+  source_url_fingerprint: string;
+  content_sha256: string;
+  modepack_name: string;
+  schema_version: number;
+  mode_count: number;
+  mode_ids: string[];
+  compiled_policy_fingerprint: string;
+  signer_fingerprint: string;
+  statement_sha256: string;
+  signature_sha256: string;
+  verified_at: string;
+  provenance_event_id: string;
+}
+
+export interface ModePackVerifyCandidateProvenanceResult {
+  verified: boolean;
+  replayed: boolean;
+  provenance: ModePackCandidateProvenanceSummary;
+  next_action: string;
+}
+
 export interface ToolPlanDecisionSummary {
   tool_id: string;
   required_action: RuntimeActionName;
@@ -3086,6 +3112,21 @@ export function isModePackApproveCandidateResult(value: unknown): value is ModeP
   );
 }
 
+export function isModePackVerifyCandidateProvenanceResult(value: unknown): value is ModePackVerifyCandidateProvenanceResult {
+  return (
+    isRecord(value) &&
+    typeof value.verified === 'boolean' &&
+    typeof value.replayed === 'boolean' &&
+    isModePackCandidateProvenanceSummary(value.provenance) &&
+    typeof value.next_action === 'string' &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_modepack_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_provenance_statement_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'provenance_signature_base64') &&
+    !Object.prototype.hasOwnProperty.call(value, 'provenance_public_key_base64') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_ledger_payload')
+  );
+}
+
 function isModePackApprovedCandidateSummary(value: unknown): value is ModePackApprovedCandidateSummary {
   return (
     isRecord(value) &&
@@ -3111,6 +3152,43 @@ function isModePackApprovedCandidateSummary(value: unknown): value is ModePackAp
     typeof value.consumed === 'boolean' &&
     !Object.prototype.hasOwnProperty.call(value, 'modepack_json') &&
     !Object.prototype.hasOwnProperty.call(value, 'raw_modepack_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_ledger_payload')
+  );
+}
+
+function isModePackCandidateProvenanceSummary(value: unknown): value is ModePackCandidateProvenanceSummary {
+  return (
+    isRecord(value) &&
+    typeof value.provenance_id === 'string' &&
+    typeof value.candidate_id === 'string' &&
+    typeof value.source_kind === 'string' &&
+    typeof value.source_url_host === 'string' &&
+    typeof value.source_url_fingerprint === 'string' &&
+    isSha256Fingerprint(value.source_url_fingerprint) &&
+    typeof value.content_sha256 === 'string' &&
+    isSha256Fingerprint(value.content_sha256) &&
+    typeof value.modepack_name === 'string' &&
+    typeof value.schema_version === 'number' &&
+    Number.isInteger(value.schema_version) &&
+    typeof value.mode_count === 'number' &&
+    Number.isInteger(value.mode_count) &&
+    Array.isArray(value.mode_ids) &&
+    value.mode_ids.every((modeId) => typeof modeId === 'string') &&
+    typeof value.compiled_policy_fingerprint === 'string' &&
+    isSha256Fingerprint(value.compiled_policy_fingerprint) &&
+    typeof value.signer_fingerprint === 'string' &&
+    isSha256Fingerprint(value.signer_fingerprint) &&
+    typeof value.statement_sha256 === 'string' &&
+    isSha256Fingerprint(value.statement_sha256) &&
+    typeof value.signature_sha256 === 'string' &&
+    isSha256Fingerprint(value.signature_sha256) &&
+    typeof value.verified_at === 'string' &&
+    typeof value.provenance_event_id === 'string' &&
+    !Object.prototype.hasOwnProperty.call(value, 'modepack_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_modepack_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'raw_provenance_statement_json') &&
+    !Object.prototype.hasOwnProperty.call(value, 'provenance_signature_base64') &&
+    !Object.prototype.hasOwnProperty.call(value, 'provenance_public_key_base64') &&
     !Object.prototype.hasOwnProperty.call(value, 'raw_ledger_payload')
   );
 }

--- a/extensions/brownie-vsix/src/runtime/runtimeClient.ts
+++ b/extensions/brownie-vsix/src/runtime/runtimeClient.ts
@@ -3,12 +3,12 @@ import type { ProposalApplyResult, ProposalPatchHunk } from './protocol';
 import type { CodebaseIndexSelectionReadResult, TaskRunParams } from './protocol';
 import type { HeadlessContinueOnceParams, HeadlessContinueOnceResult } from './protocol';
 import type { HeadlessRunAdvanceParams, HeadlessRunAdvanceResult, HeadlessRunDriveParams, HeadlessRunDriveResult } from './protocol';
-import type { ModePackActivateResult, ModePackApproveCandidateResult, ModePackFetchCandidateResult, ModePackReplaceActiveResult, ModePackRollbackActiveResult } from './protocol';
+import type { ModePackActivateResult, ModePackApproveCandidateResult, ModePackFetchCandidateResult, ModePackReplaceActiveResult, ModePackRollbackActiveResult, ModePackVerifyCandidateProvenanceResult } from './protocol';
 import { isProposalApplyResult } from './protocol';
 import type { TaskListResult } from './protocol';
 import { isHeadlessContinueOnceResult, isTaskListResult } from './protocol';
 import { isHeadlessRunAdvanceResult, isHeadlessRunDriveResult } from './protocol';
-import { isModePackActivateResult, isModePackApproveCandidateResult, isModePackFetchCandidateResult, isModePackReplaceActiveResult, isModePackRollbackActiveResult } from './protocol';
+import { isModePackActivateResult, isModePackApproveCandidateResult, isModePackFetchCandidateResult, isModePackReplaceActiveResult, isModePackRollbackActiveResult, isModePackVerifyCandidateProvenanceResult } from './protocol';
 import type { JsonRpcRequest, LlmHealthResult, LlmStatusResult, RuntimeConfigGetResult, RuntimeDiagnosticsResult, ModeSummary, PermissionCheckResult, RuntimeActionName, RuntimeStatusResult, RunEventsResult, RunInspectResult, RunInspectSummary, ProposalApplyCapabilityResult, ProposalApplyDryRunHistoryResult, ProposalApplyDryRunResult, ProposalApproveResult, ProposalAuditTrailResult, ProposalPreflightResult, ProposalReadinessResult, ProposalInspectResult, ProposalListResult, ProposalRejectResult, ProposalReviewBundleResult, ProposalReviewQueueDiagnosticsDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryResult, ProposalReviewQueueDiagnosticsDigestReportVerdictReportResult, ProposalReviewQueueDiagnosticsDigestReportVerdictResult, ProposalReviewQueueDiagnosticsDigestResult, ProposalReviewQueueDiagnosticsHistoryResult, ProposalReviewQueueDiagnosticsReportResult, ProposalReviewQueueDiagnosticsResult, ProposalReviewQueueResult, ProposalReviewReportResult, ProposalReviewVerdictResult, TaskInspectResult, TaskRecord, TaskRunResult, ToolExecuteResult, ToolIntentParseResult, ToolPlanResult, TaskStartParams, TaskStartResult } from './protocol';
 import type { ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult } from './protocol';
 import type { ProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult } from './protocol';
@@ -159,6 +159,32 @@ export class RuntimeClient {
 
     if (!isModePackApproveCandidateResult(result)) {
       throw new RuntimeProtocolError('modepack.approveCandidate returned an invalid result');
+    }
+
+    return result;
+  }
+
+  async verifyModePackCandidateProvenance(params: {
+    authorizeProvenanceVerification: boolean;
+    expectedContentSha256: string;
+    expectedCompiledPolicyFingerprint: string;
+    expectedSignerFingerprint: string;
+    provenanceStatementJson: string;
+    provenanceSignatureBase64: string;
+    provenancePublicKeyBase64: string;
+  }): Promise<ModePackVerifyCandidateProvenanceResult> {
+    const result = await this.call<ModePackVerifyCandidateProvenanceResult>('modepack.verifyCandidateProvenance', {
+      authorize_provenance_verification: params.authorizeProvenanceVerification,
+      expected_content_sha256: params.expectedContentSha256,
+      expected_compiled_policy_fingerprint: params.expectedCompiledPolicyFingerprint,
+      expected_signer_fingerprint: params.expectedSignerFingerprint,
+      provenance_statement_json: params.provenanceStatementJson,
+      provenance_signature_base64: params.provenanceSignatureBase64,
+      provenance_public_key_base64: params.provenancePublicKeyBase64,
+    });
+
+    if (!isModePackVerifyCandidateProvenanceResult(result)) {
+      throw new RuntimeProtocolError('modepack.verifyCandidateProvenance returned an invalid result');
     }
 
     return result;

--- a/extensions/brownie-vsix/src/test/runtimeClient.test.ts
+++ b/extensions/brownie-vsix/src/test/runtimeClient.test.ts
@@ -15,7 +15,7 @@ import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestH
 import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryResult } from '../runtime/protocol';
 import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportResult } from '../runtime/protocol';
 import { isProposalReviewQueueDiagnosticsDigestReportVerdictReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryDigestHistoryReportHistoryResult } from '../runtime/protocol';
-import { isModePackActivateResult, isModePackApproveCandidateResult, isModePackFetchCandidateResult, isModePackReplaceActiveResult, isModePackRollbackActiveResult } from '../runtime/protocol';
+import { isModePackActivateResult, isModePackApproveCandidateResult, isModePackFetchCandidateResult, isModePackReplaceActiveResult, isModePackRollbackActiveResult, isModePackVerifyCandidateProvenanceResult } from '../runtime/protocol';
 import { RuntimeClient } from '../runtime/runtimeClient';
 import type { RuntimeTransport } from '../runtime/runtimeProcess';
 
@@ -556,6 +556,39 @@ describe('protocol validation', () => {
     expect(isModePackApproveCandidateResult({ ...result, approval: { ...approval, modepack_json: '{}' } })).toBe(false);
     expect(isModePackApproveCandidateResult({ ...result, raw_modepack_json: '{}' })).toBe(false);
     expect(isModePackApproveCandidateResult({ ...result, raw_ledger_payload: {} })).toBe(false);
+  });
+
+  it('accepts bounded modepack.verifyCandidateProvenance results and rejects raw fields', () => {
+    const provenance = {
+      provenance_id: 'modepack_candidate_provenance_123',
+      candidate_id: 'modepack_candidate_123',
+      source_kind: 'remote_https',
+      source_url_host: 'example.com',
+      source_url_fingerprint: `sha256:${'a'.repeat(64)}`,
+      content_sha256: `sha256:${'b'.repeat(64)}`,
+      modepack_name: 'remote-agentmodes',
+      schema_version: 1,
+      mode_count: 1,
+      mode_ids: ['remote-reviewer-lite'],
+      compiled_policy_fingerprint: `sha256:${'c'.repeat(64)}`,
+      signer_fingerprint: `sha256:${'d'.repeat(64)}`,
+      statement_sha256: `sha256:${'e'.repeat(64)}`,
+      signature_sha256: `sha256:${'f'.repeat(64)}`,
+      verified_at: '2026-08-10T00:00:00Z',
+      provenance_event_id: 'event_3',
+    };
+    const result = {
+      verified: true,
+      replayed: false,
+      provenance,
+      next_action: 'approve_verified_modepack_candidate',
+    };
+
+    expect(isModePackVerifyCandidateProvenanceResult(result)).toBe(true);
+    expect(isModePackVerifyCandidateProvenanceResult({ ...result, provenance: { ...provenance, signer_fingerprint: 'bad' } })).toBe(false);
+    expect(isModePackVerifyCandidateProvenanceResult({ ...result, raw_provenance_statement_json: '{}' })).toBe(false);
+    expect(isModePackVerifyCandidateProvenanceResult({ ...result, provenance_signature_base64: 'raw' })).toBe(false);
+    expect(isModePackVerifyCandidateProvenanceResult({ ...result, raw_ledger_payload: {} })).toBe(false);
   });
 
   it('accepts bounded modepack.rollbackActive results and rejects raw fields', () => {
@@ -2373,6 +2406,58 @@ describe('RuntimeClient', () => {
         authorize_trust: true,
         expected_content_sha256: result.approval.content_sha256,
         expected_compiled_policy_fingerprint: result.approval.compiled_policy_fingerprint,
+      },
+    }]);
+  });
+
+  it('creates a modepack.verifyCandidateProvenance request', async () => {
+    const result = {
+      verified: true,
+      replayed: false,
+      provenance: {
+        provenance_id: 'modepack_candidate_provenance_123',
+        candidate_id: 'modepack_candidate_123',
+        source_kind: 'remote_https',
+        source_url_host: 'example.com',
+        source_url_fingerprint: `sha256:${'a'.repeat(64)}`,
+        content_sha256: `sha256:${'b'.repeat(64)}`,
+        modepack_name: 'remote-agentmodes',
+        schema_version: 1,
+        mode_count: 1,
+        mode_ids: ['remote-reviewer-lite'],
+        compiled_policy_fingerprint: `sha256:${'c'.repeat(64)}`,
+        signer_fingerprint: `sha256:${'d'.repeat(64)}`,
+        statement_sha256: `sha256:${'e'.repeat(64)}`,
+        signature_sha256: `sha256:${'f'.repeat(64)}`,
+        verified_at: '2026-08-10T00:00:00Z',
+        provenance_event_id: 'event_3',
+      },
+      next_action: 'approve_verified_modepack_candidate',
+    };
+    const transport = new FakeTransport({ jsonrpc: '2.0', id: 1, result });
+    const client = new RuntimeClient(transport);
+
+    await expect(client.verifyModePackCandidateProvenance({
+      authorizeProvenanceVerification: true,
+      expectedContentSha256: result.provenance.content_sha256,
+      expectedCompiledPolicyFingerprint: result.provenance.compiled_policy_fingerprint,
+      expectedSignerFingerprint: result.provenance.signer_fingerprint,
+      provenanceStatementJson: '{"content_sha256":"x"}',
+      provenanceSignatureBase64: 'signature',
+      provenancePublicKeyBase64: 'public-key',
+    })).resolves.toEqual(result);
+    expect(transport.requests).toEqual([{
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'modepack.verifyCandidateProvenance',
+      params: {
+        authorize_provenance_verification: true,
+        expected_content_sha256: result.provenance.content_sha256,
+        expected_compiled_policy_fingerprint: result.provenance.compiled_policy_fingerprint,
+        expected_signer_fingerprint: result.provenance.signer_fingerprint,
+        provenance_statement_json: '{"content_sha256":"x"}',
+        provenance_signature_base64: 'signature',
+        provenance_public_key_base64: 'public-key',
       },
     }]);
   });


### PR DESCRIPTION
## Summary
- Add `modepack.verifyCandidateProvenance` as a Rust-owned provenance verification action for cached remote Mode Pack candidates.
- Persist bounded provenance snapshots and `ModePackCandidateProvenanceVerified` ledger events.
- Update VSIX result validation/client coverage and M39.1 phase manifests.

## Capability gain
A headless caller can now advance a fetched remote Mode Pack candidate into a durable provenance-verified state by supplying explicit authorization, expected candidate fingerprints, expected signer fingerprint, a bounded statement JSON string, a detached Ed25519 signature, and the public key.

## Why existing behavior was insufficient
M38.1 cached remote Mode Pack bytes, M38.2 approved candidates by expected hashes, and M38.3 activated approved candidates. None verified that the candidate evidence was signed by an expected external publisher.

## Architecture
- Protocol adds bounded provenance request/result and summary types.
- Runtime verifies public-key-derived signer fingerprint, detached Ed25519 signature over the provided statement bytes, statement bindings, cached content SHA, recompiled policy fingerprint, source URL fingerprint, schema version, and mode IDs.
- Store writes `<sha>.provenance.json` and appends a bounded candidate ledger event with replay reconciliation.
- VSIX remains a thin client and only validates bounded shapes.

## Safety boundary
- Explicit authorization required.
- No network fetch, trust approval, activation, registry, revocation, or generic signature API mixed into this phase.
- RPC and ledger evidence omit raw candidate JSON, raw provenance statement, raw signature bytes, and raw public key bytes.
- Failed verification leaves approval and active Mode Pack state untouched.

## Tests
- `cargo fmt --check`
- `cargo check --workspace`
- `cargo test --workspace`
- `pnpm install`
- `pnpm guard:diagnostics`
- `pnpm guard:phase-value`
- `pnpm --filter brownie-vsix check`
- `pnpm --filter brownie-vsix test`
- `pnpm --filter brownie-vsix build`
- `git diff --check`

## Non-goals
- No package manager or registry discovery.
- No automatic fetch, trust approval, or activation.
- No signer allowlist, revocation list, or certificate-chain validation.
- No report/history/digest/readiness/inspection wrapper.

## Value gate
M39.1 is a runtime trust-state transition: cached remote candidates can be cryptographically provenance-verified before a later phase consumes provenance during approval.
